### PR TITLE
fix the bug of save bf16 optimizer state in the bf16+zero1+pp mode

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3165,7 +3165,8 @@ class DeepSpeedEngine(Module):
         # if we don't use it, we get parameters ordered incorrectly
         if hasattr(self.optimizer, "round_robin_bit16_groups"):
             bit16_groups = self.optimizer.round_robin_bit16_groups
-        elif self.bfloat16_enabled() and not self.zero_optimization():
+        elif self.bfloat16_enabled() and (not self.zero_optimization() or self.zero_optimization_stage() == 1 
+            and hasattr(self.optimizer, 'bf16_groups')):
             bit16_groups = self.optimizer.bf16_groups
         else:
             bit16_groups = self.optimizer.bit16_groups if self.zero_optimization_stage(

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3165,8 +3165,9 @@ class DeepSpeedEngine(Module):
         # if we don't use it, we get parameters ordered incorrectly
         if hasattr(self.optimizer, "round_robin_bit16_groups"):
             bit16_groups = self.optimizer.round_robin_bit16_groups
-        elif self.bfloat16_enabled() and (not self.zero_optimization() or self.zero_optimization_stage() == 1 
-            and hasattr(self.optimizer, 'bf16_groups')):
+        elif self.bfloat16_enabled() and (not self.zero_optimization() or
+                                          (self.zero_optimization_stage() == 1
+                                           and hasattr(self.optimizer, "bf16_groups"))):
             bit16_groups = self.optimizer.bf16_groups
         else:
             bit16_groups = self.optimizer.bit16_groups if self.zero_optimization_stage(


### PR DESCRIPTION
Fix the bug " AttributeError: 'BF16_Optimizer' object has no attribute 'bit16_groups' " when using bf16 + zero1 + pp to train model and saving the bf16 optimizer state