### PR TITLE
Add falcon-180b support

### DIFF
--- a/csrc/transformer/inference/includes/inference_cuda_layers.h
+++ b/csrc/transformer/inference/includes/inference_cuda_layers.h
@@ -162,6 +162,7 @@ void launch_gptj_residual_add(T* input,
 template <typename T>
 void launch_apply_rotary_pos_emb(T* mixed_query,
                                  T* key_layer,
+                                 T* cache,
                                  unsigned head_size,
                                  unsigned seq_len,
                                  unsigned rotary_dim,

--- a/deepspeed/module_inject/containers/falcon.py
+++ b/deepspeed/module_inject/containers/falcon.py
@@ -110,7 +110,7 @@ class FALCONLayerPolicy(TransformerPolicy):
             self.num_kv = self.client_module.self_attention.num_kv if hasattr(self.client_module.self_attention, 'num_kv') else \
                         self.client_module.self_attention.num_kv_heads
             self.config = self.client_module.config
-
+        
     def get_hidden_heads(self):
         heads = self.client_module.self_attention.num_heads
         return self.client_module.self_attention.query_key_value.weight.shape[1], \

--- a/deepspeed/ops/transformer/inference/ds_attention.py
+++ b/deepspeed/ops/transformer/inference/ds_attention.py
@@ -39,7 +39,8 @@ class DeepSpeedSelfAttention(nn.Module):
         else:
             if self.config.multi_query:
                 if self.config.global_kv_sharing:
-                    qkv_size_per_partition = (self.config.hidden_size // self.config.mp_size) + 2 * (self.config.hidden_size // self.config.heads)
+                    qkv_size_per_partition = (self.config.hidden_size // self.config.mp_size) + \
+                        2 * (self.config.hidden_size // self.config.heads)
                 else:
                     qkv_size_per_partition = (self.config.hidden_size // self.config.heads) * (
                         self.config.num_kv * 2 + self.config.heads) // self.config.mp_size
@@ -112,7 +113,8 @@ class DeepSpeedSelfAttention(nn.Module):
             no_masking=no_masking,
             layer_id=self.config.layer_id,
             num_layers=DeepSpeedSelfAttention.num_layers,
-            alibi=alibi)
+            alibi=alibi,
+            layer_past=layer_past)
 
         context_layer, key_layer, value_layer = attn_key_value
         return context_layer, key_layer, value_layer

--- a/deepspeed/ops/transformer/inference/ds_mlp.py
+++ b/deepspeed/ops/transformer/inference/ds_mlp.py
@@ -111,16 +111,13 @@ class DeepSpeedMLP(nn.Module):
                                                       bias=self.inter_b,
                                                       gamma=self.attn_nw,
                                                       beta=self.attn_nb)
-        output = output + input
-        #residual = self.residual_add_func(hidden_state=output,
-        #                                  residual=residual,
-        #                                  add_bias=bias is not None,
-        #                                  attention_output=input,
-        #                                  attention_bias=bias if bias is not None else self.output_b,
-        #                                  final_bias=self.output_b,
-        #                                  residual_add=residual_add)
-        #print(f'mlp_out: {}')
+        residual = self.residual_add_func(hidden_state=output,
+                                          residual=residual,
+                                          add_bias=bias is not None,
+                                          attention_output=input,
+                                          attention_bias=bias if bias is not None else self.output_b,
+                                          final_bias=self.output_b,
+                                          residual_add=residual_add)
         if self.mp_group is not None and dist.get_world_size(group=self.mp_group) > 1:
-            dist.all_reduce(output, group=self.mp_group)
-        residual = residual + output
+            dist.all_reduce(residual, group=self.mp_group)
         return residual

--- a/deepspeed/ops/transformer/inference/ds_mlp.py
+++ b/deepspeed/ops/transformer/inference/ds_mlp.py
@@ -111,15 +111,16 @@ class DeepSpeedMLP(nn.Module):
                                                       bias=self.inter_b,
                                                       gamma=self.attn_nw,
                                                       beta=self.attn_nb)
-        residual = self.residual_add_func(hidden_state=output,
-                                          residual=residual,
-                                          add_bias=bias is not None,
-                                          attention_output=input,
-                                          attention_bias=bias if bias is not None else self.output_b,
-                                          final_bias=self.output_b,
-                                          residual_add=residual_add)
+        output = output + input
+        #residual = self.residual_add_func(hidden_state=output,
+        #                                  residual=residual,
+        #                                  add_bias=bias is not None,
+        #                                  attention_output=input,
+        #                                  attention_bias=bias if bias is not None else self.output_b,
+        #                                  final_bias=self.output_b,
+        #                                  residual_add=residual_add)
         #print(f'mlp_out: {}')
         if self.mp_group is not None and dist.get_world_size(group=self.mp_group) > 1:
-            dist.all_reduce(residual, group=self.mp_group)
-
+            dist.all_reduce(output, group=self.mp_group)
+        residual = residual + output
         return residual

--- a/deepspeed/ops/transformer/inference/op_binding/mlp_gemm.py
+++ b/deepspeed/ops/transformer/inference/op_binding/mlp_gemm.py
@@ -67,29 +67,23 @@ class MLPGemmOp(BaseOp):
                 gamma: Optional[torch.Tensor] = None,
                 beta: Optional[torch.Tensor] = None):
         if self.config.norm_type == NormType.LayerNorm:
-            from torch.nn import functional as F
-            norm_out = F.layer_norm(residual, gamma.shape, gamma, beta, self.config.epsilon)
-            intm = torch.matmul(norm_out, weight_interm)
-            intm = torch.nn.GELU()(intm)
-            output = torch.matmul(intm, weight_out)
-            residual_add = output
-            #output, residual_add = self.mlp_gemm_func(
-            #    input,
-            #    residual,
-            #    input_bias if input_bias is not None else dummy_tensor,
-            #    weight_interm,
-            #    weight_out,
-            #    bias if bias is not None else dummy_tensor,
-            #    gamma,
-            #    beta,
-            #    self.config.epsilon,
-            #    self.config.pre_layer_norm,
-            #    self.config.mlp_after_attn,
-            #    weight_interm.scale if hasattr(weight_interm, 'scale') else torch.empty(1),  # type: ignore
-            #    weight_out.scale if hasattr(weight_out, 'scale') else torch.empty(1),  # type: ignore
-            #    self.config.dtype == torch.int8,
-            #    self.config.mlp_act_func_type,
-            #    self.config.transposed_mode)
+            output, residual_add = self.mlp_gemm_func(
+                input,
+                residual,
+                input_bias if input_bias is not None else dummy_tensor,
+                weight_interm,
+                weight_out,
+                bias if bias is not None else dummy_tensor,
+                gamma,
+                beta,
+                self.config.epsilon,
+                self.config.pre_layer_norm,
+                self.config.mlp_after_attn,
+                weight_interm.scale if hasattr(weight_interm, 'scale') else torch.empty(1),  # type: ignore
+                weight_out.scale if hasattr(weight_out, 'scale') else torch.empty(1),  # type: ignore
+                self.config.dtype == torch.int8,
+                self.config.mlp_act_func_type,
+                self.config.transposed_mode)
         else:
             output, residual_add = self.mlp_gemm_func(
                 input,

--- a/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
+++ b/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
@@ -128,58 +128,10 @@ class SoftmaxContextOp(BaseOp):
         else:
             alibi = torch.empty(1)
         
-        context_layer, key_layer, value_layer = self.softmax_context_func(query_key_value, attn_mask, self.config.rotary_dim, self.config.rotate_half,
+        output = self.softmax_context_func(query_key_value, attn_mask, self.config.rotary_dim, self.config.rotate_half,
                                            self.config.rotate_every_two, heads, norm_factor,
                                            self.config.triangular_masking, self.config.local_attention,
                                            self.config.window_size, no_masking, layer_id, num_layers, alibi,
                                            self.config.multi_query, self.num_kv_per_partition)
-        #return output
-        #print(f'q:{output[0][0,:,0,:]}, k:{output[1][0,:,0,:]}, v:{output[2][0,:,0,:]}')
-        batch, seq_len, _ = query_key_value.shape
-        qkv = query_key_value.view(batch, seq_len, -1, 64)
-        query_layer  = qkv[:, :, :-2]
-        key_layer    = qkv[:, :, [-2]]
-        value_layer_ = qkv[:, :, [-1]]
-        key_layer = torch.broadcast_to(key_layer, query_layer.shape)
-        value_layer_ = torch.broadcast_to(value_layer_, query_layer.shape)
-        query_layer  = query_layer.transpose(1,2)
-        key_layer    = key_layer.transpose(1,2)
-        value_layer_ = value_layer_.transpose(1,2)
-        past_kv_length = 0 if layer_past is None else layer_past[0].shape[-2]
-        query_layer_, key_layer_ = self.rotary_emb(query_layer, key_layer, past_kv_length)
-        #if torch.distributed.get_rank() == 0:
-        #
-        if layer_past is not None:
-            past_key, past_value = layer_past
-            
-            try:
-                key_layer_ = torch.cat((past_key, key_layer_), dim=-2)
-                value_layer_ = torch.cat((past_value, value_layer_), dim=-2)
-            except:
-                print(f'layer_past: {key_layer_.shape}, {past_key.shape}')
-                exit()
-        if True: #layer_past is not None:
-            print(f'''[{torch.distributed.get_rank()}]: 
-                    key_error: {(((key_layer_-key_layer1).abs()/(key_layer_.abs() + 1e-5)).sum() / key_layer.numel()).item()}
-                    value_error: {(((value_layer_-value_layer1).abs()/(value_layer_.abs() + 1e-5)).sum() / value_layer_.numel()).item()}
-                    query_error:{(((query_layer_-query_layer1).abs()/(query_layer_.abs() + 1e-5)).sum() / query_layer.numel()).item()}''')
-            exit()
-        attention_scores = query_layer_ @ key_layer_.transpose(-1, -2)
         
-        input_dtype = attention_scores.dtype
-        if input_dtype == torch.float16 or input_dtype == torch.bfloat16:
-            attention_scores = attention_scores.to(torch.float32)
-        attention_scores *= (1 / math.sqrt(64))
-        attention_mask_float = (attn_mask * 1.0).masked_fill(attn_mask, float("-1e9")).to(torch.float32)
-        try:
-            attention_probs = torch.nn.functional.softmax(attention_scores + attention_mask_float, dim=-1, dtype=query_layer_.dtype)
-        except:
-            print(attention_scores.shape, attention_mask_float.shape)
-            exit()
-        # matmul: [batch_size * num_heads, q_length, head_dim]
-        context_layer = (attention_probs @ value_layer_)
-    
-        context_layer = self._merge_heads(context_layer)
-        #print(context_layer, context_layer.shape)
-        #exit()
-        return context_layer, key_layer_, value_layer_
+        return output

--- a/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
+++ b/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
@@ -8,6 +8,70 @@ from deepspeed import comm as dist
 from ..config import DeepSpeedInferenceConfig
 from .base import BaseOp
 
+import math
+
+from torch import nn
+# rotary pos emb helpers (torch.jit.script does not seem to support staticmethod...)
+def rotate_half(x):
+    x1, x2 = x[..., : x.shape[-1] // 2], x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+class FalconRotaryEmbedding(nn.Module):
+    """Implementation of RotaryEmbedding from GPT-NeoX.
+    This implementation is designed to operate on queries and keys that are compatible with `[batch_size,
+    n_heads_per_partition, seq_len, head_dim]` (e.g. MinGPTAttention format).
+    """
+
+    def __init__(self, head_dim: int, base=10000, max_position_embeddings=2048):
+        super().__init__()
+        self.base = base
+        self.max_position_embeddings = max_position_embeddings
+        inv_freq = 1.0 / (self.base ** (torch.arange(0, head_dim, 2).float() / head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.head_dim = head_dim
+        self.seq_len_cached = -1
+        self.cos_cached: torch.Tensor | None = None
+        self.sin_cached: torch.Tensor | None = None
+
+    def _set_cos_sin_cache(self, seq_len, device, dtype):
+        self.seq_len_cached = seq_len
+        t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1).to(device)
+
+        if dtype in [torch.float16, torch.bfloat16]:
+            emb = emb.float()
+
+        self.cos_cached = emb.cos()[None, None, :, :]
+        self.sin_cached = emb.sin()[None, None, :, :]
+        #if torch.distributed.get_rank() == 0:
+        #    print(emb.shape, self.cos_cached.shape)
+        #exit()
+        self.cos_cached = self.cos_cached.type(dtype)
+        self.sin_cached = self.sin_cached.type(dtype)
+
+    def cos_sin(self, seq_len: int, past_key_values_length: int, device="cpu", dtype=torch.bfloat16) -> torch.Tensor:
+        total_length = seq_len + past_key_values_length
+        if total_length > self.seq_len_cached:
+            self._set_cos_sin_cache(total_length, device, dtype)
+        return (
+            self.cos_cached[:, :, past_key_values_length : seq_len + past_key_values_length],
+            self.sin_cached[:, :, past_key_values_length : seq_len + past_key_values_length],
+        )
+
+    def forward(self, query, key, past_key_values_length=0):
+        batch, _, seq_len, head_dim = query.shape
+        cos, sin = self.cos_sin(seq_len, past_key_values_length, query.device, query.dtype)
+        try:
+            (query * cos) + (rotate_half(query) * sin)
+        except:
+            print(f'rotary: {query.shape}, {cos.shape}, {seq_len}')
+            exit()
+        return (query * cos) + (rotate_half(query) * sin), (key * cos) + (rotate_half(key) * sin)
+
+
+
 
 class SoftmaxContextOp(BaseOp):
 
@@ -24,13 +88,38 @@ class SoftmaxContextOp(BaseOp):
             self.softmax_context_func = self.softmax_context_fallback
         self.num_kv_per_partition = self.config.num_kv // self.config.mp_size
 
+        self.rotary_emb = FalconRotaryEmbedding(
+                64,
+                max_position_embeddings=2048,
+            )
     def softmax_context_fallback(self, query_key_value, attn_mask, rotary_dim, rotate_half, roteate_every_two, heads,
                                  norm_factor, triangular_masking, local_attention, window_size, no_masking, layer_id,
                                  num_layers, alibi):
         raise NotImplementedError
+    # Copied from transformers.models.bloom.modeling_bloom.BloomAttention._merge_heads
+    def _merge_heads(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Merge heads together over the last dimension
+
+        Args:
+            x (`torch.tensor`, *required*): [batch_size * num_heads, seq_length, head_dim]
+
+        Returns:
+            torch.tensor: [batch_size, seq_length, num_heads * head_dim]
+        """
+        # What we want to achieve is:
+        # batch_size * num_heads, seq_length, head_dim -> batch_size, seq_length, num_heads * head_dim
+        batch_size, num_heads, seq_length, _ = x.shape
+
+        # batch_size, num_heads, seq_length, head_dim -> batch_size, seq_length, num_heads, head_dim
+        x = x.permute(0, 2, 1, 3)
+
+        # batch_size, seq_length, num_heads, head_dim -> batch_size, seq_length, num_heads * head_dim
+        return x.reshape(batch_size, seq_length, -1)
+
 
     def forward(self, query_key_value: torch.Tensor, attn_mask: torch.Tensor, heads: int, norm_factor: float,
-                no_masking: bool, layer_id: int, num_layers: int, alibi: torch.Tensor):
+                no_masking: bool, layer_id: int, num_layers: int, alibi: torch.Tensor, layer_past=None):
 
         if alibi is not None:
             batch_heads = query_key_value.shape[0] * heads
@@ -38,11 +127,59 @@ class SoftmaxContextOp(BaseOp):
             alibi = alibi[offset:batch_heads + offset, :, :]
         else:
             alibi = torch.empty(1)
-
-        output = self.softmax_context_func(query_key_value, attn_mask, self.config.rotary_dim, self.config.rotate_half,
+        
+        context_layer, key_layer, value_layer = self.softmax_context_func(query_key_value, attn_mask, self.config.rotary_dim, self.config.rotate_half,
                                            self.config.rotate_every_two, heads, norm_factor,
                                            self.config.triangular_masking, self.config.local_attention,
                                            self.config.window_size, no_masking, layer_id, num_layers, alibi,
                                            self.config.multi_query, self.num_kv_per_partition)
-
-        return output
+        #return output
+        #print(f'q:{output[0][0,:,0,:]}, k:{output[1][0,:,0,:]}, v:{output[2][0,:,0,:]}')
+        batch, seq_len, _ = query_key_value.shape
+        qkv = query_key_value.view(batch, seq_len, -1, 64)
+        query_layer  = qkv[:, :, :-2]
+        key_layer    = qkv[:, :, [-2]]
+        value_layer_ = qkv[:, :, [-1]]
+        key_layer = torch.broadcast_to(key_layer, query_layer.shape)
+        value_layer_ = torch.broadcast_to(value_layer_, query_layer.shape)
+        query_layer  = query_layer.transpose(1,2)
+        key_layer    = key_layer.transpose(1,2)
+        value_layer_ = value_layer_.transpose(1,2)
+        past_kv_length = 0 if layer_past is None else layer_past[0].shape[-2]
+        query_layer_, key_layer_ = self.rotary_emb(query_layer, key_layer, past_kv_length)
+        #if torch.distributed.get_rank() == 0:
+        #
+        if layer_past is not None:
+            past_key, past_value = layer_past
+            
+            try:
+                key_layer_ = torch.cat((past_key, key_layer_), dim=-2)
+                value_layer_ = torch.cat((past_value, value_layer_), dim=-2)
+            except:
+                print(f'layer_past: {key_layer_.shape}, {past_key.shape}')
+                exit()
+        if True: #layer_past is not None:
+            print(f'''[{torch.distributed.get_rank()}]: 
+                    key_error: {(((key_layer_-key_layer1).abs()/(key_layer_.abs() + 1e-5)).sum() / key_layer.numel()).item()}
+                    value_error: {(((value_layer_-value_layer1).abs()/(value_layer_.abs() + 1e-5)).sum() / value_layer_.numel()).item()}
+                    query_error:{(((query_layer_-query_layer1).abs()/(query_layer_.abs() + 1e-5)).sum() / query_layer.numel()).item()}''')
+            exit()
+        attention_scores = query_layer_ @ key_layer_.transpose(-1, -2)
+        
+        input_dtype = attention_scores.dtype
+        if input_dtype == torch.float16 or input_dtype == torch.bfloat16:
+            attention_scores = attention_scores.to(torch.float32)
+        attention_scores *= (1 / math.sqrt(64))
+        attention_mask_float = (attn_mask * 1.0).masked_fill(attn_mask, float("-1e9")).to(torch.float32)
+        try:
+            attention_probs = torch.nn.functional.softmax(attention_scores + attention_mask_float, dim=-1, dtype=query_layer_.dtype)
+        except:
+            print(attention_scores.shape, attention_mask_float.shape)
+            exit()
+        # matmul: [batch_size * num_heads, q_length, head_dim]
+        context_layer = (attention_probs @ value_layer_)
+    
+        context_layer = self._merge_heads(context_layer)
+        #print(context_layer, context_layer.shape)
+        #exit()
+        return context_layer, key_layer_, value_layer_


### PR DESCRIPTION
Load Falcon-180B in about 20 second using TP-sharded checkpoints. The text quality seems fine however requires some more accuracy testing.
```
Loading 8 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:20<00:00,  2.58s/it]
checkpoint loading time at rank 4: 19.99671220779419 sec                                                                                             | 0/1 [00:00<?, ?it/s]
Loading 1 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.89it/s]
Loading 8 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:19<00:00,  2.50s/it]
Loading 8 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:20<00:00,  2.42s/it]
checkpoint loading time at rank 0: 20.810762882232666 sec
Loading 1 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  5.71it/s]
checkpoint loading time at rank 7: 20.186130046844482 sec
Loading 1 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  5.08it/s]
Loading 8 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:21<00:00,  2.70s/it]
checkpoint loading time at rank 6: 21.765174627304077 sec                                                                                            | 0/1 [00:00<?, ?it/s]
Loading 1 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  5.77it/s]
Loading 8 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:24<00:00,  3.02s/it]
checkpoint loading time at rank 5: 24.360199213027954 sec                                                                                            | 0/1 [00:00<?, ?it/s]
Loading 1 checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  4.81it/s]
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
------------------------------------------------------
Free memory : 33.154175 (GigaBytes)  
Total memory: 79.169678 (GigaBytes)  
Requested memory: 0.906250 (GigaBytes) 
Setting maximum total tokens (input + output) to 1024 
WorkSpace: 0x7fbece000000 
------------------------------------------------------
Setting `pad_token_id` to `eos_token_id`:11 for open-end generation.
Context: Deep learning involves the use of neural networks
Generated: Result: Deep learning involves the use of neural networks to train large volumes of data and is widely used for autonomous driving, robotic control, image recognition, and natural language processing.                                                        
A fundamental challenge in deep learning is ensuring the accuracy of the models developed by neural networks. This is important in any machine learning task but becomes especially key in applications that can have broad societal impact. One emerging technique is adversarial learning, which involves training deep learning algorithms to predict results that "fool" a model under
```
Performance: generating 100 tokens for 1 batch in 3.95 sec (39.46ms per token, 1.14 TB/s of memory BW utilization). 

Needs some cleanup before merging!