### PR TITLE
Pin numpy version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ einops
 hjson
 msgpack
 ninja
-numpy
+numpy<=1.26.4
 packaging>=20.0
 psutil
 py-cpuinfo


### PR DESCRIPTION
This PR is to fix incompatible numpy version of pyt_deepspeed_megatron_gpt2 and pyt_train_deepspeed_megatron_gpt2 with ROCm PyTorch release/2.5 branch.