### PR TITLE
[ROCm] Enable fp_quantizer on ROCm

### DIFF
--- a/op_builder/fp_quantizer.py
+++ b/op_builder/fp_quantizer.py
@@ -94,7 +94,6 @@ class FPQuantizerBuilder(CUDAOpBuilder):
         ]
 
     def extra_ldflags(self):
-        return ['-lcurand']
         if not self.is_rocm_pytorch():
             return ['-lcurand']
         else:

--- a/op_builder/fp_quantizer.py
+++ b/op_builder/fp_quantizer.py
@@ -95,6 +95,10 @@ class FPQuantizerBuilder(CUDAOpBuilder):
 
     def extra_ldflags(self):
         return ['-lcurand']
+        if not self.is_rocm_pytorch():
+            return ['-lcurand']
+        else:
+            return []
 
     def include_paths(self):
         return ['csrc/fp_quantizer/includes', 'csrc/includes']


### PR DESCRIPTION
This change is required to successfully build fp_quantizer extension on ROCm.