### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "ninja",
+    "typing-extensions>=4.10.0",
+]
+# Use legacy backend to import local packages in setup.py
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
- [ ] Test all build cases this needs to support.
- [ ] Test Windows builds/support.
- [ ] Confirm pre-compiling ops

This PR was quickly updated with `hatch` to build the pyproject.toml as a starting point.

Fixes: #7031