### PR TITLE
nv-ds-chat breaks with latest transformers

### DIFF
--- a/.github/workflows/nv-ds-chat.yml
+++ b/.github/workflows/nv-ds-chat.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install deepspeed
         run: |
-          pip install transformers
+          pip install transformers==4.48.3
           pip install .[dev]
           ds_report
 


### PR DESCRIPTION
Traceback: 

```
[rank4]: Traceback (most recent call last):
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/deepspeed/runtime/hybrid_engine.py", line 247, in generate
[rank4]:     generate_ret_vals = self._generate(*inputs, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank4]:     return func(*args, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/transformers/generation/utils.py", line 2223, in generate
[rank4]:     result = self._sample(
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/transformers/generation/utils.py", line 3214, in _sample
[rank4]:     outputs = model_forward(**model_inputs, return_dict=True)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
[rank4]:     return self._call_impl(*args, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1845, in _call_impl
[rank4]:     return inner()
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1793, in inner
[rank4]:     result = forward_call(*args, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/transformers/models/opt/modeling_opt.py", line 1182, in forward
[rank4]:     outputs = self.model.decoder(
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
[rank4]:     return self._call_impl(*args, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1845, in _call_impl
[rank4]:     return inner()
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1793, in inner
[rank4]:     result = forward_call(*args, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/transformers/models/opt/modeling_opt.py", line 853, in forward
[rank4]:     past_key_values = DynamicCache.from_legacy_cache(past_key_values)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/transformers/utils/deprecation.py", line 172, in wrapped_func
[rank4]:     return func(*args, **kwargs)
[rank4]:   File "/scratch/azureml/cr/j/fd0226bc522341fc895296811334080f/exe/wd/actions-runner/_work/DeepSpeed/DeepSpeed/unit-test-venv/lib/python3.10/site-packages/transformers/cache_utils.py", line 478, in from_legacy_cache
[rank4]:     key_states, value_states = past_key_values[layer_idx]
[rank4]: ValueError: too many values to unpack (expected 2)
```

The error occurs with the latest transformers (4.49.0+)

Fixes: #7048