### PR TITLE
Handle special case of libuv for Windows

### DIFF
--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -145,7 +145,7 @@ class TorchBackend(Backend):
 
     def init_process_group(self, backend, timeout, init_method, rank, world_size):
         if not torch.distributed.is_initialized():
-            if required_torch_version(min_version=2.4):
+            if not required_torch_version(min_version=2.4):
                 # Windows torch builds do not come with lib_uv by default.
                 # More information here: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html
                 use_libuv = False if os.name == "nt" else True

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -145,15 +145,22 @@ class TorchBackend(Backend):
 
     def init_process_group(self, backend, timeout, init_method, rank, world_size):
         if not torch.distributed.is_initialized():
-            # Windows torch builds do not come with lib_uv by default.
-            # More information here: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html
-            use_libuv = False if os.name == "nt" and required_torch_version(min_version=2.4) else True
-            torch.distributed.init_process_group(backend,
-                                                 timeout=timeout,
-                                                 init_method=init_method,
-                                                 rank=rank,
-                                                 world_size=world_size,
-                                                 use_libuv=use_libuv)
+            if required_torch_version(min_version=2.4):
+                # Windows torch builds do not come with lib_uv by default.
+                # More information here: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html
+                use_libuv = False if os.name == "nt" else True
+                torch.distributed.init_process_group(backend,
+                                                     timeout=timeout,
+                                                     init_method=init_method,
+                                                     rank=rank,
+                                                     world_size=world_size,
+                                                     use_libuv=use_libuv)
+            else:
+                torch.distributed.init_process_group(backend,
+                                                     timeout=timeout,
+                                                     init_method=init_method,
+                                                     rank=rank,
+                                                     world_size=world_size)
         self.using_mpi = torch.distributed.get_backend() == 'mpi'
 
     @disable_compiler_collective

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -145,11 +145,15 @@ class TorchBackend(Backend):
 
     def init_process_group(self, backend, timeout, init_method, rank, world_size):
         if not torch.distributed.is_initialized():
+            # Windows torch builds do not come with lib_uv by default.
+            # More information here: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html
+            use_lib_uv = False if os.name == "nt" and required_torch_version(min_version=2.4) else True
             torch.distributed.init_process_group(backend,
                                                  timeout=timeout,
                                                  init_method=init_method,
                                                  rank=rank,
-                                                 world_size=world_size)
+                                                 world_size=world_size,
+                                                 use_libuv=use_libuv)
         self.using_mpi = torch.distributed.get_backend() == 'mpi'
 
     @disable_compiler_collective

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -147,7 +147,7 @@ class TorchBackend(Backend):
         if not torch.distributed.is_initialized():
             # Windows torch builds do not come with lib_uv by default.
             # More information here: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html
-            use_lib_uv = False if os.name == "nt" and required_torch_version(min_version=2.4) else True
+            use_libuv = False if os.name == "nt" and required_torch_version(min_version=2.4) else True
             torch.distributed.init_process_group(backend,
                                                  timeout=timeout,
                                                  init_method=init_method,


### PR DESCRIPTION
More information on libuv in pytorch: https://pytorch.org/tutorials/intermediate/TCPStore_libuv_backend.html
Issue tracking the prevalence of the error on Windows (unresolved at the time of this PR):  https://github.com/pytorch/pytorch/issues/139990
LibUV github: https://github.com/libuv/libuv

Windows error:
```
  File "C:\hostedtoolcache\windows\Python\3.12.7\x64\Lib\site-packages\torch\distributed\rendezvous.py", line 189, in _create_c10d_store
    return TCPStore(
           ^^^^^^^^^
RuntimeError: use_libuv was requested but PyTorch was build without libuv support
```

use_libuv isn't well supported on Windows in pytorch <2.4, so we need to guard around this case.