### PR TITLE
Pin transformers version on tests that use latest.

### DIFF
--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -42,7 +42,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          # git checkout 6c3f168b3
+          git checkout 41925e421
           git rev-parse --short HEAD
           pip install .
 

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -42,7 +42,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          git checkout 41925e421
+          git checkout 981c276
           git rev-parse --short HEAD
           pip install .
 

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -112,7 +112,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          git checkout 6c3f168b3
+          git checkout 981c276
           git rev-parse --short HEAD
           pip install .
 

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -43,7 +43,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if you need to use an older transformers version temporarily in case of breakage
-          # git checkout v4.47.1
+          git checkout 981c276
           git rev-parse --short HEAD
           python -m pip install .
       - name: Install deepspeed

--- a/.github/workflows/nv-torch-latest-v100.yml
+++ b/.github/workflows/nv-torch-latest-v100.yml
@@ -38,7 +38,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          # git checkout 6c3f168b3
+          git checkout 981c276
           git rev-parse --short HEAD
           pip install .
 

--- a/.github/workflows/nv-torch-nightly-v100.yml
+++ b/.github/workflows/nv-torch-nightly-v100.yml
@@ -2,11 +2,11 @@ name: nv-torch-nightly-v100
 
 on:
   workflow_dispatch:
-    pull_request:
-    paths:
-      - '.github/workflows/nv-torch-nightly-v100.yml'
   schedule:
     - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - '.github/workflows/nv-torch-nightly-v100.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,7 +37,7 @@ jobs:
           git clone https://github.com/huggingface/transformers
           cd transformers
           # if needed switch to the last known good SHA until transformers@master is fixed
-          # git checkout 6c3f168b3
+          git checkout 981c276
           git rev-parse --short HEAD
           pip install .
 


### PR DESCRIPTION
Latest transformers causes failures when cpu-torch-latest test, so we pin it for now to unblock other PRs.