### PR TITLE
Avoid graph break due to unsupported frozenset

### DIFF
--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -297,7 +297,7 @@ class PartitionedParameterCoordinator:
                     "inflight": [p.ds_id for p in self.__inflight_param_registry],
                 }))
 
-        params_to_fetch = frozenset(iter_params(current_submodule, recurse=z3_leaf_module(current_submodule)))
+        params_to_fetch = set(iter_params(current_submodule, recurse=z3_leaf_module(current_submodule)))
         fetch_numel = sum(
             [p.partition_numel() for p in params_to_fetch if p.ds_status == ZeroParamStatus.NOT_AVAILABLE])
 


### PR DESCRIPTION
This PR is a continuation of the efforts to improve Deepspeed performance when using PyTorch compile.

The `fetch_sub_module()` routine makes use of the `frozenset` which is problematic because:

1. `iter_params` returns an iterable over model parameters
2. `frozenset` wraps this iterable, making it unmodifiable
3. PyTorch’s compilation process cannot infer how `frozenset` interacts with tensors, leading to a graph break.

If we replace the `frozenset` with a modifiable `set`, then there is no longer such graph break.