### PR TITLE
fix `seq_parallel_communication_data_type` constant.

### DIFF
--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -249,7 +249,7 @@ SEQ_PARALLEL_COMMUNICATION_DATA_TYPE_FORMAT = '''
 Optional comm data type for seq paralleism should be set as:
 "seq_parallel_communication_data_type": "fp32"
 '''
-SEQ_PARALLEL_COMMUNICATION_DATA_TYPE = "seq_parallel_comm_data_type"
+SEQ_PARALLEL_COMMUNICATION_DATA_TYPE = "seq_parallel_communication_data_type"
 SEQ_PARALLEL_COMMUNICATION_DATA_TYPE_DEFAULT = "fp32"
 
 #########################################


### PR DESCRIPTION
A user couldn't override `seq_parallel_communication_data_type` because of a typo in a name, this PR fixes it.