### PR TITLE
Update to fix pydantic warning

### DIFF
--- a/deepspeed/runtime/config_utils.py
+++ b/deepspeed/runtime/config_utils.py
@@ -61,7 +61,7 @@ class DeepSpeedConfigModel(BaseModel):
         # Get information about the deprecated field
         pydantic_config = self
         fields_set = pydantic_config.model_fields_set
-        kwargs = pydantic_config.model_fields[dep_field].json_schema_extra
+        kwargs = type(pydantic_config).model_fields[dep_field].json_schema_extra
         new_param_fn = kwargs.get("new_param_fn", lambda x: x)
         param_value = new_param_fn(getattr(pydantic_config, dep_field))
         new_field = kwargs.get("new_param", "")


### PR DESCRIPTION
Warning:

```
site-packages/deepspeed/runtime/config_utils.py:64: PydanticDeprecatedSince211: Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    kwargs = pydantic_config.model_fields[dep_field].json_schema_extra
```