### PR TITLE
Add defence for DeepCompile w/o optimizer

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3896,9 +3896,8 @@ class DeepSpeedEngine(Module):
                 or self.zero_optimization_stage() == ZeroStageEnum.weights \
                 , "Currently DeepCompile supports stage 1 or 3 only."
 
-            assert not isinstance(
-                self.optimizer,
-                DeepSpeedZeRoOffload), "Currently DeepCompile is not supported without an optimizer."
+            assert not isinstance(self.optimizer,
+                                  DeepSpeedZeRoOffload), "Currently DeepCompile is not supported without an optimizer."
 
             if schedule is not None:
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3896,6 +3896,10 @@ class DeepSpeedEngine(Module):
                 or self.zero_optimization_stage() == ZeroStageEnum.weights \
                 , "Currently DeepCompile supports stage 1 or 3 only."
 
+            assert not isinstance(
+                self.optimizer,
+                DeepSpeedZeRoOffload), "Currently DeepCompile is not supported without an optimizer."
+
             if schedule is not None:
 
                 def passes_name_to_fn(passes):


### PR DESCRIPTION
Similar to #7211

When the optimizer is not specified, the optimizer will be type `DeepSpeedZeRoOffload` instead of `DeepSpeedZeroOptimizer_Stage3` (e.g. for ZeRO-3 pure inference), while `DeepSpeedZeRoOffload` doesn't have `parameter_offload`.

https://github.com/deepspeedai/DeepSpeed/blob/56005d2b256eb81a88cba0a1984375f9663a3110/deepspeed/runtime/engine.py#L1684-L1707

```log
  File "deepspeed/runtime/engine.py", line 3919, in compile
    backend = init_z3(self, backend, compile_config, compile_kwargs, schedule)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "deepspeed/compile/init_z3.py", line 36, in init_z3
    optimizer.parameter_offload._remove_module_hooks()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DeepSpeedZeRoOffload' object has no attribute 'parameter_offload'
```