### PR TITLE
Pass `with_cuda` arg for jit_load in OpBuilder

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -590,6 +590,7 @@ class OpBuilder(ABC):
                          extra_cflags=cxx_args,
                          extra_cuda_cflags=nvcc_args,
                          extra_ldflags=self.strip_empty_entries(self.extra_ldflags()),
+                         with_cuda=True if (isinstance(self, CUDAOpBuilder) and not self.build_for_cpu) else None,
                          verbose=verbose)
 
         build_duration = time.time() - start_build


### PR DESCRIPTION
Torch loads and hipify JIT C++ extension by determining whether CUDA headers and libraries are added to the build, based on the existence of `.cu` or `.cuh` in `sources`, if we let `with_cuda` to be the default `None`.

https://github.com/pytorch/pytorch/blob/2a909cab1699e2be26fc7d01c7c2d20c726e1be6/torch/utils/cpp_extension.py#L1623-L1627

While for some Ops, such as DeepCompile, there are no `.cu` or `.cuh` files in the sources, but we still need to do the hipify on AMD as it includes several CUDA headers in the C++ code. So, it's better for us to control this behavior if it's not `build_for_cpu`, otherwise, the hipify will get skipped.