### PR TITLE
Make sure it's not None before offloading contiguous_grad_buffer

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -2915,7 +2915,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
 
         # contiguous bucket
         if needs_offload(OffloadStateTypeEnum.contiguous_grad_buffer):
-            if hasattr(self, "_DeepSpeedZeroOptimizer_Stage3__ipg_bucket_flat_buffer"):
+            if hasattr(self, "_DeepSpeedZeroOptimizer_Stage3__ipg_bucket_flat_buffer"
+                       ) and self.__ipg_bucket_flat_buffer is not None:
                 # Record properties like shape, strides, etc. as a meta tensor
                 self.grad_buffer_meta = self.__ipg_bucket_flat_buffer.to("meta")
                 self.__ipg_bucket_flat_buffer = None


### PR DESCRIPTION
Resolves #7223

When DeepCompile is enabled in ZeRO-3, contiguous_grad_buffer is released, so we should check and make sure it's not None before we continue.

https://github.com/deepspeedai/DeepSpeed/blob/227a60c0c412ddf4619401b5d8d9d1674aee17b5/deepspeed/compile/init_z3.py#L22-L25