### PR TITLE
Fixed the bug of memory consumption when using ZeRO-Offload

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1887,8 +1887,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 #    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
-                # bit16_partitions[partition_id].data.copy_(
-                #     fp32_partition.to(get_accelerator().current_device_name()).data)
                 bit16_partitions[partition_id].data.copy_(fp32_partition.to(dtype=bit16_partitions[partition_id].data.dtype).data, non_blocking=True)
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1887,9 +1887,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 #    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
-                bit16_partitions[partition_id].data.copy_(
-                    fp32_partition.to(get_accelerator().current_device_name()).data)
-
+                # bit16_partitions[partition_id].data.copy_(
+                #     fp32_partition.to(get_accelerator().current_device_name()).data)
+                bit16_partitions[partition_id].data.copy_(fp32_partition.to(dtype=bit16_partitions[partition_id].data.dtype).data, non_blocking=True)
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:
                 # free gradients for all the parameters that are not updated by this process(ZeRO stage2)


### PR DESCRIPTION
Fixed the bug of memory consumption when using ZeRO-Offload with FP16/BF16. Before the fix, the memory usage about 3x params_FP16. Now it is 1x params_FP16.
(Something is also not sure, such as how custom CUDA stream used in deepspeed, is that can used on multi-machines? )