### PR TITLE
Fixed the bug of memory consumption when using ZeRO-Offload

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1888,7 +1888,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
                 bit16_partitions[partition_id].data.copy_(
-                    fp32_partition.to(get_accelerator().current_device_name()).data)
+                  fp32_partition.to(dtype=bit16_partitions[partition_id].data.dtype).data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:


### PR DESCRIPTION
Fixed the bug of memory consumption when using ZeRO-Offload with FP16/BF16. Before the fix, the memory usage about 3x params_FP16. Now it is 1x params_FP16. (Something is also not sure, such as how custom CUDA stream used in deepspeed, is that can used on multi-machines? )
> 51F1y <1790690514@qq.com>