### PR TITLE
Fix the memory usage of ZeRO-Offload (update stage_1_and_2.py)

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1888,7 +1888,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
                 bit16_partitions[partition_id].data.copy_(
-                    fp32_partition.to(dtype=bit16_partitions[partition_id].data.dtype).data, non_blocking=True)
+                    fp32_partition.to(dtype=bit16_partitions[partition_id].data.dtype, non_blocking=True).data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1888,7 +1888,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
                 bit16_partitions[partition_id].data.copy_(
-                    fp32_partition.to(get_accelerator().current_device_name()).data)
+                    fp32_partition.to(dtype=bit16_partitions[partition_id].data.dtype).data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:


### PR DESCRIPTION
Fix the memory usage of ZeRO-Offload with stage 1 and 2. Before the fix, the memory usage about 3x params_FP16. Now it is 1x params_FP16.
Signed-off-by: arminzhu <mingzhengzhu1998@gmail.com>