### PR TITLE
set `device_id` in torch's `init_process_group`

### DIFF
--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -145,11 +145,13 @@ class TorchBackend(Backend):
 
     def init_process_group(self, backend, timeout, init_method, rank, world_size):
         if not torch.distributed.is_initialized():
+            local_rank = int(os.environ.get('LOCAL_RANK', 0))
             torch.distributed.init_process_group(backend,
                                                  timeout=timeout,
                                                  init_method=init_method,
                                                  rank=rank,
-                                                 world_size=world_size)
+                                                 world_size=world_size,
+                                                 device_id=torch.device('cuda', local_rank))
         self.using_mpi = torch.distributed.get_backend() == 'mpi'
 
     @disable_compiler_collective


### PR DESCRIPTION
This PR overcomes this issue:
```
[W404 00:15:21.693690333 ProcessGroupNCCL.cpp:4561] [PG ID 0 PG GUID 0 Rank 0]  using GPU 0 to perform barrier as devices used by this process are currently unknown. This can potentially cause a hang if this rank to GPU mapping is incorrect. Specify device_ids in barrier() to force use of a particular device, or call init_process_group() with a device_id.
```
by setting `device_id` to the correct device corresponding to `LOCAL_RANK` env var.