### PR TITLE
disable license check until the new license situation has been sorted…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         args: []
 
 # disabled until the new license situation has been sorted out:
-# 1. the old copyrights need to remain 
+# 1. the old copyrights need to remain
 # 2. probably need to modify the check to check for the new copyright's existence only
 # -   repo: local
 #     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,17 +33,14 @@ repos:
     -   id: clang-format  # formatter of C/C++ code based on a style guide: LLVM, Google, Chromium, Mozilla, and WebKit available
         args: []
 
-# disabled until the new license situation has been sorted out:
-# 1. the old copyrights need to remain
-# 2. probably need to modify the check to check for the new copyright's existence only
-# -   repo: local
-#     hooks:
-#     -   id: check-torchdist
-#         name: check-torchdist
-#         entry: ./scripts/check-torchdist.py
-#         language: python
-#         exclude: ^(deepspeed/comm/|docs/|benchmarks/|scripts/check-torchdist.py|deepspeed/moe/sharded_moe.py|deepspeed/runtime/comm/coalesced_collectives.py|deepspeed/elasticity/elastic_agent.py|deepspeed/launcher/launch.py|tests/unit/comm/test_dist.py)
-#         # Specific deepspeed/ files are excluded for now until we wrap ProcessGroup in deepspeed.comm
+-   repo: local
+    hooks:
+    -   id: check-torchdist
+        name: check-torchdist
+        entry: ./scripts/check-torchdist.py
+        language: python
+        exclude: ^(deepspeed/comm/|docs/|benchmarks/|scripts/check-torchdist.py|deepspeed/moe/sharded_moe.py|deepspeed/runtime/comm/coalesced_collectives.py|deepspeed/elasticity/elastic_agent.py|deepspeed/launcher/launch.py|tests/unit/comm/test_dist.py)
+        # Specific deepspeed/ files are excluded for now until we wrap ProcessGroup in deepspeed.comm
 
 -   repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,14 +33,17 @@ repos:
     -   id: clang-format  # formatter of C/C++ code based on a style guide: LLVM, Google, Chromium, Mozilla, and WebKit available
         args: []
 
--   repo: local
-    hooks:
-    -   id: check-torchdist
-        name: check-torchdist
-        entry: ./scripts/check-torchdist.py
-        language: python
-        exclude: ^(deepspeed/comm/|docs/|benchmarks/|scripts/check-torchdist.py|deepspeed/moe/sharded_moe.py|deepspeed/runtime/comm/coalesced_collectives.py|deepspeed/elasticity/elastic_agent.py|deepspeed/launcher/launch.py|tests/unit/comm/test_dist.py)
-        # Specific deepspeed/ files are excluded for now until we wrap ProcessGroup in deepspeed.comm
+# disabled until the new license situation has been sorted out:
+# 1. the old copyrights need to remain 
+# 2. probably need to modify the check to check for the new copyright's existence only
+# -   repo: local
+#     hooks:
+#     -   id: check-torchdist
+#         name: check-torchdist
+#         entry: ./scripts/check-torchdist.py
+#         language: python
+#         exclude: ^(deepspeed/comm/|docs/|benchmarks/|scripts/check-torchdist.py|deepspeed/moe/sharded_moe.py|deepspeed/runtime/comm/coalesced_collectives.py|deepspeed/elasticity/elastic_agent.py|deepspeed/launcher/launch.py|tests/unit/comm/test_dist.py)
+#         # Specific deepspeed/ files are excluded for now until we wrap ProcessGroup in deepspeed.comm
 
 -   repo: local
     hooks:

--- a/scripts/check-license.py
+++ b/scripts/check-license.py
@@ -19,7 +19,7 @@ def err(s: str) -> None:
 
 
 COPYRIGHT = [
-    (r"^# Copyright (c) Microsoft Corporation.$", r"^\/\/ Copyright (c) Microsoft Corporation.$"),
+    # (r"^# Copyright (c) Microsoft Corporation.$", r"^\/\/ Copyright (c) Microsoft Corporation.$"),
     (r"^# SPDX-License-Identifier: Apache-2.0$", r"^\/\/ SPDX-License-Identifier: Apache-2.0$"),
     (r"^# DeepSpeed Team$", r"^\/\/ DeepSpeed Team$"),
 ]


### PR DESCRIPTION
Until we sort out the new license situation disable this check so that new code not owned by MSFT could be added