### PR TITLE
Fix the GPU memory usage of ZeRO-Offload (only update stage_1_and_2.py)

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -258,6 +258,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # that this process will update
         self.single_partition_of_fp32_groups = []
 
+        # a 16-bit CPU param buffer for cpu offload
+        if self.cpu_offload:
+            self.param_buffer_of_bit16_for_cpu_offload_groups = []
+
         # param partition info
 
         # These are the parameters in each group that will not be updated by this process directly
@@ -406,6 +410,17 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             if self.cpu_offload:
                 weights_partition = get_accelerator().pin_memory(weights_partition)
+                temp_param_buffer_of_bit16 = torch.full(
+                    weights_partition.shape,
+                    fill_value=0.,
+                    dtype=self.parallel_partitioned_bit16_groups[i][partition_id].dtype,
+                    device=weights_partition.device)
+                if self.cpu_offload_pin_memory:
+                    self.param_buffer_of_bit16_for_cpu_offload_groups.append(
+                        get_accelerator().pin_memory(temp_param_buffer_of_bit16))
+                else:
+                    self.param_buffer_of_bit16_for_cpu_offload_groups.append(
+                        temp_param_buffer_of_bit16)
 
             self.single_partition_of_fp32_groups.append(weights_partition)
 
@@ -1887,8 +1902,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 #    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
-                bit16_partitions[partition_id].data.copy_(
-                    fp32_partition.to(get_accelerator().current_device_name()).data)
+                bit16_partition_buffer = self.param_buffer_of_bit16_for_cpu_offload_groups[i]
+                bit16_partition_buffer.data.copy_(fp32_partition.data)
+                bit16_partitions[partition_id].data.copy_(bit16_partition_buffer.data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1903,8 +1903,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 fp32_partition = self.single_partition_of_fp32_groups[i]
                 bit16_partition_buffer = self.param_buffer_of_bit16_for_cpu_offload_groups[i]
                 bit16_partition_buffer.data.copy_(fp32_partition.data)
-                bit16_partitions[partition_id].data.copy_(
-                    bit16_partition_buffer.data, non_blocking=True)
+                bit16_partitions[partition_id].data.copy_(bit16_partition_buffer.data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -11,8 +11,15 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 from deepspeed.runtime.base_optimizer import ZeROOptimizer
 from deepspeed.runtime.fp16.loss_scaler import CreateLossScaler
-from deepspeed.runtime.utils import (empty_cache, see_memory_usage, inf, is_model_parallel_parameter,
-                                     align_dense_tensors, all_gather_dp_groups, mask_nan_or_inf_with_val_inplace)
+from deepspeed.runtime.utils import (
+    empty_cache,
+    see_memory_usage,
+    inf,
+    is_model_parallel_parameter,
+    align_dense_tensors,
+    all_gather_dp_groups,
+    mask_nan_or_inf_with_val_inplace,
+)
 from deepspeed.runtime.zero.config import ZeroStageEnum
 from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum
 from deepspeed.ops.adam import DeepSpeedCPUAdam
@@ -25,21 +32,35 @@ from deepspeed.git_version_info import version
 from deepspeed.runtime.constants import PIPE_REPLICATED
 from deepspeed.accelerator import get_accelerator
 
-from deepspeed.checkpoint.constants import (DS_VERSION, GROUP_PADDINGS, PARTITION_COUNT, LOSS_SCALER,
-                                            SINGLE_PARTITION_OF_FP32_GROUPS, BASE_OPTIMIZER_STATE,
-                                            BASE_OPTIMIZER_STATE_STEP, CLIP_GRAD, ZERO_STAGE, PARAM_SLICE_MAPPINGS)
+from deepspeed.checkpoint.constants import (
+    DS_VERSION,
+    GROUP_PADDINGS,
+    PARTITION_COUNT,
+    LOSS_SCALER,
+    SINGLE_PARTITION_OF_FP32_GROUPS,
+    BASE_OPTIMIZER_STATE,
+    BASE_OPTIMIZER_STATE_STEP,
+    CLIP_GRAD,
+    ZERO_STAGE,
+    PARAM_SLICE_MAPPINGS,
+)
 from deepspeed.utils import link_hp_params, lazy_init_hp_params_optimizer_state
 from deepspeed.checkpoint import enable_universal_checkpoint
 
 from deepspeed.utils import groups
+
 # Toggle this to true to enable correctness test
 # with gradient partitioning and without
 pg_correctness_test = False
 
-OPTIMIZER_ALLGATHER_TIMER = 'optimizer_allgather'
-OPTIMIZER_GRADIENTS_TIMER = 'optimizer_gradients'
-OPTIMIZER_STEP_TIMER = 'optimizer_step'
-OPTIMIZER_TIMERS = [OPTIMIZER_ALLGATHER_TIMER, OPTIMIZER_GRADIENTS_TIMER, OPTIMIZER_STEP_TIMER]
+OPTIMIZER_ALLGATHER_TIMER = "optimizer_allgather"
+OPTIMIZER_GRADIENTS_TIMER = "optimizer_gradients"
+OPTIMIZER_STEP_TIMER = "optimizer_step"
+OPTIMIZER_TIMERS = [
+    OPTIMIZER_ALLGATHER_TIMER,
+    OPTIMIZER_GRADIENTS_TIMER,
+    OPTIMIZER_STEP_TIMER,
+]
 INITIAL_MICRO_STEP_ID = -1
 
 
@@ -50,8 +71,10 @@ def input(msg):
 def split_half_float_double(tensors):
     device_type = get_accelerator().device_name()
     dtypes = [
-        "torch.{}.HalfTensor".format(device_type), "torch.{}.FloatTensor".format(device_type),
-        "torch.{}.DoubleTensor".format(device_type), "torch.{}.BFloat16Tensor".format(device_type)
+        "torch.{}.HalfTensor".format(device_type),
+        "torch.{}.FloatTensor".format(device_type),
+        "torch.{}.DoubleTensor".format(device_type),
+        "torch.{}.BFloat16Tensor".format(device_type),
     ]
     buckets = []
     for i, dtype in enumerate(dtypes):
@@ -67,6 +90,7 @@ def isclose(a, b, rtol=1e-09, atol=0.0):
 
 def lcm(x, y):
     from fractions import gcd  # or can import gcd from `math` in Python 3
+
     return x * y // gcd(x, y)
 
 
@@ -90,8 +114,10 @@ def _get_padded_tensor(src_tensor, size):
 
 
 def _pad_tensor_by_size(src_tensor, pad_size, dtype, device):
-    padded_tensor = torch.zeros(src_tensor.numel() + pad_size, dtype=dtype, device=device)
-    padded_tensor.data[:src_tensor.numel()].copy_(src_tensor.data)
+    padded_tensor = torch.zeros(
+        src_tensor.numel() + pad_size, dtype=dtype, device=device
+    )
+    padded_tensor.data[: src_tensor.numel()].copy_(src_tensor.data)
     return padded_tensor
 
 
@@ -107,39 +133,44 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     """
 
-    def __init__(self,
-                 init_optimizer,
-                 param_names,
-                 timers,
-                 static_loss_scale=1.0,
-                 dynamic_loss_scale=False,
-                 dynamic_loss_args=None,
-                 verbose=True,
-                 contiguous_gradients=True,
-                 reduce_bucket_size=500000000,
-                 use_multi_rank_bucket_allreduce=True,
-                 allgather_bucket_size=5000000000,
-                 dp_process_group=None,
-                 expert_parallel_group=None,
-                 expert_data_parallel_group=None,
-                 reduce_scatter=True,
-                 overlap_comm=False,
-                 offload_optimizer_config=None,
-                 mpu=None,
-                 clip_grad=0.0,
-                 gradient_accumulation_dtype=torch.float32,
-                 communication_data_type=torch.float16,
-                 postscale_gradients=True,
-                 gradient_predivide_factor=1.0,
-                 gradient_accumulation_steps=1,
-                 ignore_unused_parameters=True,
-                 partition_grads=True,
-                 round_robin_gradients=False,
-                 has_moe_layers=False,
-                 fp16_master_weights_and_gradients=False,
-                 elastic_checkpoint=False):
+    def __init__(
+        self,
+        init_optimizer,
+        param_names,
+        timers,
+        static_loss_scale=1.0,
+        dynamic_loss_scale=False,
+        dynamic_loss_args=None,
+        verbose=True,
+        contiguous_gradients=True,
+        reduce_bucket_size=500000000,
+        use_multi_rank_bucket_allreduce=True,
+        allgather_bucket_size=5000000000,
+        dp_process_group=None,
+        expert_parallel_group=None,
+        expert_data_parallel_group=None,
+        reduce_scatter=True,
+        overlap_comm=False,
+        offload_optimizer_config=None,
+        mpu=None,
+        clip_grad=0.0,
+        gradient_accumulation_dtype=torch.float32,
+        communication_data_type=torch.float16,
+        postscale_gradients=True,
+        gradient_predivide_factor=1.0,
+        gradient_accumulation_steps=1,
+        ignore_unused_parameters=True,
+        partition_grads=True,
+        round_robin_gradients=False,
+        has_moe_layers=False,
+        fp16_master_weights_and_gradients=False,
+        elastic_checkpoint=False,
+    ):
 
-        if offload_optimizer_config is not None and offload_optimizer_config.device != OffloadDeviceEnum.none:
+        if (
+            offload_optimizer_config is not None
+            and offload_optimizer_config.device != OffloadDeviceEnum.none
+        ):
             self.cpu_offload = True
             self.cpu_offload_pin_memory = offload_optimizer_config.pin_memory
         else:
@@ -150,7 +181,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             logger.info(f"Reduce bucket size {reduce_bucket_size}")
             logger.info(f"Allgather bucket size {allgather_bucket_size}")
             logger.info(f"CPU Offload: {self.cpu_offload}")
-            logger.info(f'Round robin gradient partitioning: {round_robin_gradients}')
+            logger.info(f"Round robin gradient partitioning: {round_robin_gradients}")
         # The fused optimizer does all the work. We need this layer for two reason:
         # 1. maintain same user API from apex.fp16_utils
         # 2. keep common stuff here in case we need to add ne552w fused optimizer later
@@ -164,7 +195,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # - flat by groups, not keeping state. TODO: remove state explicitly?
         # - master grad and unflat master weight never exist. TODO: a way to save out unflat master?
         if not get_accelerator().is_available():
-            raise SystemError("Accelerator is not detected, cannot perform low precision training (e.g., fp16, bf16).")
+            raise SystemError(
+                "Accelerator is not detected, cannot perform low precision training (e.g., fp16, bf16)."
+            )
         self.optimizer = init_optimizer
 
         # Use torch (un)flatten ops
@@ -183,23 +216,29 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         self.deepspeed_adam_offload = self.cpu_offload
 
-        self.device = get_accelerator().current_device_name() if not self.cpu_offload else 'cpu'
+        self.device = (
+            get_accelerator().current_device_name() if not self.cpu_offload else "cpu"
+        )
 
         self.dp_process_group = dp_process_group
         self.sequence_parallel_size = groups._get_sequence_parallel_world_size()
-        #expert parallel group
+        # expert parallel group
         self.ep_process_group = expert_parallel_group
 
-        #data parallel group for experts
+        # data parallel group for experts
         self.expert_dp_process_group = expert_data_parallel_group
 
-        #data parallel size for non-experts
+        # data parallel size for non-experts
         dp_size = dist.get_world_size(group=self.dp_process_group)
 
-        #For MoE models this maybe different for different param group
-        #It will be modified during MoE setup later in the init
-        self.real_dp_process_group = [dp_process_group for i in range(len(self.optimizer.param_groups))]
-        self.partition_count = [dp_size for i in range(len(self.optimizer.param_groups))]
+        # For MoE models this maybe different for different param group
+        # It will be modified during MoE setup later in the init
+        self.real_dp_process_group = [
+            dp_process_group for i in range(len(self.optimizer.param_groups))
+        ]
+        self.partition_count = [
+            dp_size for i in range(len(self.optimizer.param_groups))
+        ]
 
         self.is_gradient_accumulation_boundary = True
 
@@ -209,7 +248,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.has_moe_layers = has_moe_layers
         if self.has_moe_layers:
             self._configure_moe_settings()
-        self._global_grad_norm = 0.
+        self._global_grad_norm = 0.0
 
         if mpu is None:
             self.model_parallel_group = None
@@ -234,16 +273,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.fp16_master_weights_and_gradients = fp16_master_weights_and_gradients
 
         if self.fp16_master_weights_and_gradients:
-            assert self.cpu_offload and type(self.optimizer) in [DeepSpeedCPUAdam], \
-            f"fp16_master_and_gradients requires optimizer to support keeping fp16 master and gradients while keeping the optimizer states in fp32."\
-            f"Currently only supported using ZeRO-Offload with DeepSpeedCPUAdam. But current setting is ZeRO-Offload:{self.cpu_offload} and optimizer type {type(self.optimizer)}." \
-            f"Either disable fp16_master_weights_and_gradients or enable {self.zero_stage_string} Offload with DeepSpeedCPUAdam."
+            assert self.cpu_offload and type(self.optimizer) in [DeepSpeedCPUAdam], (
+                f"fp16_master_and_gradients requires optimizer to support keeping fp16 master and gradients while keeping the optimizer states in fp32."
+                f"Currently only supported using ZeRO-Offload with DeepSpeedCPUAdam. But current setting is ZeRO-Offload:{self.cpu_offload} and optimizer type {type(self.optimizer)}."
+                f"Either disable fp16_master_weights_and_gradients or enable {self.zero_stage_string} Offload with DeepSpeedCPUAdam."
+            )
 
         if self.reduce_scatter and self.partition_gradients:
             valid_reduce_scatter_dtypes = (torch.float16, torch.bfloat16, torch.float32)
-            assert self.communication_data_type in valid_reduce_scatter_dtypes, f"{self.zero_stage_string} supports {valid_reduce_scatter_dtypes} communication_data_type with reduce scatter enabled. Got: '{self.communication_data_type}'"
-            assert self.gradient_predivide_factor == 1.0, f"gradient_predivide_factor != 1.0 is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
-            assert self.postscale_gradients, f"pre-scale gradients is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
+            assert (
+                self.communication_data_type in valid_reduce_scatter_dtypes
+            ), f"{self.zero_stage_string} supports {valid_reduce_scatter_dtypes} communication_data_type with reduce scatter enabled. Got: '{self.communication_data_type}'"
+            assert (
+                self.gradient_predivide_factor == 1.0
+            ), f"gradient_predivide_factor != 1.0 is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
+            assert (
+                self.postscale_gradients
+            ), f"pre-scale gradients is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
 
         # param flattened by groups
         self.bit16_groups = []
@@ -286,7 +332,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         ), f"allgather_bucket_size must be a multiple of nccl_start_alignment_factor, {self.nccl_start_alignment_factor} "
 
         self.all_reduce_print = False
-        self.dtype = self.optimizer.param_groups[0]['params'][0].dtype
+        self.dtype = self.optimizer.param_groups[0]["params"][0].dtype
         self.gradient_accumulation_dtype = gradient_accumulation_dtype
 
         if self.dtype != self.gradient_accumulation_dtype:
@@ -312,7 +358,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # push this group to list before modify
             # TODO: Explore simplification that avoids the extra book-keeping by pushing the reordered group
             trainable_parameters = []
-            for param in param_group['params']:
+            for param in param_group["params"]:
                 if param.requires_grad:
                     param.grad_accum = None
                     param.param_idx_in_group = len(trainable_parameters)
@@ -341,7 +387,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # to the same rank, instead they will belong to 3 ranks (r_m+2, r_m+1, r_m).
             if self.round_robin_gradients:
                 round_robin_tensors, round_robin_indices = self._round_robin_reorder(
-                    self.bit16_groups[i], dist.get_world_size(group=self.real_dp_process_group[i]))
+                    self.bit16_groups[i],
+                    dist.get_world_size(group=self.real_dp_process_group[i]),
+                )
             else:
                 round_robin_tensors = self.bit16_groups[i]
                 round_robin_indices = list(range(len(self.bit16_groups[i])))
@@ -358,32 +406,45 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # create flat buffer in CPU
             flattened_buffer = self.flatten_dense_tensors_aligned(
                 self.round_robin_bit16_groups[i],
-                self.nccl_start_alignment_factor * dist.get_world_size(group=self.real_dp_process_group[i]),
-                use_cpu_data=True)
+                self.nccl_start_alignment_factor
+                * dist.get_world_size(group=self.real_dp_process_group[i]),
+                use_cpu_data=True,
+            )
 
             # free temp CPU params
             for param in self.bit16_groups[i]:
                 del param.cpu_data
 
             # Move CPU flat tensor to the accelerator memory.
-            self.bit16_groups_flat.append(flattened_buffer.to(get_accelerator().current_device_name()))
+            self.bit16_groups_flat.append(
+                flattened_buffer.to(get_accelerator().current_device_name())
+            )
             del flattened_buffer
 
-            see_memory_usage(f"After flattening and moving param group {i} to GPU", force=False)
+            see_memory_usage(
+                f"After flattening and moving param group {i} to GPU", force=False
+            )
 
             if dist.get_rank(group=self.real_dp_process_group[i]) == 0:
-                see_memory_usage(f"After Flattening and after emptying param group {i} cache", force=False)
+                see_memory_usage(
+                    f"After Flattening and after emptying param group {i} cache",
+                    force=False,
+                )
 
             # set model bit16 weight to slices of flattened buffer
             self._update_model_bit16_weights(i)
 
             # divide the flat weights into near equal partition equal to the data parallel degree
             # each process will compute on a different part of the partition
-            data_parallel_partitions = self.get_data_parallel_partitions(self.bit16_groups_flat[i], i)
+            data_parallel_partitions = self.get_data_parallel_partitions(
+                self.bit16_groups_flat[i], i
+            )
             self.parallel_partitioned_bit16_groups.append(data_parallel_partitions)
 
             # Record padding required for alignment
-            left_boundary = sum([t.numel() for t in data_parallel_partitions[:partition_id]])
+            left_boundary = sum(
+                [t.numel() for t in data_parallel_partitions[:partition_id]]
+            )
             curr_partition_size = data_parallel_partitions[partition_id].numel()
 
             if orig_group_numel <= left_boundary:
@@ -396,44 +457,66 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             # verify that data partition start locations are 4-byte aligned
             for partitioned_data in data_parallel_partitions:
-                assert (partitioned_data.data_ptr() % (2 * self.nccl_start_alignment_factor) == 0)
+                assert (
+                    partitioned_data.data_ptr() % (2 * self.nccl_start_alignment_factor)
+                    == 0
+                )
 
             # A partition of the fp32 master weights that will be updated by this process.
             # Note that the params in single_partition_of_fp32_groups is cloned and detached
             # from the origin params of the model.
             if not fp16_master_weights_and_gradients:
-                weights_partition = self.parallel_partitioned_bit16_groups[i][partition_id].to(
-                    self.device).clone().float().detach()
+                weights_partition = (
+                    self.parallel_partitioned_bit16_groups[i][partition_id]
+                    .to(self.device)
+                    .clone()
+                    .float()
+                    .detach()
+                )
             else:
-                weights_partition = self.parallel_partitioned_bit16_groups[i][partition_id].to(
-                    self.device).clone().half().detach()
+                weights_partition = (
+                    self.parallel_partitioned_bit16_groups[i][partition_id]
+                    .to(self.device)
+                    .clone()
+                    .half()
+                    .detach()
+                )
 
             if self.cpu_offload:
                 weights_partition = get_accelerator().pin_memory(weights_partition)
                 temp_param_buffer_of_bit16 = torch.full(
                     weights_partition.shape,
-                    fill_value=0.,
+                    fill_value=0.0,
                     dtype=self.parallel_partitioned_bit16_groups[i][partition_id].dtype,
-                    device=weights_partition.device)
+                    device=weights_partition.device,
+                )
                 if self.cpu_offload_pin_memory:
                     self.param_buffer_of_bit16_for_cpu_offload_groups.append(
-                        get_accelerator().pin_memory(temp_param_buffer_of_bit16))
+                        get_accelerator().pin_memory(temp_param_buffer_of_bit16)
+                    )
                 else:
                     self.param_buffer_of_bit16_for_cpu_offload_groups.append(
-                        temp_param_buffer_of_bit16)
+                        temp_param_buffer_of_bit16
+                    )
 
             self.single_partition_of_fp32_groups.append(weights_partition)
 
             # Set local optimizer to have flat params of its own partition.
             # After this, the local optimizer will only contain its own partition of params.
             # In that case, the local optimizer only saves the states(momentum, variance, etc.) related to its partition's params(zero stage1).
-            self.single_partition_of_fp32_groups[
-                i].requires_grad = True  # keep this in case internal optimizer uses it
-            param_group['params'] = [self.single_partition_of_fp32_groups[i]]
+            self.single_partition_of_fp32_groups[i].requires_grad = (
+                True  # keep this in case internal optimizer uses it
+            )
+            param_group["params"] = [self.single_partition_of_fp32_groups[i]]
 
-            partition_size = len(self.bit16_groups_flat[i]) / dist.get_world_size(group=self.real_dp_process_group[i])
-            params_in_partition, params_not_in_partition, first_offset = self.get_partition_info(
-                self.round_robin_bit16_groups[i], partition_size, partition_id)
+            partition_size = len(self.bit16_groups_flat[i]) / dist.get_world_size(
+                group=self.real_dp_process_group[i]
+            )
+            params_in_partition, params_not_in_partition, first_offset = (
+                self.get_partition_info(
+                    self.round_robin_bit16_groups[i], partition_size, partition_id
+                )
+            )
 
             self.partition_size.append(partition_size)
             self.params_in_partition.append(params_in_partition)
@@ -444,8 +527,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.use_multi_rank_bucket_allreduce = use_multi_rank_bucket_allreduce
         self.allgather_bucket_size = int(allgather_bucket_size)
 
-        self.reduction_stream = None if get_accelerator().is_synchronized_device() else get_accelerator().Stream()
-        #self.copy_grad_stream = get_accelerator().Stream()
+        self.reduction_stream = (
+            None
+            if get_accelerator().is_synchronized_device()
+            else get_accelerator().Stream()
+        )
+        # self.copy_grad_stream = get_accelerator().Stream()
         self.callback_queued = False
 
         self.param_dict = {}
@@ -464,7 +551,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # simplified param id
         self.param_id = {}
 
-        #interesting code: unique ids being assigned to individual parameters
+        # interesting code: unique ids being assigned to individual parameters
         largest_param_numel = 0
         count = 0
         for i, params_group in enumerate(self.bit16_groups):
@@ -490,17 +577,25 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.norm_for_param_grads = {}
             self.local_overflow = False
             self.grad_position = {}
-            self.temp_grad_buffer_for_cpu_offload = torch.zeros(largest_param_numel,
-                                                                device=self.device,
-                                                                dtype=self.dtype)
+            self.temp_grad_buffer_for_cpu_offload = torch.zeros(
+                largest_param_numel, device=self.device, dtype=self.dtype
+            )
             if self.cpu_offload_pin_memory:
                 self.temp_grad_buffer_for_cpu_offload = get_accelerator().pin_memory(
-                    self.temp_grad_buffer_for_cpu_offload)
-            self.temp_grad_buffer_for_gpu_offload = torch.zeros(largest_param_numel,
-                                                                device=get_accelerator().current_device_name(),
-                                                                dtype=self.dtype)
+                    self.temp_grad_buffer_for_cpu_offload
+                )
+            self.temp_grad_buffer_for_gpu_offload = torch.zeros(
+                largest_param_numel,
+                device=get_accelerator().current_device_name(),
+                dtype=self.dtype,
+            )
             for i, params_group in enumerate(self.bit16_groups):
-                self.get_grad_position(i, self.params_in_partition[i], self.first_offset[i], self.partition_size[i])
+                self.get_grad_position(
+                    i,
+                    self.params_in_partition[i],
+                    self.first_offset[i],
+                    self.partition_size[i],
+                )
 
         # mapping from parameter to partition that it belongs to
         self.param_to_partition_ids = {}
@@ -544,8 +639,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # 3. overlapping backward and reduction
         self._grad_acc_hooks = []
 
-        if (self.partition_gradients or self.overlap_comm or self.use_grad_accum_attribute
-                or self.contiguous_gradients):
+        if (
+            self.partition_gradients
+            or self.overlap_comm
+            or self.use_grad_accum_attribute
+            or self.contiguous_gradients
+        ):
             self.create_gradient_handling_hooks()
 
         self.ready_for_gradients = False
@@ -553,10 +652,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.external_loss_scale = None
 
         # we may have a way of fusing dynamic scale. Do not support for now
-        self.loss_scaler = CreateLossScaler(dtype=self.dtype,
-                                            static_loss_scale=static_loss_scale,
-                                            dynamic_scaling=dynamic_loss_scale,
-                                            dynamic_loss_args=dynamic_loss_args)
+        self.loss_scaler = CreateLossScaler(
+            dtype=self.dtype,
+            static_loss_scale=static_loss_scale,
+            dynamic_scaling=dynamic_loss_scale,
+            dynamic_loss_args=dynamic_loss_args,
+        )
         self.dynamic_loss_scale = self.loss_scaler.dynamic
 
         if self.dtype != torch.float16:
@@ -583,7 +684,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def destroy(self):
         for i, _ in enumerate(self.optimizer.param_groups):
             for p in self.bit16_groups[i]:
-                if getattr(p, '_hp_mapping', None):
+                if getattr(p, "_hp_mapping", None):
                     p._hp_mapping = None
         for hook in self._grad_acc_hooks:
             hook.remove()
@@ -600,7 +701,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for lp in self.bit16_groups[i]:
                 if lp._hp_mapping is not None:
                     lp_name = self.param_names[lp]
-                    param_mapping_per_group[lp_name] = lp._hp_mapping.get_hp_fragment_address()
+                    param_mapping_per_group[lp_name] = (
+                        lp._hp_mapping.get_hp_fragment_address()
+                    )
             param_mapping.append(param_mapping_per_group)
 
         return param_mapping
@@ -613,37 +716,48 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # Link bit16 and fp32 params in partition
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             partition_size = self.bit16_groups_flat[i].numel() // dist.get_world_size(
-                group=self.real_dp_process_group[i])
+                group=self.real_dp_process_group[i]
+            )
             flat_hp_partition = self.single_partition_of_fp32_groups[i]
-            link_hp_params(lp_param_list=self.bit16_groups[i],
-                           flat_hp_partition=flat_hp_partition,
-                           gradient_dict=self.averaged_gradients,
-                           offload_gradient_dict=self.offload_gradient_dict,
-                           use_offload=self.cpu_offload,
-                           param_group_index=i,
-                           partition_start=partition_id * partition_size,
-                           partition_size=partition_size,
-                           dp_group=self.real_dp_process_group[i])
+            link_hp_params(
+                lp_param_list=self.bit16_groups[i],
+                flat_hp_partition=flat_hp_partition,
+                gradient_dict=self.averaged_gradients,
+                offload_gradient_dict=self.offload_gradient_dict,
+                use_offload=self.cpu_offload,
+                param_group_index=i,
+                partition_start=partition_id * partition_size,
+                partition_size=partition_size,
+                dp_group=self.real_dp_process_group[i],
+            )
 
     def _lazy_init_hp_params_optimizer_state(self):
         if not self._hp_optimizer_states_linked:
             for i, _ in enumerate(self.optimizer.param_groups):
-                lazy_init_hp_params_optimizer_state(self.bit16_groups[i], self.single_partition_of_fp32_groups[i],
-                                                    self.optimizer.state)
+                lazy_init_hp_params_optimizer_state(
+                    self.bit16_groups[i],
+                    self.single_partition_of_fp32_groups[i],
+                    self.optimizer.state,
+                )
             self._hp_optimizer_states_linked = True
 
     def is_moe_group(self, group):
-        return 'moe' in group and group['moe']
+        return "moe" in group and group["moe"]
 
     def _configure_moe_settings(self):
         # if we're using ZeRO stage 2, ensure contiguous gradients are used
         if self.partition_gradients:
-            assert self.contiguous_gradients, "Contiguous Gradients in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
+            assert (
+                self.contiguous_gradients
+            ), "Contiguous Gradients in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
         # NOTE: To run ZeRO stage 1 with MoE, we need to set self.contiguous_gradients to True or ignore the assertion
         if not self.partition_gradients and not self.contiguous_gradients:
             logger.warning(
-                "ZeRO Stage 1 has not been thoroughly tested with MoE. This configuration is still experimental.")
-        assert self.reduce_scatter, "Reduce Scatter in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
+                "ZeRO Stage 1 has not been thoroughly tested with MoE. This configuration is still experimental."
+            )
+        assert (
+            self.reduce_scatter
+        ), "Reduce Scatter in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
 
         assert any(
             [self.is_moe_group(group) for group in self.optimizer.param_groups]
@@ -651,19 +765,31 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.is_moe_param_group = []
         for i, group in enumerate(self.optimizer.param_groups):
             if self.is_moe_group(group):
-                assert all([is_moe_param(param)
-                            for param in group['params']]), "All params in MoE group must be MoE params"
-                self.real_dp_process_group[i] = self.expert_dp_process_group[group['name']]
-                self.partition_count[i] = dist.get_world_size(group=self.expert_dp_process_group[group['name']])
+                assert all(
+                    [is_moe_param(param) for param in group["params"]]
+                ), "All params in MoE group must be MoE params"
+                self.real_dp_process_group[i] = self.expert_dp_process_group[
+                    group["name"]
+                ]
+                self.partition_count[i] = dist.get_world_size(
+                    group=self.expert_dp_process_group[group["name"]]
+                )
                 self.is_moe_param_group.append(True)
             else:
                 self.is_moe_param_group.append(False)
 
-        assert self.expert_dp_process_group is not None, "Expert data parallel group should be configured with MoE"
-        assert self.ep_process_group is not None, "Expert parallel group should be configured with MoE"
+        assert (
+            self.expert_dp_process_group is not None
+        ), "Expert data parallel group should be configured with MoE"
+        assert (
+            self.ep_process_group is not None
+        ), "Expert parallel group should be configured with MoE"
 
     def _update_model_bit16_weights(self, group_index):
-        updated_params = self.unflatten(self.bit16_groups_flat[group_index], self.round_robin_bit16_meta[group_index])
+        updated_params = self.unflatten(
+            self.bit16_groups_flat[group_index],
+            self.round_robin_bit16_meta[group_index],
+        )
         for p, q in zip(self.round_robin_bit16_groups[group_index], updated_params):
             p.data = q.data
 
@@ -689,7 +815,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         reordered_indices = {}
 
         for partition_index in partition_tensors.keys():
-            for i, (original_index, tensor) in enumerate(partition_tensors[partition_index]):
+            for i, (original_index, tensor) in enumerate(
+                partition_tensors[partition_index]
+            ):
                 reordered_indices[original_index] = len(reordered_tensors)
                 reordered_tensors.append(tensor)
 
@@ -705,21 +833,28 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def initialize_optimizer_states(self):
 
         for i, group in enumerate(self.bit16_groups):
-            single_grad_partition = torch.zeros(int(self.partition_size[i]),
-                                                dtype=self.single_partition_of_fp32_groups[i].dtype,
-                                                device=self.device)
-            self.single_partition_of_fp32_groups[i].grad = get_accelerator().pin_memory(
-                single_grad_partition) if self.cpu_offload_pin_memory else single_grad_partition
+            single_grad_partition = torch.zeros(
+                int(self.partition_size[i]),
+                dtype=self.single_partition_of_fp32_groups[i].dtype,
+                device=self.device,
+            )
+            self.single_partition_of_fp32_groups[i].grad = (
+                get_accelerator().pin_memory(single_grad_partition)
+                if self.cpu_offload_pin_memory
+                else single_grad_partition
+            )
 
         # Initialize the optimizer states with the flattened fp32 partition.
         # State initialization for the Adagrad optimizer occurs at construction as opposed to other optimizers
         # which do lazy initialization of the state at the first call to step.
         if isinstance(self.optimizer, torch.optim.Adagrad):
-            self.optimizer = torch.optim.Adagrad(self.single_partition_of_fp32_groups, **self.optimizer.defaults)
+            self.optimizer = torch.optim.Adagrad(
+                self.single_partition_of_fp32_groups, **self.optimizer.defaults
+            )
 
         if not self.cpu_offload:
             for group in self.single_partition_of_fp32_groups:
-                group.grad = None  #class init
+                group.grad = None  # class init
 
         return
 
@@ -733,9 +868,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # with PP we must create ipg buffer, since backward is handled outside zero
         if pipeline_parallel and self.contiguous_gradients:
             self.ipg_buffer = []
-            buf_0 = torch.empty(int(self.reduce_bucket_size),
-                                dtype=self.dtype,
-                                device=get_accelerator().current_device_name())
+            buf_0 = torch.empty(
+                int(self.reduce_bucket_size),
+                dtype=self.dtype,
+                device=get_accelerator().current_device_name(),
+            )
             self.ipg_buffer.append(buf_0)
             self.ipg_index = 0
 
@@ -755,7 +892,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def get_first_param_index(self, group_id, param_group, partition_id):
         for index, param in enumerate(param_group):
             param_id = self.get_param_id(param)
-            if group_id in self.param_to_partition_ids and param_id in self.param_to_partition_ids[group_id]:
+            if (
+                group_id in self.param_to_partition_ids
+                and param_id in self.param_to_partition_ids[group_id]
+            ):
                 if partition_id in self.param_to_partition_ids[group_id][param_id]:
                     return index
         return None
@@ -781,8 +921,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.total_grads_in_partition[i][partition_id] = 0
                 self.initialize_gradient_partition(i, param_group, partition_id)
                 self.is_partition_reduced[i][partition_id] = False
-                self.first_param_index_in_partition[i][partition_id] = self.get_first_param_index(
-                    i, param_group, partition_id)
+                self.first_param_index_in_partition[i][partition_id] = (
+                    self.get_first_param_index(i, param_group, partition_id)
+                )
 
     def independent_gradient_partition_epilogue(self):
         self.report_ipg_memory_usage(f"In ipg_epilogue before reduce_ipg_grads", 0)
@@ -803,23 +944,31 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if self.cpu_offload is False:
             for i, _ in enumerate(self.bit16_groups):
 
-                if not i in self.averaged_gradients or self.averaged_gradients[i] is None:
+                if (
+                    not i in self.averaged_gradients
+                    or self.averaged_gradients[i] is None
+                ):
                     self.averaged_gradients[i] = self.get_flat_partition(
                         self.params_in_partition[i],
                         self.first_offset[i],
                         self.partition_size[i],
                         dtype=self.gradient_accumulation_dtype,
                         device=get_accelerator().current_device_name(),
-                        return_tensor_list=True)
+                        return_tensor_list=True,
+                    )
                 else:
-                    avg_new = self.get_flat_partition(self.params_in_partition[i],
-                                                      self.first_offset[i],
-                                                      self.partition_size[i],
-                                                      dtype=self.gradient_accumulation_dtype,
-                                                      device=get_accelerator().current_device_name(),
-                                                      return_tensor_list=True)
+                    avg_new = self.get_flat_partition(
+                        self.params_in_partition[i],
+                        self.first_offset[i],
+                        self.partition_size[i],
+                        dtype=self.gradient_accumulation_dtype,
+                        device=get_accelerator().current_device_name(),
+                        return_tensor_list=True,
+                    )
 
-                    for accumulated_grad, new_avg_grad in zip(self.averaged_gradients[i], avg_new):
+                    for accumulated_grad, new_avg_grad in zip(
+                        self.averaged_gradients[i], avg_new
+                    ):
                         accumulated_grad.add_(new_avg_grad)
 
         self._release_ipg_buffers()
@@ -838,7 +987,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             total_partitions = dist.get_world_size(group=self.real_dp_process_group[i])
             for partition_id in range(total_partitions):
                 self.is_partition_reduced[i][partition_id] = False
-                self.remaining_grads_in_partition[i][partition_id] = self.total_grads_in_partition[i][partition_id]
+                self.remaining_grads_in_partition[i][partition_id] = (
+                    self.total_grads_in_partition[i][partition_id]
+                )
 
                 for param_id in self.is_grad_computed[i][partition_id]:
                     self.is_grad_computed[i][partition_id][param_id] = False
@@ -871,20 +1022,27 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             param_id = self.get_param_id(param)
 
             if start_index <= current_index < end_index:
-                set_key_value_list(self.param_to_partition_ids[i], param_id, partition_id)
+                set_key_value_list(
+                    self.param_to_partition_ids[i], param_id, partition_id
+                )
                 increment_value(self.total_grads_in_partition[i], partition_id)
 
                 self.is_grad_computed[i][partition_id][param_id] = False
 
-                self.grad_partition_insertion_offset[i][partition_id][param_id] = current_index - start_index
+                self.grad_partition_insertion_offset[i][partition_id][param_id] = (
+                    current_index - start_index
+                )
                 self.grad_start_offset[i][partition_id][param_id] = 0
 
             elif current_index < start_index < (current_index + param_size):
-                assert (first_offset == 0
-                        ), "This can happen either zero or only once as this must be the first tensor in the partition"
+                assert (
+                    first_offset == 0
+                ), "This can happen either zero or only once as this must be the first tensor in the partition"
                 first_offset = start_index - current_index
 
-                set_key_value_list(self.param_to_partition_ids[i], param_id, partition_id)
+                set_key_value_list(
+                    self.param_to_partition_ids[i], param_id, partition_id
+                )
                 increment_value(self.total_grads_in_partition[i], partition_id)
 
                 self.is_grad_computed[i][partition_id][param_id] = False
@@ -902,7 +1060,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if param.grad_accum is None:
                 param.grad_accum = param.grad.to(self.gradient_accumulation_dtype)
             else:
-                param.grad_accum.add_(param.grad.to(self.gradient_accumulation_dtype).view(param.grad_accum.shape))
+                param.grad_accum.add_(
+                    param.grad.to(self.gradient_accumulation_dtype).view(
+                        param.grad_accum.shape
+                    )
+                )
             param.grad = None
 
     def fill_grad_accum_attribute(self):
@@ -912,7 +1074,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def get_gradient_for_reduction(self, param):
         if self.use_grad_accum_attribute:
-            return param.grad_accum.to(self.dtype) if param.grad_accum is not None else None
+            return (
+                param.grad_accum.to(self.dtype)
+                if param.grad_accum is not None
+                else None
+            )
         else:
             return param.grad
 
@@ -936,7 +1102,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         def grad_handling_hook(*notneeded):
                             self.process_gradients(param, i)
 
-                        self._grad_acc_hooks.append(register_grad_hook(param, grad_handling_hook))
+                        self._grad_acc_hooks.append(
+                            register_grad_hook(param, grad_handling_hook)
+                        )
 
                     wrapper(param, i)
 
@@ -953,7 +1121,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     # create a flat tensor aligned at the alignment boundary
     def flatten_dense_tensors_aligned(self, tensor_list, alignment, use_cpu_data=False):
-        tensor_list = [param.cpu_data for param in tensor_list] if use_cpu_data else tensor_list
+        tensor_list = (
+            [param.cpu_data for param in tensor_list] if use_cpu_data else tensor_list
+        )
         return self.flatten(align_dense_tensors(tensor_list, alignment))
 
     ############### Independent Partition Gradient ########################
@@ -961,16 +1131,21 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         grad_reduc = self.get_gradient_for_reduction(param)
         if self.elements_in_ipg_bucket + param.numel() > self.reduce_bucket_size:
-            self.report_ipg_memory_usage("In ipg_remove_grads before reduce_ipg_grads", param.numel())
+            self.report_ipg_memory_usage(
+                "In ipg_remove_grads before reduce_ipg_grads", param.numel()
+            )
             self.reduce_ipg_grads()
             if self.contiguous_gradients and self.overlap_comm:
                 # Swap ipg_index between 0 and 1
                 self.ipg_index = 1 - self.ipg_index
-            self.report_ipg_memory_usage("In ipg_remove_grads after reduce_ipg_grads", param.numel())
+            self.report_ipg_memory_usage(
+                "In ipg_remove_grads after reduce_ipg_grads", param.numel()
+            )
 
         param_id = self.get_param_id(param)
-        assert self.params_already_reduced[param_id] == False, \
-            f"The parameter {param_id} has already been reduced. \
+        assert (
+            self.params_already_reduced[param_id] == False
+        ), f"The parameter {param_id} has already been reduced. \
             Gradient computed twice for this partition. \
             Multiple gradient reduction is currently not supported"
 
@@ -979,18 +1154,22 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.extra_large_param_to_reduce = param
             else:
                 # keeping the gradients contiguous to prevent memory fragmentation, and avoid flattening
-                new_grad_tensor = self.ipg_buffer[self.ipg_index].narrow(0, self.elements_in_ipg_bucket, param.numel())
+                new_grad_tensor = self.ipg_buffer[self.ipg_index].narrow(
+                    0, self.elements_in_ipg_bucket, param.numel()
+                )
                 new_grad_tensor.copy_(grad_reduc.view(-1))
                 grad_reduc.data = new_grad_tensor.data.view_as(grad_reduc)
 
         self.elements_in_ipg_bucket += param.numel()
 
-        assert grad_reduc is not None, f"rank {dist.get_rank()} - Invalid to reduce Param {param_id} with None gradient"
+        assert (
+            grad_reduc is not None
+        ), f"rank {dist.get_rank()} - Invalid to reduce Param {param_id} with None gradient"
 
         self.grads_in_ipg_bucket.append(grad_reduc)
         self.params_in_ipg_bucket.append((i, param.param_idx_in_group, param_id))
 
-        #make sure the average tensor function knows how to average the gradients
+        # make sure the average tensor function knows how to average the gradients
         if is_moe_param(param):
             self.ipg_bucket_has_moe_params = True
 
@@ -1013,35 +1192,50 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         if self.postscale_gradients:
             if self.gradient_predivide_factor != 1.0:
-                tensor_to_allreduce.mul_(1. / self.gradient_predivide_factor)
+                tensor_to_allreduce.mul_(1.0 / self.gradient_predivide_factor)
 
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
 
             if self.gradient_predivide_factor != dp_world_size:
-                tensor_to_allreduce.mul_(self.gradient_predivide_factor /
-                                         (dp_world_size / float(self.sequence_parallel_size)))
+                tensor_to_allreduce.mul_(
+                    self.gradient_predivide_factor
+                    / (dp_world_size / float(self.sequence_parallel_size))
+                )
         else:
             tensor_to_allreduce.div_(dp_world_size / float(self.sequence_parallel_size))
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
 
-        if self.communication_data_type != tensor.dtype and tensor is not tensor_to_allreduce:
+        if (
+            self.communication_data_type != tensor.dtype
+            and tensor is not tensor_to_allreduce
+        ):
             tensor.copy_(tensor_to_allreduce)
 
         return tensor
 
-    def allreduce_and_copy_with_multiple_ranks(self,
-                                               small_bucket,
-                                               log=None,
-                                               divide=True,
-                                               process_group=None,
-                                               bucket_ranks=None):
-        process_group = self.dp_process_group if process_group is None else process_group
-        allreduced = self.allreduce_bucket(small_bucket, log=log, divide=divide, process_group=process_group)
-        for buf, synced, bucket_rank in zip(small_bucket, self.unflatten(allreduced, small_bucket), bucket_ranks):
+    def allreduce_and_copy_with_multiple_ranks(
+        self, small_bucket, log=None, divide=True, process_group=None, bucket_ranks=None
+    ):
+        process_group = (
+            self.dp_process_group if process_group is None else process_group
+        )
+        allreduced = self.allreduce_bucket(
+            small_bucket, log=log, divide=divide, process_group=process_group
+        )
+        for buf, synced, bucket_rank in zip(
+            small_bucket, self.unflatten(allreduced, small_bucket), bucket_ranks
+        ):
             if dist.get_rank(group=process_group) == bucket_rank:
                 buf.copy_(synced)
 
-    def allreduce_and_scatter(self, bucket, numel_per_bucket=500000000, log=None, divide=True, process_group=None):
+    def allreduce_and_scatter(
+        self,
+        bucket,
+        numel_per_bucket=500000000,
+        log=None,
+        divide=True,
+        process_group=None,
+    ):
         small_bucket = []
         small_bucket_ranks = []
         numel = 0
@@ -1053,21 +1247,25 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             small_bucket_ranks.append(rank)
             numel = numel + tensor.numel()
             if numel > numel_per_bucket:
-                self.allreduce_and_copy_with_multiple_ranks(small_bucket,
-                                                            log=None,
-                                                            divide=divide,
-                                                            process_group=process_group,
-                                                            bucket_ranks=small_bucket_ranks)
+                self.allreduce_and_copy_with_multiple_ranks(
+                    small_bucket,
+                    log=None,
+                    divide=divide,
+                    process_group=process_group,
+                    bucket_ranks=small_bucket_ranks,
+                )
                 small_bucket = []
                 small_bucket_ranks = []
                 numel = 0
 
         if len(small_bucket) > 0:
-            self.allreduce_and_copy_with_multiple_ranks(small_bucket,
-                                                        log=None,
-                                                        divide=divide,
-                                                        process_group=process_group,
-                                                        bucket_ranks=small_bucket_ranks)
+            self.allreduce_and_copy_with_multiple_ranks(
+                small_bucket,
+                log=None,
+                divide=divide,
+                process_group=process_group,
+                bucket_ranks=small_bucket_ranks,
+            )
 
     def average_tensor(self, tensor):
         if self.overlap_comm:
@@ -1100,12 +1298,19 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 process_group = self.dp_process_group
 
                 if self.ipg_bucket_has_moe_params:
-                    process_group = self.expert_dp_process_group[param.group_name] if is_moe_param(
-                        param) else self.dp_process_group
+                    process_group = (
+                        self.expert_dp_process_group[param.group_name]
+                        if is_moe_param(param)
+                        else self.dp_process_group
+                    )
 
                 partition_ids = self.param_to_partition_ids[i][param_id]
-                assert all([p_id < dist.get_world_size(group=process_group) for p_id in partition_ids
-                            ]), f"world size {dist.get_world_size(group=process_group)} and p_ids: {partition_ids}"
+                assert all(
+                    [
+                        p_id < dist.get_world_size(group=process_group)
+                        for p_id in partition_ids
+                    ]
+                ), f"world size {dist.get_world_size(group=process_group)} and p_ids: {partition_ids}"
                 partition_size = self.partition_size[i]
                 # Get all partition ids + their offsets
                 partition_ids_w_offsets = []
@@ -1140,13 +1345,19 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     curr_size += numel
                     prev_id, prev_process_group = partition_id, process_group
 
-            tensor.div_(dist.get_world_size(group=self.dp_process_group) / float(self.sequence_parallel_size))
+            tensor.div_(
+                dist.get_world_size(group=self.dp_process_group)
+                / float(self.sequence_parallel_size)
+            )
 
             buckets = {}
             for i, (dst, bucket_offset, numel) in enumerate(rank_and_offsets):
                 grad_slice = tensor.narrow(0, int(bucket_offset), int(numel))
-                bucket_key = real_dp_process_group[i] if self.use_multi_rank_bucket_allreduce else (
-                    dst, real_dp_process_group[i])
+                bucket_key = (
+                    real_dp_process_group[i]
+                    if self.use_multi_rank_bucket_allreduce
+                    else (dst, real_dp_process_group[i])
+                )
                 if bucket_key not in buckets:
                     buckets[bucket_key] = []
                 if self.use_multi_rank_bucket_allreduce:
@@ -1156,17 +1367,21 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             for bucket_key in buckets:
                 if self.use_multi_rank_bucket_allreduce:
-                    self.allreduce_and_scatter(buckets[bucket_key],
-                                               numel_per_bucket=self.reduce_bucket_size,
-                                               divide=False,
-                                               process_group=bucket_key)
+                    self.allreduce_and_scatter(
+                        buckets[bucket_key],
+                        numel_per_bucket=self.reduce_bucket_size,
+                        divide=False,
+                        process_group=bucket_key,
+                    )
                 else:
                     dst, process_group = bucket_key
-                    self.allreduce_no_retain(buckets[bucket_key],
-                                             numel_per_bucket=self.reduce_bucket_size,
-                                             rank=dst,
-                                             divide=False,
-                                             process_group=process_group)
+                    self.allreduce_no_retain(
+                        buckets[bucket_key],
+                        numel_per_bucket=self.reduce_bucket_size,
+                        rank=dst,
+                        divide=False,
+                        process_group=process_group,
+                    )
 
     ##############################################################################
     ############################# CPU Offload Methods#############################
@@ -1191,8 +1406,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 num_elements = partition_size - current_offset
 
             self.grad_position[param_id] = [
-                int(group_id), int(param_start_offset),
-                int(current_offset), int(num_elements)
+                int(group_id),
+                int(param_start_offset),
+                int(current_offset),
+                int(num_elements),
             ]
             current_offset += num_elements
 
@@ -1207,8 +1424,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for lp_param in self.params_in_partition[param_group_index]:
                 param_id = self.get_param_id(lp_param)
                 [_, _, dest_offset, num_elements] = self.grad_position[param_id]
-                dest_tensor = self.single_partition_of_fp32_groups[param_group_index].grad.view(-1).narrow(
-                    0, dest_offset, num_elements)
+                dest_tensor = (
+                    self.single_partition_of_fp32_groups[param_group_index]
+                    .grad.view(-1)
+                    .narrow(0, dest_offset, num_elements)
+                )
                 self.offload_gradient_dict[param_group_index].append(dest_tensor)
 
     def async_accumulate_grad_in_cpu_via_gpu(self, param):
@@ -1217,38 +1437,56 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 
         # copy to a preexisiting buffer to avoid memory allocation penalty
-        dest_buffer = self.temp_grad_buffer_for_gpu_offload.view(-1).narrow(0, 0, param.numel())
+        dest_buffer = self.temp_grad_buffer_for_gpu_offload.view(-1).narrow(
+            0, 0, param.numel()
+        )
 
-        #buffer for storing gradients for this parameter in CPU
+        # buffer for storing gradients for this parameter in CPU
         def buffer_to_accumulate_to_in_cpu():
             if not self.fp16_master_weights_and_gradients:
-                buffer = torch.zeros(param.numel(), dtype=param.dtype, device=self.device)
-                return get_accelerator().pin_memory(buffer) if self.cpu_offload_pin_memory else buffer
+                buffer = torch.zeros(
+                    param.numel(), dtype=param.dtype, device=self.device
+                )
+                return (
+                    get_accelerator().pin_memory(buffer)
+                    if self.cpu_offload_pin_memory
+                    else buffer
+                )
             else:
-                return self.single_partition_of_fp32_groups[i].grad.view(-1).narrow(0, dest_offset, num_elements)
+                return (
+                    self.single_partition_of_fp32_groups[i]
+                    .grad.view(-1)
+                    .narrow(0, dest_offset, num_elements)
+                )
 
-        #accumulate gradients into param.grad_accum or parts of it that belongs to this partition
+        # accumulate gradients into param.grad_accum or parts of it that belongs to this partition
         def accumulate_gradients():
             grad_accum = self.get_param_gradient_attribute(param)
             if not self.fp16_master_weights_and_gradients:
-                dest_buffer.copy_(self.accumulated_grads_in_cpu[param_id].view(-1), non_blocking=True)
+                dest_buffer.copy_(
+                    self.accumulated_grads_in_cpu[param_id].view(-1), non_blocking=True
+                )
                 grad_accum.data.view(-1).add_(dest_buffer)
             else:
-                dest_buffer.narrow(0, source_offset,
-                                   num_elements).copy_(self.accumulated_grads_in_cpu[param_id].view(-1),
-                                                       non_blocking=True)
-                grad_accum.data.view(-1).narrow(0, source_offset,
-                                                num_elements).add_(dest_buffer.narrow(0, source_offset, num_elements))
+                dest_buffer.narrow(0, source_offset, num_elements).copy_(
+                    self.accumulated_grads_in_cpu[param_id].view(-1), non_blocking=True
+                )
+                grad_accum.data.view(-1).narrow(0, source_offset, num_elements).add_(
+                    dest_buffer.narrow(0, source_offset, num_elements)
+                )
 
-        #move accumulated gradients back to CPU
+        # move accumulated gradients back to CPU
         def copy_gradients_to_cpu():
             grad_accum = self.get_param_gradient_attribute(param)
             if not self.fp16_master_weights_and_gradients:
-                self.accumulated_grads_in_cpu[param_id].data.copy_(grad_accum.data.view(-1), non_blocking=True)
+                self.accumulated_grads_in_cpu[param_id].data.copy_(
+                    grad_accum.data.view(-1), non_blocking=True
+                )
             else:
-                self.accumulated_grads_in_cpu[param_id].data.copy_(grad_accum.data.view(-1).narrow(
-                    0, source_offset, num_elements),
-                                                                   non_blocking=True)
+                self.accumulated_grads_in_cpu[param_id].data.copy_(
+                    grad_accum.data.view(-1).narrow(0, source_offset, num_elements),
+                    non_blocking=True,
+                )
 
         if param_id not in self.accumulated_grads_in_cpu:
             self.accumulated_grads_in_cpu[param_id] = buffer_to_accumulate_to_in_cpu()
@@ -1261,8 +1499,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def set_norm_for_param_grad(self, param):
         param_id = self.get_param_id(param)
         grad_accum = self.get_param_gradient_attribute(param)
-        accumulated_grad = self.accumulated_grads_in_cpu[
-            param_id] if self.gradient_accumulation_steps > 1 else grad_accum
+        accumulated_grad = (
+            self.accumulated_grads_in_cpu[param_id]
+            if self.gradient_accumulation_steps > 1
+            else grad_accum
+        )
 
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 
@@ -1291,7 +1532,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 
-        dest_tensor = self.single_partition_of_fp32_groups[i].grad.view(-1).narrow(0, dest_offset, num_elements)
+        dest_tensor = (
+            self.single_partition_of_fp32_groups[i]
+            .grad.view(-1)
+            .narrow(0, dest_offset, num_elements)
+        )
 
         grad_accum = self.get_param_gradient_attribute(param)
         if grad_accum is None:
@@ -1302,7 +1547,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             src_tensor = src_tensor.float()
 
         dest_tensor.copy_(src_tensor, non_blocking=True)
-        param.grad = None  #offload only
+        param.grad = None  # offload only
 
     def complete_grad_norm_calculation_for_cpu_offload(self, params):
         total_norm = 0.0
@@ -1319,7 +1564,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 # so they have no norm_for_param_grads
                 if param_id in self.norm_for_param_grads:
                     param_norm = self.norm_for_param_grads[param_id]
-                    total_norm += param_norm.item()**2
+                    total_norm += param_norm.item() ** 2
                 else:
                     # As unused parameters in modules may not be expected sometimes,
                     # add an explicit error msg when it occurred and an option to
@@ -1335,13 +1580,19 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         # Sum across all model parallel GPUs.
         total_norm_cuda = get_accelerator().FloatTensor([float(total_norm)])
-        dist.all_reduce(total_norm_cuda, op=dist.ReduceOp.SUM, group=self.dp_process_group)
+        dist.all_reduce(
+            total_norm_cuda, op=dist.ReduceOp.SUM, group=self.dp_process_group
+        )
 
         self._model_parallel_all_reduce(tensor=total_norm_cuda, op=dist.ReduceOp.SUM)
 
-        total_norm = total_norm_cuda[0].item()**(1. / norm_type)
+        total_norm = total_norm_cuda[0].item() ** (1.0 / norm_type)
 
-        if total_norm == float('inf') or total_norm == -float('inf') or total_norm != total_norm:
+        if (
+            total_norm == float("inf")
+            or total_norm == -float("inf")
+            or total_norm != total_norm
+        ):
             total_norm = -1
 
         return total_norm
@@ -1361,7 +1612,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.async_inplace_copy_grad_to_fp32_buffer_from_gpu(param)
 
             return
-        #print(f"ID {self.get_param_id(param)} grad norm {param.grad.norm()}")
+        # print(f"ID {self.get_param_id(param)} grad norm {param.grad.norm()}")
         if self.grads_in_partition is None:
             self.grads_in_partition_offset = 0
             total_size = 0
@@ -1370,35 +1621,50 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     total_size += param_in_partition.numel()
 
             see_memory_usage(f"before copying {total_size} gradients into partition")
-            self.grads_in_partition = torch.empty(int(total_size),
-                                                  dtype=self.dtype,
-                                                  device=get_accelerator().current_device_name())
+            self.grads_in_partition = torch.empty(
+                int(total_size),
+                dtype=self.dtype,
+                device=get_accelerator().current_device_name(),
+            )
             see_memory_usage(f"after copying {total_size} gradients into partition")
 
         grad_reduc = self.get_gradient_for_reduction(param)
         # The allreduce buffer will be rewritten. Copy the gradients in partition to a new buffer
-        new_grad_tensor = self.grads_in_partition.view(-1).narrow(0, self.grads_in_partition_offset, param.numel())
+        new_grad_tensor = self.grads_in_partition.view(-1).narrow(
+            0, self.grads_in_partition_offset, param.numel()
+        )
         new_grad_tensor.copy_(grad_reduc.view(-1))
         grad_reduc.data = new_grad_tensor.data.view_as(grad_reduc)
-        #print(f"Grad norm after copy to contiguous_buffer {param.grad.data.norm()}")
+        # print(f"Grad norm after copy to contiguous_buffer {param.grad.data.norm()}")
         self.grads_in_partition_offset += param.numel()
 
     def reduce_ipg_grads(self):
         if self.contiguous_gradients:
             if self.extra_large_param_to_reduce is not None:
-                assert len(self.params_in_ipg_bucket) == 1, "more than 1 param in ipg bucket, this shouldn't happen"
+                assert (
+                    len(self.params_in_ipg_bucket) == 1
+                ), "more than 1 param in ipg bucket, this shouldn't happen"
                 _, _, param_id = self.params_in_ipg_bucket[0]
-                assert self.get_param_id(self.extra_large_param_to_reduce
-                                         ) == param_id, "param in ipg bucket does not match extra-large param"
-                extra_large_grad_reduc = self.get_gradient_for_reduction(self.extra_large_param_to_reduce)
+                assert (
+                    self.get_param_id(self.extra_large_param_to_reduce) == param_id
+                ), "param in ipg bucket does not match extra-large param"
+                extra_large_grad_reduc = self.get_gradient_for_reduction(
+                    self.extra_large_param_to_reduce
+                )
                 self.average_tensor(extra_large_grad_reduc.view(-1))
                 self.extra_large_param_to_reduce = None
             else:
-                self.average_tensor(self.ipg_buffer[self.ipg_index].narrow(0, 0, self.elements_in_ipg_bucket))
+                self.average_tensor(
+                    self.ipg_buffer[self.ipg_index].narrow(
+                        0, 0, self.elements_in_ipg_bucket
+                    )
+                )
         else:
-            self.buffered_reduce_fallback(None,
-                                          self.grads_in_ipg_bucket,
-                                          elements_per_buffer=self.elements_in_ipg_bucket)
+            self.buffered_reduce_fallback(
+                None,
+                self.grads_in_ipg_bucket,
+                elements_per_buffer=self.elements_in_ipg_bucket,
+            )
 
         if self.overlap_comm:
             stream = self.reduction_stream
@@ -1414,8 +1680,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for group_idx, param_idx_in_group, param_id in self.params_in_ipg_bucket:
                 param = self.bit16_groups[group_idx][param_idx_in_group]
 
-                assert self.params_already_reduced[param_id] == False, \
-                    f"The parameter {param_id} has already been reduced. \
+                assert (
+                    self.params_already_reduced[param_id] == False
+                ), f"The parameter {param_id} has already been reduced. \
                     Gradient computed twice for this partition. \
                     Multiple gradient reduction is currently not supported"
 
@@ -1433,7 +1700,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     elif self.contiguous_gradients:
                         self.copy_grads_in_partition(param)
                 else:  # zero stage 1 - partition only optimizer state
-                    if self.contiguous_gradients and self.is_param_in_current_partition[param_id]:
+                    if (
+                        self.contiguous_gradients
+                        and self.is_param_in_current_partition[param_id]
+                    ):
                         self.copy_grads_in_partition(param)
 
         self.grads_in_ipg_bucket = []
@@ -1479,18 +1749,30 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             grad = self.param_dict[key].grad
             total_elements = grad.numel()
             start = self.grad_start_offset[i][partition_id][key]
-            num_elements = min(total_elements - start,
-                               self.partition_size[i] - self.grad_partition_insertion_offset[i][partition_id][key])
+            num_elements = min(
+                total_elements - start,
+                self.partition_size[i]
+                - self.grad_partition_insertion_offset[i][partition_id][key],
+            )
             if not pg_correctness_test:
                 if num_elements == total_elements:
                     return grad
                 else:
-                    return grad.contiguous().view(-1).narrow(0, int(start), int(num_elements))
+                    return (
+                        grad.contiguous()
+                        .view(-1)
+                        .narrow(0, int(start), int(num_elements))
+                    )
             else:
                 if num_elements == total_elements:
                     return grad.clone()
                 else:
-                    return grad.clone().contiguous().view(-1).narrow(0, int(start), int(num_elements))
+                    return (
+                        grad.clone()
+                        .contiguous()
+                        .view(-1)
+                        .narrow(0, int(start), int(num_elements))
+                    )
 
         grads_to_reduce = []
         for key in self.is_grad_computed[i][partition_id]:
@@ -1515,10 +1797,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 param.grad = torch.zeros_like(param)
 
     ######################Reduction Related Methods##############################
-    def allreduce_bucket(self, bucket, rank=None, log=None, divide=True, process_group=None):
+    def allreduce_bucket(
+        self, bucket, rank=None, log=None, divide=True, process_group=None
+    ):
         tensor = self.flatten(bucket)
 
-        process_group = self.dp_process_group if process_group is None else process_group
+        process_group = (
+            self.dp_process_group if process_group is None else process_group
+        )
 
         tensor_to_allreduce = tensor
 
@@ -1531,7 +1817,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             tensor_to_allreduce = tensor.to(communication_data_type)
 
         if divide:
-            tensor_to_allreduce.div_(dist.get_world_size(group=process_group) / float(self.sequence_parallel_size))
+            tensor_to_allreduce.div_(
+                dist.get_world_size(group=process_group)
+                / float(self.sequence_parallel_size)
+            )
 
         if rank is None:
             #    "All Reducing"
@@ -1540,7 +1829,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             global_rank = dist.get_global_rank(process_group, rank)
             dist.reduce(tensor_to_allreduce, global_rank, group=process_group)
 
-        if communication_data_type != tensor.dtype and tensor is not tensor_to_allreduce:
+        if (
+            communication_data_type != tensor.dtype
+            and tensor is not tensor_to_allreduce
+        ):
             if rank is None or rank == dist.get_rank(group=process_group):
                 tensor.copy_(tensor_to_allreduce)
 
@@ -1553,8 +1845,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.previous_reduced_grads = None
 
     # if rank is specified do a reduction instead of an allreduce
-    def allreduce_and_copy(self, small_bucket, rank=None, log=None, divide=True, process_group=None):
-        process_group = self.dp_process_group if process_group is None else process_group
+    def allreduce_and_copy(
+        self, small_bucket, rank=None, log=None, divide=True, process_group=None
+    ):
+        process_group = (
+            self.dp_process_group if process_group is None else process_group
+        )
         if self.overlap_comm:
             if not get_accelerator().resolves_data_dependency():
                 get_accelerator().synchronize()
@@ -1573,7 +1869,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 process_group=process_group,
             )
             if rank is None or rank == dist.get_rank(group=self.dp_process_group):
-                for buf, synced in zip(small_bucket, self.unflatten(allreduced, small_bucket)):
+                for buf, synced in zip(
+                    small_bucket, self.unflatten(allreduced, small_bucket)
+                ):
                     buf.copy_(synced)
 
     def allreduce_no_retain(
@@ -1591,20 +1889,36 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             small_bucket.append(tensor)
             numel = numel + tensor.numel()
             if numel > numel_per_bucket:
-                self.allreduce_and_copy(small_bucket, rank=rank, log=None, divide=divide, process_group=process_group)
+                self.allreduce_and_copy(
+                    small_bucket,
+                    rank=rank,
+                    log=None,
+                    divide=divide,
+                    process_group=process_group,
+                )
                 small_bucket = []
                 numel = 0
 
         if len(small_bucket) > 0:
-            self.allreduce_and_copy(small_bucket, rank=rank, log=log, divide=divide, process_group=process_group)
+            self.allreduce_and_copy(
+                small_bucket,
+                rank=rank,
+                log=log,
+                divide=divide,
+                process_group=process_group,
+            )
 
     # allows using reduction of gradients instead of using all_reduce
 
-    def buffered_reduce_fallback(self, rank, grads, elements_per_buffer=500000000, log=None):
+    def buffered_reduce_fallback(
+        self, rank, grads, elements_per_buffer=500000000, log=None
+    ):
         split_buckets = split_half_float_double(grads)
 
         for i, bucket in enumerate(split_buckets):
-            self.allreduce_no_retain(bucket, numel_per_bucket=elements_per_buffer, rank=rank, log=log)
+            self.allreduce_no_retain(
+                bucket, numel_per_bucket=elements_per_buffer, rank=rank, log=log
+            )
 
     #############################################################################
     #############################################################################
@@ -1652,8 +1966,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             elif current_index < start_index < (current_index + tensor_size):
                 params_in_partition.append(tensor)
 
-                assert (first_offset == 0
-                        ), "This can happen either zero or only once as this must be the first tensor in the partition"
+                assert (
+                    first_offset == 0
+                ), "This can happen either zero or only once as this must be the first tensor in the partition"
                 first_offset = start_index - current_index
 
             else:
@@ -1681,8 +1996,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         p.grad.zero_()
 
     def _model_parallel_all_reduce(self, tensor, op):
-        """ Perform all reduce within model parallel group, if any.
-        """
+        """Perform all reduce within model parallel group, if any."""
         if self.model_parallel_group is None or self.model_parallel_world_size == 1:
             pass
         else:
@@ -1711,7 +2025,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for g in gradients:
                 all_norms.append(g.data.abs().max().float())
             total_norm = torch.stack(all_norms).max()
-            dist.all_reduce(total_norm, op=dist.ReduceOp.MAX, group=self.dp_process_group)
+            dist.all_reduce(
+                total_norm, op=dist.ReduceOp.MAX, group=self.dp_process_group
+            )
 
             # Take max across all GPUs.
             self._model_parallel_all_reduce(tensor=total_norm, op=dist.ReduceOp.MAX)
@@ -1724,18 +2040,22 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     continue
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
                     all_norms.append(
-                        torch.linalg.vector_norm(g.data.double().detach(),
-                                                 ord=norm_type).to(get_accelerator().current_device_name()))
+                        torch.linalg.vector_norm(
+                            g.data.double().detach(), ord=norm_type
+                        ).to(get_accelerator().current_device_name())
+                    )
             if len(all_norms) > 0:
                 total_norm = torch.stack(all_norms).square().sum().float()
             else:
                 total_norm = torch.tensor(0.0, dtype=torch.float32).to(self.device)
             # Sum across all model parallel Device.
-            dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=self.dp_process_group)
+            dist.all_reduce(
+                total_norm, op=dist.ReduceOp.SUM, group=self.dp_process_group
+            )
 
             self._model_parallel_all_reduce(tensor=total_norm, op=dist.ReduceOp.SUM)
 
-            total_norm = total_norm.pow(1. / norm_type)
+            total_norm = total_norm.pow(1.0 / norm_type)
 
         mask_nan_or_inf_with_val_inplace(total_norm, device=self.device)
 
@@ -1744,7 +2064,15 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     # creates a flat fused tensor from the tensor list starting at the first_offset
     # in the first tensor of the list. If there are not enough elements in the tensor
     # list then the flat tensor will be padded with zeros
-    def get_flat_partition(self, tensor_list, first_offset, partition_size, dtype, device, return_tensor_list=False):
+    def get_flat_partition(
+        self,
+        tensor_list,
+        first_offset,
+        partition_size,
+        dtype,
+        device,
+        return_tensor_list=False,
+    ):
         flat_tensor_list = []
         current_size = 0
 
@@ -1769,7 +2097,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # we need a narrow view of the tensor based on the tensor offset and number of elements that
             # we need from this tensor
             if tensor_offset > 0 or num_elements < tensor.numel():
-                flat_tensor_list.append(tensor.contiguous().view(-1).narrow(0, int(tensor_offset), int(num_elements)))
+                flat_tensor_list.append(
+                    tensor.contiguous()
+                    .view(-1)
+                    .narrow(0, int(tensor_offset), int(num_elements))
+                )
             else:
                 flat_tensor_list.append(tensor)
 
@@ -1777,7 +2109,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         # this means its the last partition and does not align with the dp boundary. We need to pad before flattening
         if current_size < partition_size:
-            flat_tensor_list.append(torch.zeros(int(partition_size - current_size), dtype=dtype, device=device))
+            flat_tensor_list.append(
+                torch.zeros(
+                    int(partition_size - current_size), dtype=dtype, device=device
+                )
+            )
 
         if return_tensor_list:
             return flat_tensor_list
@@ -1804,7 +2140,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def override_loss_scale(self, loss_scale):
         if loss_scale != self.external_loss_scale:
-            logger.info(f'[deepspeed] setting loss scale from {self.external_loss_scale} -> {loss_scale}')
+            logger.info(
+                f"[deepspeed] setting loss scale from {self.external_loss_scale} -> {loss_scale}"
+            )
         self.custom_loss_scaler = True
         self.external_loss_scale = loss_scale
 
@@ -1815,11 +2153,19 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if self.cpu_offload:
                 # complete complete_grad_norm_calculation_for_cpu_offload return python float, moving back to
                 # torch.tensor as else statement returns tensor as well
-                norm = torch.tensor(self.complete_grad_norm_calculation_for_cpu_offload(self.params_in_partition[i]),
-                                    device=self.device)
+                norm = torch.tensor(
+                    self.complete_grad_norm_calculation_for_cpu_offload(
+                        self.params_in_partition[i]
+                    ),
+                    device=self.device,
+                )
                 norm_groups.append(norm)
             else:
-                norm_groups.append(self.get_grad_norm_direct(self.averaged_gradients[i], self.params_in_partition[i]))
+                norm_groups.append(
+                    self.get_grad_norm_direct(
+                        self.averaged_gradients[i], self.params_in_partition[i]
+                    )
+                )
 
         if self.has_moe_layers:
             self._average_expert_grad_norms(norm_groups)
@@ -1830,16 +2176,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def get_bit16_param_group(self, group_no):
         bit16_partitions = self.parallel_partitioned_bit16_groups[group_no]
         partition_id = dist.get_rank(group=self.real_dp_process_group[group_no])
-        return [bit16_partitions[dist.get_rank(group=self.real_dp_process_group[group_no])]]
+        return [
+            bit16_partitions[dist.get_rank(group=self.real_dp_process_group[group_no])]
+        ]
 
     def _optimizer_step(self, group_no):
         original_param_groups = self.optimizer.param_groups
         self.optimizer.param_groups = [original_param_groups[group_no]]
         # Disabling this as the C++ side copy & synchronize is not working correctly
-        #from deepspeed.ops.adam import DeepSpeedCPUAdam
-        #if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
+        # from deepspeed.ops.adam import DeepSpeedCPUAdam
+        # if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
         #    self.optimizer.step(fp16_param_groups=[self.get_bit16_param_group(group_no)])
-        #else:
+        # else:
         #    self.optimizer.step()
         self.optimizer.step()
         self.optimizer.param_groups = original_param_groups
@@ -1862,14 +2210,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         prev_scale = self.loss_scale
         self._update_scale(self.overflow)
         if self.overflow:
-            see_memory_usage('After overflow before clearing gradients')
+            see_memory_usage("After overflow before clearing gradients")
             self.zero_grad(set_to_none=True)
             if self.cpu_offload:
                 self.reset_cpu_buffers()
             else:
                 self.averaged_gradients = {}
 
-            see_memory_usage('After overflow after clearing gradients')
+            see_memory_usage("After overflow after clearing gradients")
 
             for timer in OPTIMIZER_TIMERS:
                 self.timers(timer).start()
@@ -1877,10 +2225,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             return
 
         # Step 1:- Calculate gradient norm using bit-16 grads
-        see_memory_usage('Before norm calculation')
+        see_memory_usage("Before norm calculation")
         scaled_global_grad_norm = self.scaled_global_norm()
         self._global_grad_norm = scaled_global_grad_norm / prev_scale
-        see_memory_usage('After norm before optimizer')
+        see_memory_usage("After norm before optimizer")
 
         # Step 2:- run optimizer and upscaling simultaneously
         for i, group in enumerate(self.bit16_groups):
@@ -1888,23 +2236,29 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             if self.cpu_offload:
                 single_grad_partition = self.single_partition_of_fp32_groups[i].grad
-                self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
+                self.unscale_and_clip_grads(
+                    [single_grad_partition], scaled_global_grad_norm
+                )
 
                 self.timers(OPTIMIZER_GRADIENTS_TIMER).stop()
                 self.timers(OPTIMIZER_STEP_TIMER).start()
                 self._optimizer_step(i)
 
                 # Disabled, this is not currently working
-                #from deepspeed.ops.adam import DeepSpeedCPUAdam
-                #if not (type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half):
+                # from deepspeed.ops.adam import DeepSpeedCPUAdam
+                # if not (type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half):
                 #    bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 #    fp32_partition = self.single_partition_of_fp32_groups[i]
                 #    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
-                bit16_partition_buffer = self.param_buffer_of_bit16_for_cpu_offload_groups[i]
+                bit16_partition_buffer = (
+                    self.param_buffer_of_bit16_for_cpu_offload_groups[i]
+                )
                 bit16_partition_buffer.data.copy_(fp32_partition.data)
-                bit16_partitions[partition_id].data.copy_(bit16_partition_buffer.data, non_blocking=True)
+                bit16_partitions[partition_id].data.copy_(
+                    bit16_partition_buffer.data, non_blocking=True
+                )
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:
@@ -1913,16 +2267,25 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
                 # create a flat gradients for parameters updated by this process
                 # If we are last partition, ensure we have same size grads and partition size, if not pad with zero tensors
-                if partition_id == dist.get_world_size(group=self.real_dp_process_group[i]) - 1:
+                if (
+                    partition_id
+                    == dist.get_world_size(group=self.real_dp_process_group[i]) - 1
+                ):
                     single_grad_partition = self.flatten_dense_tensors_aligned(
-                        self.averaged_gradients[i],
-                        int(self.partition_size[i])).to(self.single_partition_of_fp32_groups[i].dtype)
+                        self.averaged_gradients[i], int(self.partition_size[i])
+                    ).to(self.single_partition_of_fp32_groups[i].dtype)
                 else:
                     single_grad_partition = self.flatten(self.averaged_gradients[i]).to(
-                        self.single_partition_of_fp32_groups[i].dtype)
-                assert single_grad_partition.numel() == self.partition_size[i], \
-                    "averaged gradients have different number of elements that partition size {} {} {} {}".format(
-                        single_grad_partition.numel(), self.partition_size[i], i, partition_id)
+                        self.single_partition_of_fp32_groups[i].dtype
+                    )
+                assert (
+                    single_grad_partition.numel() == self.partition_size[i]
+                ), "averaged gradients have different number of elements that partition size {} {} {} {}".format(
+                    single_grad_partition.numel(),
+                    self.partition_size[i],
+                    i,
+                    partition_id,
+                )
 
                 self.single_partition_of_fp32_groups[i].grad = single_grad_partition
                 # release all the gradient since we have already created a necessary copy in dp_grad_partition(ZeRO stage2)
@@ -1930,7 +2293,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
                 self.averaged_gradients[i] = None
 
-                self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
+                self.unscale_and_clip_grads(
+                    [single_grad_partition], scaled_global_grad_norm
+                )
 
                 self.timers(OPTIMIZER_GRADIENTS_TIMER).stop()
 
@@ -1945,18 +2310,20 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
 
-        see_memory_usage('After optimizer before all-gather')
+        see_memory_usage("After optimizer before all-gather")
         if self.cpu_offload:
             self.reset_cpu_buffers()
 
         self.timers(OPTIMIZER_ALLGATHER_TIMER).start()
         # Gather the updated weights from everyone.
         # Then all partitions of the model parameters are updated and ready for next round forward.
-        all_gather_dp_groups(groups_flat=self.bit16_groups_flat,
-                             partitioned_param_groups=self.parallel_partitioned_bit16_groups,
-                             dp_process_group=self.real_dp_process_group,
-                             start_alignment_factor=self.nccl_start_alignment_factor,
-                             allgather_bucket_size=self.allgather_bucket_size)
+        all_gather_dp_groups(
+            groups_flat=self.bit16_groups_flat,
+            partitioned_param_groups=self.parallel_partitioned_bit16_groups,
+            dp_process_group=self.real_dp_process_group,
+            start_alignment_factor=self.nccl_start_alignment_factor,
+            allgather_bucket_size=self.allgather_bucket_size,
+        )
         self.timers(OPTIMIZER_ALLGATHER_TIMER).stop()
 
         # TODO: we probably don't need this? just to be safe
@@ -1964,36 +2331,48 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self._update_model_bit16_weights(i)
 
         self.timers.log(OPTIMIZER_TIMERS)
-        see_memory_usage('After zero_optimizer step')
+        see_memory_usage("After zero_optimizer step")
 
         return
 
     @torch.no_grad()
     def update_lp_params(self):
         for i, (bit16_partitions, fp32_partition) in enumerate(
-                zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups)):
+            zip(
+                self.parallel_partitioned_bit16_groups,
+                self.single_partition_of_fp32_groups,
+            )
+        ):
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             bit16_partitions[partition_id].data.copy_(fp32_partition.data)
 
-        all_gather_dp_groups(groups_flat=self.bit16_groups_flat,
-                             partitioned_param_groups=self.parallel_partitioned_bit16_groups,
-                             dp_process_group=self.real_dp_process_group,
-                             start_alignment_factor=self.nccl_start_alignment_factor,
-                             allgather_bucket_size=self.allgather_bucket_size)
+        all_gather_dp_groups(
+            groups_flat=self.bit16_groups_flat,
+            partitioned_param_groups=self.parallel_partitioned_bit16_groups,
+            dp_process_group=self.real_dp_process_group,
+            start_alignment_factor=self.nccl_start_alignment_factor,
+            allgather_bucket_size=self.allgather_bucket_size,
+        )
 
     def _average_expert_grad_norms(self, norm_groups):
         for i, norm in enumerate(norm_groups):
             if self.is_moe_param_group[i]:
-                scaled_norm_tensor = norm * 1.0 / dist.get_world_size(group=self.real_dp_process_group[i])
-                if self.device == 'cpu':
-                    scaled_norm_tensor = scaled_norm_tensor.to(get_accelerator().current_device_name())
+                scaled_norm_tensor = (
+                    norm
+                    * 1.0
+                    / dist.get_world_size(group=self.real_dp_process_group[i])
+                )
+                if self.device == "cpu":
+                    scaled_norm_tensor = scaled_norm_tensor.to(
+                        get_accelerator().current_device_name()
+                    )
                 dist.all_reduce(scaled_norm_tensor, group=self.real_dp_process_group[i])
                 norm_groups[i] = scaled_norm_tensor.to(self.device)
 
     def unscale_and_clip_grads(self, grad_groups_flat, total_norm):
         # compute combined scale factor for this group
         combined_scale = self.loss_scale
-        if self.clip_grad > 0.:
+        if self.clip_grad > 0.0:
             # norm is in fact norm*scale
             clip = ((total_norm / self.loss_scale) + 1e-6) / self.clip_grad
             clip = torch.clamp(clip, min=1.0)
@@ -2003,23 +2382,27 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if isinstance(grad, list):
                 sub_partitions = grad
                 for g in sub_partitions:
-                    g.data.mul_(1. / combined_scale)
+                    g.data.mul_(1.0 / combined_scale)
             else:
-                grad.data.mul_(1. / combined_scale)
+                grad.data.mul_(1.0 / combined_scale)
 
     def _check_overflow(self, partition_gradients=True):
         self.overflow = self.has_overflow(partition_gradients)
 
     # `params` is a list / generator of torch.Variable
     def has_overflow_serial(self, params):
-        invalid_grad_count = torch.zeros([1], dtype=torch.float, device=get_accelerator().current_device_name())
+        invalid_grad_count = torch.zeros(
+            [1], dtype=torch.float, device=get_accelerator().current_device_name()
+        )
         for p in params:
             if p.grad is not None:
                 invalid_grad_count += self._has_inf_or_nan(p.grad)
         return invalid_grad_count.bool()
 
     def has_overflow_partitioned_grads_serial(self):
-        invalid_grad_count = torch.zeros([1], dtype=torch.float, device=get_accelerator().current_device_name())
+        invalid_grad_count = torch.zeros(
+            [1], dtype=torch.float, device=get_accelerator().current_device_name()
+        )
         for i in range(len(self.bit16_groups)):
             for j, grad in enumerate(self.averaged_gradients[i]):
                 if grad is not None:
@@ -2028,19 +2411,32 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def has_overflow(self, partition_gradients=True):
         if partition_gradients:
-            overflow = self.local_overflow if self.cpu_offload else self.has_overflow_partitioned_grads_serial()
-            overflow_gpu = get_accelerator().ByteTensor([overflow]) if self.cpu_offload else overflow.byte().to(
-                get_accelerator().current_device_name())
-            '''This will capture overflow across all data parallel and expert parallel process
-            Since expert parallel process are a subset of data parallel process'''
-            dist.all_reduce(overflow_gpu, op=dist.ReduceOp.MAX, group=self.dp_process_group)
+            overflow = (
+                self.local_overflow
+                if self.cpu_offload
+                else self.has_overflow_partitioned_grads_serial()
+            )
+            overflow_gpu = (
+                get_accelerator().ByteTensor([overflow])
+                if self.cpu_offload
+                else overflow.byte().to(get_accelerator().current_device_name())
+            )
+            """This will capture overflow across all data parallel and expert parallel process
+            Since expert parallel process are a subset of data parallel process"""
+            dist.all_reduce(
+                overflow_gpu, op=dist.ReduceOp.MAX, group=self.dp_process_group
+            )
 
         else:
             params = []
             for group in self.bit16_groups:
                 for param in group:
                     params.append(param)
-            overflow_gpu = self.has_overflow_serial(params).byte().to(get_accelerator().current_device_name())
+            overflow_gpu = (
+                self.has_overflow_serial(params)
+                .byte()
+                .to(get_accelerator().current_device_name())
+            )
 
         # Since each model parallel GPU carries only part of the model,
         # make sure overflow flag is synced across all the model parallel GPUs
@@ -2063,16 +2459,20 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.micro_step_id += 1
             if self.contiguous_gradients and self.ipg_buffer is None:
                 self.ipg_buffer = []
-                buf_0 = torch.empty(int(self.reduce_bucket_size),
-                                    dtype=self.dtype,
-                                    device=get_accelerator().current_device_name())
+                buf_0 = torch.empty(
+                    int(self.reduce_bucket_size),
+                    dtype=self.dtype,
+                    device=get_accelerator().current_device_name(),
+                )
                 self.ipg_buffer.append(buf_0)
 
                 # Use double buffers to avoid data access conflict when overlap_comm is enabled.
                 if self.overlap_comm:
-                    buf_1 = torch.empty(int(self.reduce_bucket_size),
-                                        dtype=self.dtype,
-                                        device=get_accelerator().current_device_name())
+                    buf_1 = torch.empty(
+                        int(self.reduce_bucket_size),
+                        dtype=self.dtype,
+                        device=get_accelerator().current_device_name(),
+                    )
                     self.ipg_buffer.append(buf_1)
                 self.ipg_index = 0
             self.ready_for_gradients = True
@@ -2163,8 +2563,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def _get_base_optimizer_state(self):
         optimizer_groups_state = []
         for i, group in enumerate(self.optimizer.param_groups):
-            p = group['params'][0]
-            lean_optimizer_state = self._get_state_without_padding(self.optimizer.state[p], self.groups_padding[i])
+            p = group["params"][0]
+            lean_optimizer_state = self._get_state_without_padding(
+                self.optimizer.state[p], self.groups_padding[i]
+            )
             optimizer_groups_state.append(lean_optimizer_state)
 
         return optimizer_groups_state
@@ -2182,8 +2584,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         """
         state_dict = {}
         state_dict[LOSS_SCALER] = self.loss_scaler
-        state_dict['dynamic_loss_scale'] = self.dynamic_loss_scale
-        state_dict['overflow'] = self.overflow
+        state_dict["dynamic_loss_scale"] = self.dynamic_loss_scale
+        state_dict["overflow"] = self.overflow
         state_dict[CLIP_GRAD] = self.clip_grad
 
         if self.elastic_checkpoint:
@@ -2191,18 +2593,27 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             if "step" in self.optimizer.param_groups[0]:
                 # Assuming "step" is the only item that changes through training iterations
-                assert all(group["step"] == self.optimizer.param_groups[0]["step"]
-                           for group in self.optimizer.param_groups), "All param groups must have the same step value"
-                state_dict[BASE_OPTIMIZER_STATE_STEP] = self.optimizer.param_groups[0]["step"]
+                assert all(
+                    group["step"] == self.optimizer.param_groups[0]["step"]
+                    for group in self.optimizer.param_groups
+                ), "All param groups must have the same step value"
+                state_dict[BASE_OPTIMIZER_STATE_STEP] = self.optimizer.param_groups[0][
+                    "step"
+                ]
         else:
             state_dict[BASE_OPTIMIZER_STATE] = self.optimizer.state_dict()
 
         # Remove paddings for DP alignment to enable loading for other alignment values
-        fp32_groups_without_padding = self._get_groups_without_padding(self.single_partition_of_fp32_groups)
+        fp32_groups_without_padding = self._get_groups_without_padding(
+            self.single_partition_of_fp32_groups
+        )
         state_dict[SINGLE_PARTITION_OF_FP32_GROUPS] = fp32_groups_without_padding
 
-        state_dict[
-            ZERO_STAGE] = ZeroStageEnum.gradients if self.partition_gradients else ZeroStageEnum.optimizer_states
+        state_dict[ZERO_STAGE] = (
+            ZeroStageEnum.gradients
+            if self.partition_gradients
+            else ZeroStageEnum.optimizer_states
+        )
         state_dict[GROUP_PADDINGS] = self.groups_padding
         state_dict[PARTITION_COUNT] = self.partition_count
 
@@ -2220,23 +2631,35 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         for i in range(len(self.single_partition_of_fp32_groups)):
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
-            merged_partitions = [sd[SINGLE_PARTITION_OF_FP32_GROUPS][i] for sd in all_state_dict]
+            merged_partitions = [
+                sd[SINGLE_PARTITION_OF_FP32_GROUPS][i] for sd in all_state_dict
+            ]
             if self.is_moe_group(self.optimizer.param_groups[i]):
-                ranks = self.get_ep_ranks(group_name=self.optimizer.param_groups[i]['name'])
+                ranks = self.get_ep_ranks(
+                    group_name=self.optimizer.param_groups[i]["name"]
+                )
                 merged_partitions = [merged_partitions[i] for i in ranks]
             flat_merged_partitions = self.flatten_dense_tensors_aligned(
                 merged_partitions,
-                self.nccl_start_alignment_factor * dist.get_world_size(group=self.real_dp_process_group[i]))
+                self.nccl_start_alignment_factor
+                * dist.get_world_size(group=self.real_dp_process_group[i]),
+            )
             dp_partitions = self.get_data_parallel_partitions(flat_merged_partitions, i)
             merged_single_partition_of_fp32_groups.append(dp_partitions[partition_id])
 
-        for current, saved in zip(self.single_partition_of_fp32_groups, merged_single_partition_of_fp32_groups):
+        for current, saved in zip(
+            self.single_partition_of_fp32_groups, merged_single_partition_of_fp32_groups
+        ):
             current.data.copy_(saved.data)
 
     # Restore base optimizer fp32 weights from ZeRO fp16 or bfloat16 weights
     def _restore_from_bit16_weights(self):
         for group_id, (bit16_partitions, fp32_partition) in enumerate(
-                zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups)):
+            zip(
+                self.parallel_partitioned_bit16_groups,
+                self.single_partition_of_fp32_groups,
+            )
+        ):
             partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
             fp32_partition.data.copy_(bit16_partitions[partition_id].data)
 
@@ -2245,12 +2668,20 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self._restore_from_bit16_weights()
 
     # Extract optimizer state for current partition from merged states of all partitions
-    def _partition_base_optimizer_state(self, state_key, all_partition_states, group_id):
+    def _partition_base_optimizer_state(
+        self, state_key, all_partition_states, group_id
+    ):
         partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
-        alignment = self.nccl_start_alignment_factor * dist.get_world_size(group=self.real_dp_process_group[group_id])
+        alignment = self.nccl_start_alignment_factor * dist.get_world_size(
+            group=self.real_dp_process_group[group_id]
+        )
         if torch.is_tensor(all_partition_states[0]):
-            flat_merged_partitions = self.flatten_dense_tensors_aligned(all_partition_states, alignment)
-            dp_partitions = self.get_data_parallel_partitions(flat_merged_partitions, group_id)
+            flat_merged_partitions = self.flatten_dense_tensors_aligned(
+                all_partition_states, alignment
+            )
+            dp_partitions = self.get_data_parallel_partitions(
+                flat_merged_partitions, group_id
+            )
             return dp_partitions[partition_id]
         else:
             # Assume non-tensor states are not partitioned and equal across ranks, so return first one
@@ -2258,18 +2689,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def _restore_step_from_elastic_checkpoint(self, all_state_dict):
         assert BASE_OPTIMIZER_STATE_STEP in all_state_dict[0]
-        assert all(sd[BASE_OPTIMIZER_STATE_STEP] == all_state_dict[0][BASE_OPTIMIZER_STATE_STEP]
-                   for sd in all_state_dict), "State dicts of all partitions must have the same step value"
+        assert all(
+            sd[BASE_OPTIMIZER_STATE_STEP]
+            == all_state_dict[0][BASE_OPTIMIZER_STATE_STEP]
+            for sd in all_state_dict
+        ), "State dicts of all partitions must have the same step value"
         return all_state_dict[0][BASE_OPTIMIZER_STATE_STEP]
 
-    def _restore_base_optimizer_state(self, base_optimizer_group_states, base_optimizer_state_step, group_paddings):
+    def _restore_base_optimizer_state(
+        self, base_optimizer_group_states, base_optimizer_state_step, group_paddings
+    ):
         if type(base_optimizer_group_states) == dict:
-            base_optimizer_group_states = base_optimizer_group_states['state']
+            base_optimizer_group_states = base_optimizer_group_states["state"]
 
         saved_keys = base_optimizer_group_states[0].keys()
 
         for i, group in enumerate(self.optimizer.param_groups):
-            p = group['params'][0]
+            p = group["params"][0]
             padding = 0 if group_paddings is None else group_paddings[i]
             for key in saved_keys:
                 saved = base_optimizer_group_states[i][key]
@@ -2281,16 +2717,20 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         self.optimizer.state[p][key].data.copy_(src_tensor.data)
                     else:
                         self.optimizer.state[p][key] = _pad_tensor_by_size(
-                            saved, padding, torch.float32,
-                            torch.device('cpu') if self.cpu_offload else self.device)
+                            saved,
+                            padding,
+                            torch.float32,
+                            torch.device("cpu") if self.cpu_offload else self.device,
+                        )
                 else:
                     self.optimizer.state[p][key] = saved
 
         for param_group in self.optimizer.param_groups:
-            param_group['step'] = base_optimizer_state_step
+            param_group["step"] = base_optimizer_state_step
 
     def get_ep_ranks(self, rank=0, group_name=None):
         from deepspeed.utils import groups
+
         expert_parallel_size_ = groups._get_expert_parallel_world_size(group_name)
         world_size = groups._get_data_parallel_world_size()
         rank = groups._get_expert_parallel_rank(group_name)
@@ -2305,39 +2745,62 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         base_optimizer_group_states = []
         for i in range(len(self.optimizer.param_groups)):
             partition_states = {}
-            all_partition_group_states = [sd[BASE_OPTIMIZER_STATE][i] for sd in all_state_dict]
+            all_partition_group_states = [
+                sd[BASE_OPTIMIZER_STATE][i] for sd in all_state_dict
+            ]
 
             if self.is_moe_group(self.optimizer.param_groups[i]):
-                ranks = self.get_ep_ranks(group_name=self.optimizer.param_groups[i]['name'])
-                all_partition_group_states = [all_partition_group_states[i] for i in ranks]
+                ranks = self.get_ep_ranks(
+                    group_name=self.optimizer.param_groups[i]["name"]
+                )
+                all_partition_group_states = [
+                    all_partition_group_states[i] for i in ranks
+                ]
 
             for key in all_partition_group_states[0].keys():
-                all_partition_states = [all_states[key] for all_states in all_partition_group_states]
-                partition_states[key] = self._partition_base_optimizer_state(key, all_partition_states, i)
+                all_partition_states = [
+                    all_states[key] for all_states in all_partition_group_states
+                ]
+                partition_states[key] = self._partition_base_optimizer_state(
+                    key, all_partition_states, i
+                )
             base_optimizer_group_states.append(partition_states)
 
-        self._restore_base_optimizer_state(base_optimizer_group_states,
-                                           self._restore_step_from_elastic_checkpoint(all_state_dict), None)
+        self._restore_base_optimizer_state(
+            base_optimizer_group_states,
+            self._restore_step_from_elastic_checkpoint(all_state_dict),
+            None,
+        )
 
-    def load_state_dict(self,
-                        state_dict_list,
-                        load_optimizer_states=True,
-                        load_from_fp32_weights=False,
-                        checkpoint_folder=None,
-                        load_serial=None,
-                        param_shapes=None):
+    def load_state_dict(
+        self,
+        state_dict_list,
+        load_optimizer_states=True,
+        load_from_fp32_weights=False,
+        checkpoint_folder=None,
+        load_serial=None,
+        param_shapes=None,
+    ):
         if checkpoint_folder:
-            self._load_universal_checkpoint(checkpoint_folder, load_optimizer_states, load_from_fp32_weights)
+            self._load_universal_checkpoint(
+                checkpoint_folder, load_optimizer_states, load_from_fp32_weights
+            )
         else:
-            self._load_legacy_checkpoint(state_dict_list, load_optimizer_states, load_from_fp32_weights)
+            self._load_legacy_checkpoint(
+                state_dict_list, load_optimizer_states, load_from_fp32_weights
+            )
 
-    def _load_universal_checkpoint(self, checkpoint_folder, load_optimizer_states, load_from_fp32_weights):
-        self.load_hp_checkpoint_state_from_checkpoint_dir("bit16_groups", checkpoint_folder)
+    def _load_universal_checkpoint(
+        self, checkpoint_folder, load_optimizer_states, load_from_fp32_weights
+    ):
+        self.load_hp_checkpoint_state_from_checkpoint_dir(
+            "bit16_groups", checkpoint_folder
+        )
 
     def _load_global_state(self, sd):
         self.loss_scaler = sd.get(LOSS_SCALER, self.loss_scaler)
-        self.dynamic_loss_scale = sd.get('dynamic_loss_scale', self.dynamic_loss_scale)
-        self.overflow = sd.get('overflow', self.overflow)
+        self.dynamic_loss_scale = sd.get("dynamic_loss_scale", self.dynamic_loss_scale)
+        self.overflow = sd.get("overflow", self.overflow)
         self.clip_grad = sd.get(CLIP_GRAD, self.clip_grad)
 
         ckpt_version = sd.get(DS_VERSION, False)
@@ -2347,12 +2810,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # zero stage 1 mode
         if not self.partition_gradients:
             required_version = pkg_version.parse("0.3.17")
-            error_str = f"ZeRO stage 1 changed in {required_version} and is not backwards compatible " \
-                "with older stage 1 checkpoints. If you'd like to load an old ZeRO-1 checkpoint " \
+            error_str = (
+                f"ZeRO stage 1 changed in {required_version} and is not backwards compatible "
+                "with older stage 1 checkpoints. If you'd like to load an old ZeRO-1 checkpoint "
                 "please use an older version of DeepSpeed (<= 0.5.8) and set 'legacy_stage1': true in your zero config json."
-            assert required_version <= ckpt_version, f"Old version: {ckpt_version} {error_str}"
+            )
+            assert (
+                required_version <= ckpt_version
+            ), f"Old version: {ckpt_version} {error_str}"
 
-    def _load_legacy_checkpoint(self, state_dict_list, load_optimizer_states=True, load_from_fp32_weights=False):
+    def _load_legacy_checkpoint(
+        self, state_dict_list, load_optimizer_states=True, load_from_fp32_weights=False
+    ):
         r"""Loading ZeRO checkpoint
 
         Arguments:
@@ -2406,9 +2875,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     self._restore_elastic_base_optimizer_state(state_dict_list)
                 else:
                     # loading an elastic checkpoint into rigid exec
-                    self._restore_base_optimizer_state(current_rank_sd[BASE_OPTIMIZER_STATE],
-                                                       current_rank_sd[BASE_OPTIMIZER_STATE_STEP],
-                                                       current_rank_sd[GROUP_PADDINGS])
+                    self._restore_base_optimizer_state(
+                        current_rank_sd[BASE_OPTIMIZER_STATE],
+                        current_rank_sd[BASE_OPTIMIZER_STATE_STEP],
+                        current_rank_sd[GROUP_PADDINGS],
+                    )
 
         # At this point, the optimizer's references to the model's fp32 parameters are up to date.
         # The optimizer's hyperparameters and internal buffers are also up to date.
@@ -2431,8 +2902,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self._restore_from_elastic_fp32_weights(state_dict_list)
             else:
                 # For non-elastic checkpoint, simply copying from saved weights of current rank is sufficient.
-                for current, saved in zip(self.single_partition_of_fp32_groups,
-                                          current_rank_sd[SINGLE_PARTITION_OF_FP32_GROUPS]):
+                for current, saved in zip(
+                    self.single_partition_of_fp32_groups,
+                    current_rank_sd[SINGLE_PARTITION_OF_FP32_GROUPS],
+                ):
                     src_tensor = _get_padded_tensor(saved, current.numel())
                     current.data.copy_(src_tensor.data)
         else:
@@ -2445,6 +2918,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
 def _handle_overflow(cpu_sum, x, i):
     import math
+
     rank = dist.get_rank()
     if rank == 0:
         t_i = -1
@@ -2452,14 +2926,18 @@ def _handle_overflow(cpu_sum, x, i):
             if not math.isfinite(float(v)):
                 t_i = v_i
                 break
-        logger.info(f"rank {rank} detected overflow {cpu_sum} in tensor {i}:{t_i} shape {x.shape}")
+        logger.info(
+            f"rank {rank} detected overflow {cpu_sum} in tensor {i}:{t_i} shape {x.shape}"
+        )
 
 
-def estimate_zero2_model_states_mem_needs(total_params,
-                                          num_gpus_per_node=1,
-                                          num_nodes=1,
-                                          cpu_offload=True,
-                                          additional_buffer_factor=1.5):
+def estimate_zero2_model_states_mem_needs(
+    total_params,
+    num_gpus_per_node=1,
+    num_nodes=1,
+    cpu_offload=True,
+    additional_buffer_factor=1.5,
+):
 
     total_gpus = num_nodes * num_gpus_per_node
 
@@ -2477,14 +2955,15 @@ def estimate_zero2_model_states_mem_needs(total_params,
 
 def model_to_params(model):
     # shared params calculated only once
-    total_params = sum(dict((p.data_ptr(), p.numel()) for p in model.parameters()).values())
+    total_params = sum(
+        dict((p.data_ptr(), p.numel()) for p in model.parameters()).values()
+    )
     return total_params
 
 
-def estimate_zero2_model_states_mem_needs_all_live(model,
-                                                   num_gpus_per_node=1,
-                                                   num_nodes=1,
-                                                   additional_buffer_factor=1.5):
+def estimate_zero2_model_states_mem_needs_all_live(
+    model, num_gpus_per_node=1, num_nodes=1, additional_buffer_factor=1.5
+):
     """
     Print out estimates on memory usage requirements for ZeRO 2 params, optim states and gradients
     for a given ``model`` and hardware setup.
@@ -2505,16 +2984,17 @@ def estimate_zero2_model_states_mem_needs_all_live(model,
 
     total_params = model_to_params(model)
 
-    estimate_zero2_model_states_mem_needs_all_cold(total_params=total_params,
-                                                   num_gpus_per_node=num_gpus_per_node,
-                                                   num_nodes=num_nodes,
-                                                   additional_buffer_factor=additional_buffer_factor)
+    estimate_zero2_model_states_mem_needs_all_cold(
+        total_params=total_params,
+        num_gpus_per_node=num_gpus_per_node,
+        num_nodes=num_nodes,
+        additional_buffer_factor=additional_buffer_factor,
+    )
 
 
-def estimate_zero2_model_states_mem_needs_all_cold(total_params,
-                                                   num_gpus_per_node=1,
-                                                   num_nodes=1,
-                                                   additional_buffer_factor=1.5):
+def estimate_zero2_model_states_mem_needs_all_cold(
+    total_params, num_gpus_per_node=1, num_nodes=1, additional_buffer_factor=1.5
+):
     """
     Print out estimates on memory usage requirements for ZeRO 2 params, optim states and gradients
     for a given ``model`` and hardware setup.
@@ -2535,22 +3015,26 @@ def estimate_zero2_model_states_mem_needs_all_cold(total_params,
 
     def format_options(cpu_offload):
         enabled = []
-        device = f'{OffloadDeviceEnum.cpu:4}' if cpu_offload else "none"
+        device = f"{OffloadDeviceEnum.cpu:4}" if cpu_offload else "none"
         enabled.append(f"offload_optimizer={device}")
         return ", ".join(enabled)
 
     nodes_str = "nodes" if num_nodes > 1 else "node"
     gpus_str = "GPUs" if num_gpus_per_node > 1 else "GPU"
-    print("Estimated memory needed for params, optim states and gradients for a:\n"
-          f"HW: Setup with {num_nodes} {nodes_str}, {num_gpus_per_node} {gpus_str} per node.\n"
-          f"SW: Model with {int(total_params/1e6)}M total params.")
+    print(
+        "Estimated memory needed for params, optim states and gradients for a:\n"
+        f"HW: Setup with {num_nodes} {nodes_str}, {num_gpus_per_node} {gpus_str} per node.\n"
+        f"SW: Model with {int(total_params/1e6)}M total params."
+    )
     print("  per CPU  |  per GPU |   Options")
     for cpu_offload in [True, False]:
-        cpu_mem, gpu_mem = estimate_zero2_model_states_mem_needs(total_params=total_params,
-                                                                 num_gpus_per_node=num_gpus_per_node,
-                                                                 num_nodes=num_nodes,
-                                                                 cpu_offload=cpu_offload,
-                                                                 additional_buffer_factor=additional_buffer_factor)
+        cpu_mem, gpu_mem = estimate_zero2_model_states_mem_needs(
+            total_params=total_params,
+            num_gpus_per_node=num_gpus_per_node,
+            num_nodes=num_nodes,
+            cpu_offload=cpu_offload,
+            additional_buffer_factor=additional_buffer_factor,
+        )
 
         options_str = format_options(cpu_offload=cpu_offload)
         print(f" {cpu_mem/2**30:7.2f}GB | {gpu_mem/2**30:6.2f}GB | {options_str}")

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -11,15 +11,8 @@ from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
 from deepspeed.runtime.base_optimizer import ZeROOptimizer
 from deepspeed.runtime.fp16.loss_scaler import CreateLossScaler
-from deepspeed.runtime.utils import (
-    empty_cache,
-    see_memory_usage,
-    inf,
-    is_model_parallel_parameter,
-    align_dense_tensors,
-    all_gather_dp_groups,
-    mask_nan_or_inf_with_val_inplace,
-)
+from deepspeed.runtime.utils import (empty_cache, see_memory_usage, inf, is_model_parallel_parameter,
+                                     align_dense_tensors, all_gather_dp_groups, mask_nan_or_inf_with_val_inplace)
 from deepspeed.runtime.zero.config import ZeroStageEnum
 from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum
 from deepspeed.ops.adam import DeepSpeedCPUAdam
@@ -32,35 +25,21 @@ from deepspeed.git_version_info import version
 from deepspeed.runtime.constants import PIPE_REPLICATED
 from deepspeed.accelerator import get_accelerator
 
-from deepspeed.checkpoint.constants import (
-    DS_VERSION,
-    GROUP_PADDINGS,
-    PARTITION_COUNT,
-    LOSS_SCALER,
-    SINGLE_PARTITION_OF_FP32_GROUPS,
-    BASE_OPTIMIZER_STATE,
-    BASE_OPTIMIZER_STATE_STEP,
-    CLIP_GRAD,
-    ZERO_STAGE,
-    PARAM_SLICE_MAPPINGS,
-)
+from deepspeed.checkpoint.constants import (DS_VERSION, GROUP_PADDINGS, PARTITION_COUNT, LOSS_SCALER,
+                                            SINGLE_PARTITION_OF_FP32_GROUPS, BASE_OPTIMIZER_STATE,
+                                            BASE_OPTIMIZER_STATE_STEP, CLIP_GRAD, ZERO_STAGE, PARAM_SLICE_MAPPINGS)
 from deepspeed.utils import link_hp_params, lazy_init_hp_params_optimizer_state
 from deepspeed.checkpoint import enable_universal_checkpoint
 
 from deepspeed.utils import groups
-
 # Toggle this to true to enable correctness test
 # with gradient partitioning and without
 pg_correctness_test = False
 
-OPTIMIZER_ALLGATHER_TIMER = "optimizer_allgather"
-OPTIMIZER_GRADIENTS_TIMER = "optimizer_gradients"
-OPTIMIZER_STEP_TIMER = "optimizer_step"
-OPTIMIZER_TIMERS = [
-    OPTIMIZER_ALLGATHER_TIMER,
-    OPTIMIZER_GRADIENTS_TIMER,
-    OPTIMIZER_STEP_TIMER,
-]
+OPTIMIZER_ALLGATHER_TIMER = 'optimizer_allgather'
+OPTIMIZER_GRADIENTS_TIMER = 'optimizer_gradients'
+OPTIMIZER_STEP_TIMER = 'optimizer_step'
+OPTIMIZER_TIMERS = [OPTIMIZER_ALLGATHER_TIMER, OPTIMIZER_GRADIENTS_TIMER, OPTIMIZER_STEP_TIMER]
 INITIAL_MICRO_STEP_ID = -1
 
 
@@ -71,10 +50,8 @@ def input(msg):
 def split_half_float_double(tensors):
     device_type = get_accelerator().device_name()
     dtypes = [
-        "torch.{}.HalfTensor".format(device_type),
-        "torch.{}.FloatTensor".format(device_type),
-        "torch.{}.DoubleTensor".format(device_type),
-        "torch.{}.BFloat16Tensor".format(device_type),
+        "torch.{}.HalfTensor".format(device_type), "torch.{}.FloatTensor".format(device_type),
+        "torch.{}.DoubleTensor".format(device_type), "torch.{}.BFloat16Tensor".format(device_type)
     ]
     buckets = []
     for i, dtype in enumerate(dtypes):
@@ -90,7 +67,6 @@ def isclose(a, b, rtol=1e-09, atol=0.0):
 
 def lcm(x, y):
     from fractions import gcd  # or can import gcd from `math` in Python 3
-
     return x * y // gcd(x, y)
 
 
@@ -114,10 +90,8 @@ def _get_padded_tensor(src_tensor, size):
 
 
 def _pad_tensor_by_size(src_tensor, pad_size, dtype, device):
-    padded_tensor = torch.zeros(
-        src_tensor.numel() + pad_size, dtype=dtype, device=device
-    )
-    padded_tensor.data[: src_tensor.numel()].copy_(src_tensor.data)
+    padded_tensor = torch.zeros(src_tensor.numel() + pad_size, dtype=dtype, device=device)
+    padded_tensor.data[:src_tensor.numel()].copy_(src_tensor.data)
     return padded_tensor
 
 
@@ -133,44 +107,39 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     """
 
-    def __init__(
-        self,
-        init_optimizer,
-        param_names,
-        timers,
-        static_loss_scale=1.0,
-        dynamic_loss_scale=False,
-        dynamic_loss_args=None,
-        verbose=True,
-        contiguous_gradients=True,
-        reduce_bucket_size=500000000,
-        use_multi_rank_bucket_allreduce=True,
-        allgather_bucket_size=5000000000,
-        dp_process_group=None,
-        expert_parallel_group=None,
-        expert_data_parallel_group=None,
-        reduce_scatter=True,
-        overlap_comm=False,
-        offload_optimizer_config=None,
-        mpu=None,
-        clip_grad=0.0,
-        gradient_accumulation_dtype=torch.float32,
-        communication_data_type=torch.float16,
-        postscale_gradients=True,
-        gradient_predivide_factor=1.0,
-        gradient_accumulation_steps=1,
-        ignore_unused_parameters=True,
-        partition_grads=True,
-        round_robin_gradients=False,
-        has_moe_layers=False,
-        fp16_master_weights_and_gradients=False,
-        elastic_checkpoint=False,
-    ):
+    def __init__(self,
+                 init_optimizer,
+                 param_names,
+                 timers,
+                 static_loss_scale=1.0,
+                 dynamic_loss_scale=False,
+                 dynamic_loss_args=None,
+                 verbose=True,
+                 contiguous_gradients=True,
+                 reduce_bucket_size=500000000,
+                 use_multi_rank_bucket_allreduce=True,
+                 allgather_bucket_size=5000000000,
+                 dp_process_group=None,
+                 expert_parallel_group=None,
+                 expert_data_parallel_group=None,
+                 reduce_scatter=True,
+                 overlap_comm=False,
+                 offload_optimizer_config=None,
+                 mpu=None,
+                 clip_grad=0.0,
+                 gradient_accumulation_dtype=torch.float32,
+                 communication_data_type=torch.float16,
+                 postscale_gradients=True,
+                 gradient_predivide_factor=1.0,
+                 gradient_accumulation_steps=1,
+                 ignore_unused_parameters=True,
+                 partition_grads=True,
+                 round_robin_gradients=False,
+                 has_moe_layers=False,
+                 fp16_master_weights_and_gradients=False,
+                 elastic_checkpoint=False):
 
-        if (
-            offload_optimizer_config is not None
-            and offload_optimizer_config.device != OffloadDeviceEnum.none
-        ):
+        if offload_optimizer_config is not None and offload_optimizer_config.device != OffloadDeviceEnum.none:
             self.cpu_offload = True
             self.cpu_offload_pin_memory = offload_optimizer_config.pin_memory
         else:
@@ -181,7 +150,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             logger.info(f"Reduce bucket size {reduce_bucket_size}")
             logger.info(f"Allgather bucket size {allgather_bucket_size}")
             logger.info(f"CPU Offload: {self.cpu_offload}")
-            logger.info(f"Round robin gradient partitioning: {round_robin_gradients}")
+            logger.info(f'Round robin gradient partitioning: {round_robin_gradients}')
         # The fused optimizer does all the work. We need this layer for two reason:
         # 1. maintain same user API from apex.fp16_utils
         # 2. keep common stuff here in case we need to add ne552w fused optimizer later
@@ -195,9 +164,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # - flat by groups, not keeping state. TODO: remove state explicitly?
         # - master grad and unflat master weight never exist. TODO: a way to save out unflat master?
         if not get_accelerator().is_available():
-            raise SystemError(
-                "Accelerator is not detected, cannot perform low precision training (e.g., fp16, bf16)."
-            )
+            raise SystemError("Accelerator is not detected, cannot perform low precision training (e.g., fp16, bf16).")
         self.optimizer = init_optimizer
 
         # Use torch (un)flatten ops
@@ -216,29 +183,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         self.deepspeed_adam_offload = self.cpu_offload
 
-        self.device = (
-            get_accelerator().current_device_name() if not self.cpu_offload else "cpu"
-        )
+        self.device = get_accelerator().current_device_name() if not self.cpu_offload else 'cpu'
 
         self.dp_process_group = dp_process_group
         self.sequence_parallel_size = groups._get_sequence_parallel_world_size()
-        # expert parallel group
+        #expert parallel group
         self.ep_process_group = expert_parallel_group
 
-        # data parallel group for experts
+        #data parallel group for experts
         self.expert_dp_process_group = expert_data_parallel_group
 
-        # data parallel size for non-experts
+        #data parallel size for non-experts
         dp_size = dist.get_world_size(group=self.dp_process_group)
 
-        # For MoE models this maybe different for different param group
-        # It will be modified during MoE setup later in the init
-        self.real_dp_process_group = [
-            dp_process_group for i in range(len(self.optimizer.param_groups))
-        ]
-        self.partition_count = [
-            dp_size for i in range(len(self.optimizer.param_groups))
-        ]
+        #For MoE models this maybe different for different param group
+        #It will be modified during MoE setup later in the init
+        self.real_dp_process_group = [dp_process_group for i in range(len(self.optimizer.param_groups))]
+        self.partition_count = [dp_size for i in range(len(self.optimizer.param_groups))]
 
         self.is_gradient_accumulation_boundary = True
 
@@ -248,7 +209,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.has_moe_layers = has_moe_layers
         if self.has_moe_layers:
             self._configure_moe_settings()
-        self._global_grad_norm = 0.0
+        self._global_grad_norm = 0.
 
         if mpu is None:
             self.model_parallel_group = None
@@ -273,23 +234,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.fp16_master_weights_and_gradients = fp16_master_weights_and_gradients
 
         if self.fp16_master_weights_and_gradients:
-            assert self.cpu_offload and type(self.optimizer) in [DeepSpeedCPUAdam], (
-                f"fp16_master_and_gradients requires optimizer to support keeping fp16 master and gradients while keeping the optimizer states in fp32."
-                f"Currently only supported using ZeRO-Offload with DeepSpeedCPUAdam. But current setting is ZeRO-Offload:{self.cpu_offload} and optimizer type {type(self.optimizer)}."
-                f"Either disable fp16_master_weights_and_gradients or enable {self.zero_stage_string} Offload with DeepSpeedCPUAdam."
-            )
+            assert self.cpu_offload and type(self.optimizer) in [DeepSpeedCPUAdam], \
+            f"fp16_master_and_gradients requires optimizer to support keeping fp16 master and gradients while keeping the optimizer states in fp32."\
+            f"Currently only supported using ZeRO-Offload with DeepSpeedCPUAdam. But current setting is ZeRO-Offload:{self.cpu_offload} and optimizer type {type(self.optimizer)}." \
+            f"Either disable fp16_master_weights_and_gradients or enable {self.zero_stage_string} Offload with DeepSpeedCPUAdam."
 
         if self.reduce_scatter and self.partition_gradients:
             valid_reduce_scatter_dtypes = (torch.float16, torch.bfloat16, torch.float32)
-            assert (
-                self.communication_data_type in valid_reduce_scatter_dtypes
-            ), f"{self.zero_stage_string} supports {valid_reduce_scatter_dtypes} communication_data_type with reduce scatter enabled. Got: '{self.communication_data_type}'"
-            assert (
-                self.gradient_predivide_factor == 1.0
-            ), f"gradient_predivide_factor != 1.0 is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
-            assert (
-                self.postscale_gradients
-            ), f"pre-scale gradients is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
+            assert self.communication_data_type in valid_reduce_scatter_dtypes, f"{self.zero_stage_string} supports {valid_reduce_scatter_dtypes} communication_data_type with reduce scatter enabled. Got: '{self.communication_data_type}'"
+            assert self.gradient_predivide_factor == 1.0, f"gradient_predivide_factor != 1.0 is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
+            assert self.postscale_gradients, f"pre-scale gradients is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
 
         # param flattened by groups
         self.bit16_groups = []
@@ -332,7 +286,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         ), f"allgather_bucket_size must be a multiple of nccl_start_alignment_factor, {self.nccl_start_alignment_factor} "
 
         self.all_reduce_print = False
-        self.dtype = self.optimizer.param_groups[0]["params"][0].dtype
+        self.dtype = self.optimizer.param_groups[0]['params'][0].dtype
         self.gradient_accumulation_dtype = gradient_accumulation_dtype
 
         if self.dtype != self.gradient_accumulation_dtype:
@@ -358,7 +312,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # push this group to list before modify
             # TODO: Explore simplification that avoids the extra book-keeping by pushing the reordered group
             trainable_parameters = []
-            for param in param_group["params"]:
+            for param in param_group['params']:
                 if param.requires_grad:
                     param.grad_accum = None
                     param.param_idx_in_group = len(trainable_parameters)
@@ -387,9 +341,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # to the same rank, instead they will belong to 3 ranks (r_m+2, r_m+1, r_m).
             if self.round_robin_gradients:
                 round_robin_tensors, round_robin_indices = self._round_robin_reorder(
-                    self.bit16_groups[i],
-                    dist.get_world_size(group=self.real_dp_process_group[i]),
-                )
+                    self.bit16_groups[i], dist.get_world_size(group=self.real_dp_process_group[i]))
             else:
                 round_robin_tensors = self.bit16_groups[i]
                 round_robin_indices = list(range(len(self.bit16_groups[i])))
@@ -406,45 +358,32 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # create flat buffer in CPU
             flattened_buffer = self.flatten_dense_tensors_aligned(
                 self.round_robin_bit16_groups[i],
-                self.nccl_start_alignment_factor
-                * dist.get_world_size(group=self.real_dp_process_group[i]),
-                use_cpu_data=True,
-            )
+                self.nccl_start_alignment_factor * dist.get_world_size(group=self.real_dp_process_group[i]),
+                use_cpu_data=True)
 
             # free temp CPU params
             for param in self.bit16_groups[i]:
                 del param.cpu_data
 
             # Move CPU flat tensor to the accelerator memory.
-            self.bit16_groups_flat.append(
-                flattened_buffer.to(get_accelerator().current_device_name())
-            )
+            self.bit16_groups_flat.append(flattened_buffer.to(get_accelerator().current_device_name()))
             del flattened_buffer
 
-            see_memory_usage(
-                f"After flattening and moving param group {i} to GPU", force=False
-            )
+            see_memory_usage(f"After flattening and moving param group {i} to GPU", force=False)
 
             if dist.get_rank(group=self.real_dp_process_group[i]) == 0:
-                see_memory_usage(
-                    f"After Flattening and after emptying param group {i} cache",
-                    force=False,
-                )
+                see_memory_usage(f"After Flattening and after emptying param group {i} cache", force=False)
 
             # set model bit16 weight to slices of flattened buffer
             self._update_model_bit16_weights(i)
 
             # divide the flat weights into near equal partition equal to the data parallel degree
             # each process will compute on a different part of the partition
-            data_parallel_partitions = self.get_data_parallel_partitions(
-                self.bit16_groups_flat[i], i
-            )
+            data_parallel_partitions = self.get_data_parallel_partitions(self.bit16_groups_flat[i], i)
             self.parallel_partitioned_bit16_groups.append(data_parallel_partitions)
 
             # Record padding required for alignment
-            left_boundary = sum(
-                [t.numel() for t in data_parallel_partitions[:partition_id]]
-            )
+            left_boundary = sum([t.numel() for t in data_parallel_partitions[:partition_id]])
             curr_partition_size = data_parallel_partitions[partition_id].numel()
 
             if orig_group_numel <= left_boundary:
@@ -457,66 +396,43 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             # verify that data partition start locations are 4-byte aligned
             for partitioned_data in data_parallel_partitions:
-                assert (
-                    partitioned_data.data_ptr() % (2 * self.nccl_start_alignment_factor)
-                    == 0
-                )
+                assert (partitioned_data.data_ptr() % (2 * self.nccl_start_alignment_factor) == 0)
 
             # A partition of the fp32 master weights that will be updated by this process.
             # Note that the params in single_partition_of_fp32_groups is cloned and detached
             # from the origin params of the model.
             if not fp16_master_weights_and_gradients:
-                weights_partition = (
-                    self.parallel_partitioned_bit16_groups[i][partition_id]
-                    .to(self.device)
-                    .clone()
-                    .float()
-                    .detach()
-                )
+                weights_partition = self.parallel_partitioned_bit16_groups[i][partition_id].to(
+                    self.device).clone().float().detach()
             else:
-                weights_partition = (
-                    self.parallel_partitioned_bit16_groups[i][partition_id]
-                    .to(self.device)
-                    .clone()
-                    .half()
-                    .detach()
-                )
+                weights_partition = self.parallel_partitioned_bit16_groups[i][partition_id].to(
+                    self.device).clone().half().detach()
 
             if self.cpu_offload:
                 weights_partition = get_accelerator().pin_memory(weights_partition)
-                temp_param_buffer_of_bit16 = torch.full(
-                    weights_partition.shape,
-                    fill_value=0.0,
-                    dtype=self.parallel_partitioned_bit16_groups[i][partition_id].dtype,
-                    device=weights_partition.device,
-                )
+                temp_dtype = self.parallel_partitioned_bit16_groups[i][partition_id].dtype
+                temp_buffer_bit16 = torch.full(weights_partition.shape,
+                                               fill_value=0.0,
+                                               dtype=temp_dtype,
+                                               device=weights_partition.device)
+                temp_pinned = get_accelerator().pin_memory(temp_buffer_bit16)
                 if self.cpu_offload_pin_memory:
-                    self.param_buffer_of_bit16_for_cpu_offload_groups.append(
-                        get_accelerator().pin_memory(temp_param_buffer_of_bit16)
-                    )
+                    self.param_buffer_of_bit16_for_cpu_offload_groups.append(temp_pinned)
                 else:
-                    self.param_buffer_of_bit16_for_cpu_offload_groups.append(
-                        temp_param_buffer_of_bit16
-                    )
+                    self.param_buffer_of_bit16_for_cpu_offload_groups.append(temp_buffer_bit16)
 
             self.single_partition_of_fp32_groups.append(weights_partition)
 
             # Set local optimizer to have flat params of its own partition.
             # After this, the local optimizer will only contain its own partition of params.
             # In that case, the local optimizer only saves the states(momentum, variance, etc.) related to its partition's params(zero stage1).
-            self.single_partition_of_fp32_groups[i].requires_grad = (
-                True  # keep this in case internal optimizer uses it
-            )
-            param_group["params"] = [self.single_partition_of_fp32_groups[i]]
+            self.single_partition_of_fp32_groups[
+                i].requires_grad = True  # keep this in case internal optimizer uses it
+            param_group['params'] = [self.single_partition_of_fp32_groups[i]]
 
-            partition_size = len(self.bit16_groups_flat[i]) / dist.get_world_size(
-                group=self.real_dp_process_group[i]
-            )
-            params_in_partition, params_not_in_partition, first_offset = (
-                self.get_partition_info(
-                    self.round_robin_bit16_groups[i], partition_size, partition_id
-                )
-            )
+            partition_size = len(self.bit16_groups_flat[i]) / dist.get_world_size(group=self.real_dp_process_group[i])
+            params_in_partition, params_not_in_partition, first_offset = self.get_partition_info(
+                self.round_robin_bit16_groups[i], partition_size, partition_id)
 
             self.partition_size.append(partition_size)
             self.params_in_partition.append(params_in_partition)
@@ -527,12 +443,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.use_multi_rank_bucket_allreduce = use_multi_rank_bucket_allreduce
         self.allgather_bucket_size = int(allgather_bucket_size)
 
-        self.reduction_stream = (
-            None
-            if get_accelerator().is_synchronized_device()
-            else get_accelerator().Stream()
-        )
-        # self.copy_grad_stream = get_accelerator().Stream()
+        self.reduction_stream = None if get_accelerator().is_synchronized_device() else get_accelerator().Stream()
+        #self.copy_grad_stream = get_accelerator().Stream()
         self.callback_queued = False
 
         self.param_dict = {}
@@ -551,7 +463,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # simplified param id
         self.param_id = {}
 
-        # interesting code: unique ids being assigned to individual parameters
+        #interesting code: unique ids being assigned to individual parameters
         largest_param_numel = 0
         count = 0
         for i, params_group in enumerate(self.bit16_groups):
@@ -577,25 +489,17 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.norm_for_param_grads = {}
             self.local_overflow = False
             self.grad_position = {}
-            self.temp_grad_buffer_for_cpu_offload = torch.zeros(
-                largest_param_numel, device=self.device, dtype=self.dtype
-            )
+            self.temp_grad_buffer_for_cpu_offload = torch.zeros(largest_param_numel,
+                                                                device=self.device,
+                                                                dtype=self.dtype)
             if self.cpu_offload_pin_memory:
                 self.temp_grad_buffer_for_cpu_offload = get_accelerator().pin_memory(
-                    self.temp_grad_buffer_for_cpu_offload
-                )
-            self.temp_grad_buffer_for_gpu_offload = torch.zeros(
-                largest_param_numel,
-                device=get_accelerator().current_device_name(),
-                dtype=self.dtype,
-            )
+                    self.temp_grad_buffer_for_cpu_offload)
+            self.temp_grad_buffer_for_gpu_offload = torch.zeros(largest_param_numel,
+                                                                device=get_accelerator().current_device_name(),
+                                                                dtype=self.dtype)
             for i, params_group in enumerate(self.bit16_groups):
-                self.get_grad_position(
-                    i,
-                    self.params_in_partition[i],
-                    self.first_offset[i],
-                    self.partition_size[i],
-                )
+                self.get_grad_position(i, self.params_in_partition[i], self.first_offset[i], self.partition_size[i])
 
         # mapping from parameter to partition that it belongs to
         self.param_to_partition_ids = {}
@@ -639,12 +543,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # 3. overlapping backward and reduction
         self._grad_acc_hooks = []
 
-        if (
-            self.partition_gradients
-            or self.overlap_comm
-            or self.use_grad_accum_attribute
-            or self.contiguous_gradients
-        ):
+        if (self.partition_gradients or self.overlap_comm or self.use_grad_accum_attribute
+                or self.contiguous_gradients):
             self.create_gradient_handling_hooks()
 
         self.ready_for_gradients = False
@@ -652,12 +552,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.external_loss_scale = None
 
         # we may have a way of fusing dynamic scale. Do not support for now
-        self.loss_scaler = CreateLossScaler(
-            dtype=self.dtype,
-            static_loss_scale=static_loss_scale,
-            dynamic_scaling=dynamic_loss_scale,
-            dynamic_loss_args=dynamic_loss_args,
-        )
+        self.loss_scaler = CreateLossScaler(dtype=self.dtype,
+                                            static_loss_scale=static_loss_scale,
+                                            dynamic_scaling=dynamic_loss_scale,
+                                            dynamic_loss_args=dynamic_loss_args)
         self.dynamic_loss_scale = self.loss_scaler.dynamic
 
         if self.dtype != torch.float16:
@@ -684,7 +582,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def destroy(self):
         for i, _ in enumerate(self.optimizer.param_groups):
             for p in self.bit16_groups[i]:
-                if getattr(p, "_hp_mapping", None):
+                if getattr(p, '_hp_mapping', None):
                     p._hp_mapping = None
         for hook in self._grad_acc_hooks:
             hook.remove()
@@ -701,9 +599,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for lp in self.bit16_groups[i]:
                 if lp._hp_mapping is not None:
                     lp_name = self.param_names[lp]
-                    param_mapping_per_group[lp_name] = (
-                        lp._hp_mapping.get_hp_fragment_address()
-                    )
+                    param_mapping_per_group[lp_name] = lp._hp_mapping.get_hp_fragment_address()
             param_mapping.append(param_mapping_per_group)
 
         return param_mapping
@@ -716,48 +612,37 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # Link bit16 and fp32 params in partition
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             partition_size = self.bit16_groups_flat[i].numel() // dist.get_world_size(
-                group=self.real_dp_process_group[i]
-            )
+                group=self.real_dp_process_group[i])
             flat_hp_partition = self.single_partition_of_fp32_groups[i]
-            link_hp_params(
-                lp_param_list=self.bit16_groups[i],
-                flat_hp_partition=flat_hp_partition,
-                gradient_dict=self.averaged_gradients,
-                offload_gradient_dict=self.offload_gradient_dict,
-                use_offload=self.cpu_offload,
-                param_group_index=i,
-                partition_start=partition_id * partition_size,
-                partition_size=partition_size,
-                dp_group=self.real_dp_process_group[i],
-            )
+            link_hp_params(lp_param_list=self.bit16_groups[i],
+                           flat_hp_partition=flat_hp_partition,
+                           gradient_dict=self.averaged_gradients,
+                           offload_gradient_dict=self.offload_gradient_dict,
+                           use_offload=self.cpu_offload,
+                           param_group_index=i,
+                           partition_start=partition_id * partition_size,
+                           partition_size=partition_size,
+                           dp_group=self.real_dp_process_group[i])
 
     def _lazy_init_hp_params_optimizer_state(self):
         if not self._hp_optimizer_states_linked:
             for i, _ in enumerate(self.optimizer.param_groups):
-                lazy_init_hp_params_optimizer_state(
-                    self.bit16_groups[i],
-                    self.single_partition_of_fp32_groups[i],
-                    self.optimizer.state,
-                )
+                lazy_init_hp_params_optimizer_state(self.bit16_groups[i], self.single_partition_of_fp32_groups[i],
+                                                    self.optimizer.state)
             self._hp_optimizer_states_linked = True
 
     def is_moe_group(self, group):
-        return "moe" in group and group["moe"]
+        return 'moe' in group and group['moe']
 
     def _configure_moe_settings(self):
         # if we're using ZeRO stage 2, ensure contiguous gradients are used
         if self.partition_gradients:
-            assert (
-                self.contiguous_gradients
-            ), "Contiguous Gradients in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
+            assert self.contiguous_gradients, "Contiguous Gradients in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
         # NOTE: To run ZeRO stage 1 with MoE, we need to set self.contiguous_gradients to True or ignore the assertion
         if not self.partition_gradients and not self.contiguous_gradients:
             logger.warning(
-                "ZeRO Stage 1 has not been thoroughly tested with MoE. This configuration is still experimental."
-            )
-        assert (
-            self.reduce_scatter
-        ), "Reduce Scatter in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
+                "ZeRO Stage 1 has not been thoroughly tested with MoE. This configuration is still experimental.")
+        assert self.reduce_scatter, "Reduce Scatter in ZeRO Stage 2 must be set to True for MoE. Other code paths are not tested with MoE"
 
         assert any(
             [self.is_moe_group(group) for group in self.optimizer.param_groups]
@@ -765,31 +650,19 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.is_moe_param_group = []
         for i, group in enumerate(self.optimizer.param_groups):
             if self.is_moe_group(group):
-                assert all(
-                    [is_moe_param(param) for param in group["params"]]
-                ), "All params in MoE group must be MoE params"
-                self.real_dp_process_group[i] = self.expert_dp_process_group[
-                    group["name"]
-                ]
-                self.partition_count[i] = dist.get_world_size(
-                    group=self.expert_dp_process_group[group["name"]]
-                )
+                assert all([is_moe_param(param)
+                            for param in group['params']]), "All params in MoE group must be MoE params"
+                self.real_dp_process_group[i] = self.expert_dp_process_group[group['name']]
+                self.partition_count[i] = dist.get_world_size(group=self.expert_dp_process_group[group['name']])
                 self.is_moe_param_group.append(True)
             else:
                 self.is_moe_param_group.append(False)
 
-        assert (
-            self.expert_dp_process_group is not None
-        ), "Expert data parallel group should be configured with MoE"
-        assert (
-            self.ep_process_group is not None
-        ), "Expert parallel group should be configured with MoE"
+        assert self.expert_dp_process_group is not None, "Expert data parallel group should be configured with MoE"
+        assert self.ep_process_group is not None, "Expert parallel group should be configured with MoE"
 
     def _update_model_bit16_weights(self, group_index):
-        updated_params = self.unflatten(
-            self.bit16_groups_flat[group_index],
-            self.round_robin_bit16_meta[group_index],
-        )
+        updated_params = self.unflatten(self.bit16_groups_flat[group_index], self.round_robin_bit16_meta[group_index])
         for p, q in zip(self.round_robin_bit16_groups[group_index], updated_params):
             p.data = q.data
 
@@ -815,9 +688,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         reordered_indices = {}
 
         for partition_index in partition_tensors.keys():
-            for i, (original_index, tensor) in enumerate(
-                partition_tensors[partition_index]
-            ):
+            for i, (original_index, tensor) in enumerate(partition_tensors[partition_index]):
                 reordered_indices[original_index] = len(reordered_tensors)
                 reordered_tensors.append(tensor)
 
@@ -833,28 +704,21 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def initialize_optimizer_states(self):
 
         for i, group in enumerate(self.bit16_groups):
-            single_grad_partition = torch.zeros(
-                int(self.partition_size[i]),
-                dtype=self.single_partition_of_fp32_groups[i].dtype,
-                device=self.device,
-            )
-            self.single_partition_of_fp32_groups[i].grad = (
-                get_accelerator().pin_memory(single_grad_partition)
-                if self.cpu_offload_pin_memory
-                else single_grad_partition
-            )
+            single_grad_partition = torch.zeros(int(self.partition_size[i]),
+                                                dtype=self.single_partition_of_fp32_groups[i].dtype,
+                                                device=self.device)
+            self.single_partition_of_fp32_groups[i].grad = get_accelerator().pin_memory(
+                single_grad_partition) if self.cpu_offload_pin_memory else single_grad_partition
 
         # Initialize the optimizer states with the flattened fp32 partition.
         # State initialization for the Adagrad optimizer occurs at construction as opposed to other optimizers
         # which do lazy initialization of the state at the first call to step.
         if isinstance(self.optimizer, torch.optim.Adagrad):
-            self.optimizer = torch.optim.Adagrad(
-                self.single_partition_of_fp32_groups, **self.optimizer.defaults
-            )
+            self.optimizer = torch.optim.Adagrad(self.single_partition_of_fp32_groups, **self.optimizer.defaults)
 
         if not self.cpu_offload:
             for group in self.single_partition_of_fp32_groups:
-                group.grad = None  # class init
+                group.grad = None  #class init
 
         return
 
@@ -868,11 +732,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # with PP we must create ipg buffer, since backward is handled outside zero
         if pipeline_parallel and self.contiguous_gradients:
             self.ipg_buffer = []
-            buf_0 = torch.empty(
-                int(self.reduce_bucket_size),
-                dtype=self.dtype,
-                device=get_accelerator().current_device_name(),
-            )
+            buf_0 = torch.empty(int(self.reduce_bucket_size),
+                                dtype=self.dtype,
+                                device=get_accelerator().current_device_name())
             self.ipg_buffer.append(buf_0)
             self.ipg_index = 0
 
@@ -892,10 +754,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def get_first_param_index(self, group_id, param_group, partition_id):
         for index, param in enumerate(param_group):
             param_id = self.get_param_id(param)
-            if (
-                group_id in self.param_to_partition_ids
-                and param_id in self.param_to_partition_ids[group_id]
-            ):
+            if group_id in self.param_to_partition_ids and param_id in self.param_to_partition_ids[group_id]:
                 if partition_id in self.param_to_partition_ids[group_id][param_id]:
                     return index
         return None
@@ -921,9 +780,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.total_grads_in_partition[i][partition_id] = 0
                 self.initialize_gradient_partition(i, param_group, partition_id)
                 self.is_partition_reduced[i][partition_id] = False
-                self.first_param_index_in_partition[i][partition_id] = (
-                    self.get_first_param_index(i, param_group, partition_id)
-                )
+                self.first_param_index_in_partition[i][partition_id] = self.get_first_param_index(
+                    i, param_group, partition_id)
 
     def independent_gradient_partition_epilogue(self):
         self.report_ipg_memory_usage(f"In ipg_epilogue before reduce_ipg_grads", 0)
@@ -944,31 +802,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if self.cpu_offload is False:
             for i, _ in enumerate(self.bit16_groups):
 
-                if (
-                    not i in self.averaged_gradients
-                    or self.averaged_gradients[i] is None
-                ):
+                if not i in self.averaged_gradients or self.averaged_gradients[i] is None:
                     self.averaged_gradients[i] = self.get_flat_partition(
                         self.params_in_partition[i],
                         self.first_offset[i],
                         self.partition_size[i],
                         dtype=self.gradient_accumulation_dtype,
                         device=get_accelerator().current_device_name(),
-                        return_tensor_list=True,
-                    )
+                        return_tensor_list=True)
                 else:
-                    avg_new = self.get_flat_partition(
-                        self.params_in_partition[i],
-                        self.first_offset[i],
-                        self.partition_size[i],
-                        dtype=self.gradient_accumulation_dtype,
-                        device=get_accelerator().current_device_name(),
-                        return_tensor_list=True,
-                    )
+                    avg_new = self.get_flat_partition(self.params_in_partition[i],
+                                                      self.first_offset[i],
+                                                      self.partition_size[i],
+                                                      dtype=self.gradient_accumulation_dtype,
+                                                      device=get_accelerator().current_device_name(),
+                                                      return_tensor_list=True)
 
-                    for accumulated_grad, new_avg_grad in zip(
-                        self.averaged_gradients[i], avg_new
-                    ):
+                    for accumulated_grad, new_avg_grad in zip(self.averaged_gradients[i], avg_new):
                         accumulated_grad.add_(new_avg_grad)
 
         self._release_ipg_buffers()
@@ -987,9 +837,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             total_partitions = dist.get_world_size(group=self.real_dp_process_group[i])
             for partition_id in range(total_partitions):
                 self.is_partition_reduced[i][partition_id] = False
-                self.remaining_grads_in_partition[i][partition_id] = (
-                    self.total_grads_in_partition[i][partition_id]
-                )
+                self.remaining_grads_in_partition[i][partition_id] = self.total_grads_in_partition[i][partition_id]
 
                 for param_id in self.is_grad_computed[i][partition_id]:
                     self.is_grad_computed[i][partition_id][param_id] = False
@@ -1022,27 +870,20 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             param_id = self.get_param_id(param)
 
             if start_index <= current_index < end_index:
-                set_key_value_list(
-                    self.param_to_partition_ids[i], param_id, partition_id
-                )
+                set_key_value_list(self.param_to_partition_ids[i], param_id, partition_id)
                 increment_value(self.total_grads_in_partition[i], partition_id)
 
                 self.is_grad_computed[i][partition_id][param_id] = False
 
-                self.grad_partition_insertion_offset[i][partition_id][param_id] = (
-                    current_index - start_index
-                )
+                self.grad_partition_insertion_offset[i][partition_id][param_id] = current_index - start_index
                 self.grad_start_offset[i][partition_id][param_id] = 0
 
             elif current_index < start_index < (current_index + param_size):
-                assert (
-                    first_offset == 0
-                ), "This can happen either zero or only once as this must be the first tensor in the partition"
+                assert (first_offset == 0
+                        ), "This can happen either zero or only once as this must be the first tensor in the partition"
                 first_offset = start_index - current_index
 
-                set_key_value_list(
-                    self.param_to_partition_ids[i], param_id, partition_id
-                )
+                set_key_value_list(self.param_to_partition_ids[i], param_id, partition_id)
                 increment_value(self.total_grads_in_partition[i], partition_id)
 
                 self.is_grad_computed[i][partition_id][param_id] = False
@@ -1060,11 +901,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if param.grad_accum is None:
                 param.grad_accum = param.grad.to(self.gradient_accumulation_dtype)
             else:
-                param.grad_accum.add_(
-                    param.grad.to(self.gradient_accumulation_dtype).view(
-                        param.grad_accum.shape
-                    )
-                )
+                param.grad_accum.add_(param.grad.to(self.gradient_accumulation_dtype).view(param.grad_accum.shape))
             param.grad = None
 
     def fill_grad_accum_attribute(self):
@@ -1074,11 +911,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def get_gradient_for_reduction(self, param):
         if self.use_grad_accum_attribute:
-            return (
-                param.grad_accum.to(self.dtype)
-                if param.grad_accum is not None
-                else None
-            )
+            return param.grad_accum.to(self.dtype) if param.grad_accum is not None else None
         else:
             return param.grad
 
@@ -1102,9 +935,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         def grad_handling_hook(*notneeded):
                             self.process_gradients(param, i)
 
-                        self._grad_acc_hooks.append(
-                            register_grad_hook(param, grad_handling_hook)
-                        )
+                        self._grad_acc_hooks.append(register_grad_hook(param, grad_handling_hook))
 
                     wrapper(param, i)
 
@@ -1121,9 +952,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     # create a flat tensor aligned at the alignment boundary
     def flatten_dense_tensors_aligned(self, tensor_list, alignment, use_cpu_data=False):
-        tensor_list = (
-            [param.cpu_data for param in tensor_list] if use_cpu_data else tensor_list
-        )
+        tensor_list = [param.cpu_data for param in tensor_list] if use_cpu_data else tensor_list
         return self.flatten(align_dense_tensors(tensor_list, alignment))
 
     ############### Independent Partition Gradient ########################
@@ -1131,21 +960,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         grad_reduc = self.get_gradient_for_reduction(param)
         if self.elements_in_ipg_bucket + param.numel() > self.reduce_bucket_size:
-            self.report_ipg_memory_usage(
-                "In ipg_remove_grads before reduce_ipg_grads", param.numel()
-            )
+            self.report_ipg_memory_usage("In ipg_remove_grads before reduce_ipg_grads", param.numel())
             self.reduce_ipg_grads()
             if self.contiguous_gradients and self.overlap_comm:
                 # Swap ipg_index between 0 and 1
                 self.ipg_index = 1 - self.ipg_index
-            self.report_ipg_memory_usage(
-                "In ipg_remove_grads after reduce_ipg_grads", param.numel()
-            )
+            self.report_ipg_memory_usage("In ipg_remove_grads after reduce_ipg_grads", param.numel())
 
         param_id = self.get_param_id(param)
-        assert (
-            self.params_already_reduced[param_id] == False
-        ), f"The parameter {param_id} has already been reduced. \
+        assert self.params_already_reduced[param_id] == False, \
+            f"The parameter {param_id} has already been reduced. \
             Gradient computed twice for this partition. \
             Multiple gradient reduction is currently not supported"
 
@@ -1154,22 +978,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.extra_large_param_to_reduce = param
             else:
                 # keeping the gradients contiguous to prevent memory fragmentation, and avoid flattening
-                new_grad_tensor = self.ipg_buffer[self.ipg_index].narrow(
-                    0, self.elements_in_ipg_bucket, param.numel()
-                )
+                new_grad_tensor = self.ipg_buffer[self.ipg_index].narrow(0, self.elements_in_ipg_bucket, param.numel())
                 new_grad_tensor.copy_(grad_reduc.view(-1))
                 grad_reduc.data = new_grad_tensor.data.view_as(grad_reduc)
 
         self.elements_in_ipg_bucket += param.numel()
 
-        assert (
-            grad_reduc is not None
-        ), f"rank {dist.get_rank()} - Invalid to reduce Param {param_id} with None gradient"
+        assert grad_reduc is not None, f"rank {dist.get_rank()} - Invalid to reduce Param {param_id} with None gradient"
 
         self.grads_in_ipg_bucket.append(grad_reduc)
         self.params_in_ipg_bucket.append((i, param.param_idx_in_group, param_id))
 
-        # make sure the average tensor function knows how to average the gradients
+        #make sure the average tensor function knows how to average the gradients
         if is_moe_param(param):
             self.ipg_bucket_has_moe_params = True
 
@@ -1192,50 +1012,35 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         if self.postscale_gradients:
             if self.gradient_predivide_factor != 1.0:
-                tensor_to_allreduce.mul_(1.0 / self.gradient_predivide_factor)
+                tensor_to_allreduce.mul_(1. / self.gradient_predivide_factor)
 
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
 
             if self.gradient_predivide_factor != dp_world_size:
-                tensor_to_allreduce.mul_(
-                    self.gradient_predivide_factor
-                    / (dp_world_size / float(self.sequence_parallel_size))
-                )
+                tensor_to_allreduce.mul_(self.gradient_predivide_factor /
+                                         (dp_world_size / float(self.sequence_parallel_size)))
         else:
             tensor_to_allreduce.div_(dp_world_size / float(self.sequence_parallel_size))
             dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
 
-        if (
-            self.communication_data_type != tensor.dtype
-            and tensor is not tensor_to_allreduce
-        ):
+        if self.communication_data_type != tensor.dtype and tensor is not tensor_to_allreduce:
             tensor.copy_(tensor_to_allreduce)
 
         return tensor
 
-    def allreduce_and_copy_with_multiple_ranks(
-        self, small_bucket, log=None, divide=True, process_group=None, bucket_ranks=None
-    ):
-        process_group = (
-            self.dp_process_group if process_group is None else process_group
-        )
-        allreduced = self.allreduce_bucket(
-            small_bucket, log=log, divide=divide, process_group=process_group
-        )
-        for buf, synced, bucket_rank in zip(
-            small_bucket, self.unflatten(allreduced, small_bucket), bucket_ranks
-        ):
+    def allreduce_and_copy_with_multiple_ranks(self,
+                                               small_bucket,
+                                               log=None,
+                                               divide=True,
+                                               process_group=None,
+                                               bucket_ranks=None):
+        process_group = self.dp_process_group if process_group is None else process_group
+        allreduced = self.allreduce_bucket(small_bucket, log=log, divide=divide, process_group=process_group)
+        for buf, synced, bucket_rank in zip(small_bucket, self.unflatten(allreduced, small_bucket), bucket_ranks):
             if dist.get_rank(group=process_group) == bucket_rank:
                 buf.copy_(synced)
 
-    def allreduce_and_scatter(
-        self,
-        bucket,
-        numel_per_bucket=500000000,
-        log=None,
-        divide=True,
-        process_group=None,
-    ):
+    def allreduce_and_scatter(self, bucket, numel_per_bucket=500000000, log=None, divide=True, process_group=None):
         small_bucket = []
         small_bucket_ranks = []
         numel = 0
@@ -1247,25 +1052,21 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             small_bucket_ranks.append(rank)
             numel = numel + tensor.numel()
             if numel > numel_per_bucket:
-                self.allreduce_and_copy_with_multiple_ranks(
-                    small_bucket,
-                    log=None,
-                    divide=divide,
-                    process_group=process_group,
-                    bucket_ranks=small_bucket_ranks,
-                )
+                self.allreduce_and_copy_with_multiple_ranks(small_bucket,
+                                                            log=None,
+                                                            divide=divide,
+                                                            process_group=process_group,
+                                                            bucket_ranks=small_bucket_ranks)
                 small_bucket = []
                 small_bucket_ranks = []
                 numel = 0
 
         if len(small_bucket) > 0:
-            self.allreduce_and_copy_with_multiple_ranks(
-                small_bucket,
-                log=None,
-                divide=divide,
-                process_group=process_group,
-                bucket_ranks=small_bucket_ranks,
-            )
+            self.allreduce_and_copy_with_multiple_ranks(small_bucket,
+                                                        log=None,
+                                                        divide=divide,
+                                                        process_group=process_group,
+                                                        bucket_ranks=small_bucket_ranks)
 
     def average_tensor(self, tensor):
         if self.overlap_comm:
@@ -1298,19 +1099,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 process_group = self.dp_process_group
 
                 if self.ipg_bucket_has_moe_params:
-                    process_group = (
-                        self.expert_dp_process_group[param.group_name]
-                        if is_moe_param(param)
-                        else self.dp_process_group
-                    )
+                    process_group = self.expert_dp_process_group[param.group_name] if is_moe_param(
+                        param) else self.dp_process_group
 
                 partition_ids = self.param_to_partition_ids[i][param_id]
-                assert all(
-                    [
-                        p_id < dist.get_world_size(group=process_group)
-                        for p_id in partition_ids
-                    ]
-                ), f"world size {dist.get_world_size(group=process_group)} and p_ids: {partition_ids}"
+                assert all([p_id < dist.get_world_size(group=process_group) for p_id in partition_ids
+                            ]), f"world size {dist.get_world_size(group=process_group)} and p_ids: {partition_ids}"
                 partition_size = self.partition_size[i]
                 # Get all partition ids + their offsets
                 partition_ids_w_offsets = []
@@ -1345,19 +1139,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     curr_size += numel
                     prev_id, prev_process_group = partition_id, process_group
 
-            tensor.div_(
-                dist.get_world_size(group=self.dp_process_group)
-                / float(self.sequence_parallel_size)
-            )
+            tensor.div_(dist.get_world_size(group=self.dp_process_group) / float(self.sequence_parallel_size))
 
             buckets = {}
             for i, (dst, bucket_offset, numel) in enumerate(rank_and_offsets):
                 grad_slice = tensor.narrow(0, int(bucket_offset), int(numel))
-                bucket_key = (
-                    real_dp_process_group[i]
-                    if self.use_multi_rank_bucket_allreduce
-                    else (dst, real_dp_process_group[i])
-                )
+                bucket_key = real_dp_process_group[i] if self.use_multi_rank_bucket_allreduce else (
+                    dst, real_dp_process_group[i])
                 if bucket_key not in buckets:
                     buckets[bucket_key] = []
                 if self.use_multi_rank_bucket_allreduce:
@@ -1367,21 +1155,17 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             for bucket_key in buckets:
                 if self.use_multi_rank_bucket_allreduce:
-                    self.allreduce_and_scatter(
-                        buckets[bucket_key],
-                        numel_per_bucket=self.reduce_bucket_size,
-                        divide=False,
-                        process_group=bucket_key,
-                    )
+                    self.allreduce_and_scatter(buckets[bucket_key],
+                                               numel_per_bucket=self.reduce_bucket_size,
+                                               divide=False,
+                                               process_group=bucket_key)
                 else:
                     dst, process_group = bucket_key
-                    self.allreduce_no_retain(
-                        buckets[bucket_key],
-                        numel_per_bucket=self.reduce_bucket_size,
-                        rank=dst,
-                        divide=False,
-                        process_group=process_group,
-                    )
+                    self.allreduce_no_retain(buckets[bucket_key],
+                                             numel_per_bucket=self.reduce_bucket_size,
+                                             rank=dst,
+                                             divide=False,
+                                             process_group=process_group)
 
     ##############################################################################
     ############################# CPU Offload Methods#############################
@@ -1406,10 +1190,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 num_elements = partition_size - current_offset
 
             self.grad_position[param_id] = [
-                int(group_id),
-                int(param_start_offset),
-                int(current_offset),
-                int(num_elements),
+                int(group_id), int(param_start_offset),
+                int(current_offset), int(num_elements)
             ]
             current_offset += num_elements
 
@@ -1424,11 +1206,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for lp_param in self.params_in_partition[param_group_index]:
                 param_id = self.get_param_id(lp_param)
                 [_, _, dest_offset, num_elements] = self.grad_position[param_id]
-                dest_tensor = (
-                    self.single_partition_of_fp32_groups[param_group_index]
-                    .grad.view(-1)
-                    .narrow(0, dest_offset, num_elements)
-                )
+                dest_tensor = self.single_partition_of_fp32_groups[param_group_index].grad.view(-1).narrow(
+                    0, dest_offset, num_elements)
                 self.offload_gradient_dict[param_group_index].append(dest_tensor)
 
     def async_accumulate_grad_in_cpu_via_gpu(self, param):
@@ -1437,56 +1216,38 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 
         # copy to a preexisiting buffer to avoid memory allocation penalty
-        dest_buffer = self.temp_grad_buffer_for_gpu_offload.view(-1).narrow(
-            0, 0, param.numel()
-        )
+        dest_buffer = self.temp_grad_buffer_for_gpu_offload.view(-1).narrow(0, 0, param.numel())
 
-        # buffer for storing gradients for this parameter in CPU
+        #buffer for storing gradients for this parameter in CPU
         def buffer_to_accumulate_to_in_cpu():
             if not self.fp16_master_weights_and_gradients:
-                buffer = torch.zeros(
-                    param.numel(), dtype=param.dtype, device=self.device
-                )
-                return (
-                    get_accelerator().pin_memory(buffer)
-                    if self.cpu_offload_pin_memory
-                    else buffer
-                )
+                buffer = torch.zeros(param.numel(), dtype=param.dtype, device=self.device)
+                return get_accelerator().pin_memory(buffer) if self.cpu_offload_pin_memory else buffer
             else:
-                return (
-                    self.single_partition_of_fp32_groups[i]
-                    .grad.view(-1)
-                    .narrow(0, dest_offset, num_elements)
-                )
+                return self.single_partition_of_fp32_groups[i].grad.view(-1).narrow(0, dest_offset, num_elements)
 
-        # accumulate gradients into param.grad_accum or parts of it that belongs to this partition
+        #accumulate gradients into param.grad_accum or parts of it that belongs to this partition
         def accumulate_gradients():
             grad_accum = self.get_param_gradient_attribute(param)
             if not self.fp16_master_weights_and_gradients:
-                dest_buffer.copy_(
-                    self.accumulated_grads_in_cpu[param_id].view(-1), non_blocking=True
-                )
+                dest_buffer.copy_(self.accumulated_grads_in_cpu[param_id].view(-1), non_blocking=True)
                 grad_accum.data.view(-1).add_(dest_buffer)
             else:
-                dest_buffer.narrow(0, source_offset, num_elements).copy_(
-                    self.accumulated_grads_in_cpu[param_id].view(-1), non_blocking=True
-                )
-                grad_accum.data.view(-1).narrow(0, source_offset, num_elements).add_(
-                    dest_buffer.narrow(0, source_offset, num_elements)
-                )
+                dest_buffer.narrow(0, source_offset,
+                                   num_elements).copy_(self.accumulated_grads_in_cpu[param_id].view(-1),
+                                                       non_blocking=True)
+                grad_accum.data.view(-1).narrow(0, source_offset,
+                                                num_elements).add_(dest_buffer.narrow(0, source_offset, num_elements))
 
-        # move accumulated gradients back to CPU
+        #move accumulated gradients back to CPU
         def copy_gradients_to_cpu():
             grad_accum = self.get_param_gradient_attribute(param)
             if not self.fp16_master_weights_and_gradients:
-                self.accumulated_grads_in_cpu[param_id].data.copy_(
-                    grad_accum.data.view(-1), non_blocking=True
-                )
+                self.accumulated_grads_in_cpu[param_id].data.copy_(grad_accum.data.view(-1), non_blocking=True)
             else:
-                self.accumulated_grads_in_cpu[param_id].data.copy_(
-                    grad_accum.data.view(-1).narrow(0, source_offset, num_elements),
-                    non_blocking=True,
-                )
+                self.accumulated_grads_in_cpu[param_id].data.copy_(grad_accum.data.view(-1).narrow(
+                    0, source_offset, num_elements),
+                                                                   non_blocking=True)
 
         if param_id not in self.accumulated_grads_in_cpu:
             self.accumulated_grads_in_cpu[param_id] = buffer_to_accumulate_to_in_cpu()
@@ -1499,11 +1260,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def set_norm_for_param_grad(self, param):
         param_id = self.get_param_id(param)
         grad_accum = self.get_param_gradient_attribute(param)
-        accumulated_grad = (
-            self.accumulated_grads_in_cpu[param_id]
-            if self.gradient_accumulation_steps > 1
-            else grad_accum
-        )
+        accumulated_grad = self.accumulated_grads_in_cpu[
+            param_id] if self.gradient_accumulation_steps > 1 else grad_accum
 
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 
@@ -1532,11 +1290,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 
-        dest_tensor = (
-            self.single_partition_of_fp32_groups[i]
-            .grad.view(-1)
-            .narrow(0, dest_offset, num_elements)
-        )
+        dest_tensor = self.single_partition_of_fp32_groups[i].grad.view(-1).narrow(0, dest_offset, num_elements)
 
         grad_accum = self.get_param_gradient_attribute(param)
         if grad_accum is None:
@@ -1547,7 +1301,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             src_tensor = src_tensor.float()
 
         dest_tensor.copy_(src_tensor, non_blocking=True)
-        param.grad = None  # offload only
+        param.grad = None  #offload only
 
     def complete_grad_norm_calculation_for_cpu_offload(self, params):
         total_norm = 0.0
@@ -1564,7 +1318,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 # so they have no norm_for_param_grads
                 if param_id in self.norm_for_param_grads:
                     param_norm = self.norm_for_param_grads[param_id]
-                    total_norm += param_norm.item() ** 2
+                    total_norm += param_norm.item()**2
                 else:
                     # As unused parameters in modules may not be expected sometimes,
                     # add an explicit error msg when it occurred and an option to
@@ -1580,19 +1334,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         # Sum across all model parallel GPUs.
         total_norm_cuda = get_accelerator().FloatTensor([float(total_norm)])
-        dist.all_reduce(
-            total_norm_cuda, op=dist.ReduceOp.SUM, group=self.dp_process_group
-        )
+        dist.all_reduce(total_norm_cuda, op=dist.ReduceOp.SUM, group=self.dp_process_group)
 
         self._model_parallel_all_reduce(tensor=total_norm_cuda, op=dist.ReduceOp.SUM)
 
-        total_norm = total_norm_cuda[0].item() ** (1.0 / norm_type)
+        total_norm = total_norm_cuda[0].item()**(1. / norm_type)
 
-        if (
-            total_norm == float("inf")
-            or total_norm == -float("inf")
-            or total_norm != total_norm
-        ):
+        if total_norm == float('inf') or total_norm == -float('inf') or total_norm != total_norm:
             total_norm = -1
 
         return total_norm
@@ -1612,7 +1360,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.async_inplace_copy_grad_to_fp32_buffer_from_gpu(param)
 
             return
-        # print(f"ID {self.get_param_id(param)} grad norm {param.grad.norm()}")
+        #print(f"ID {self.get_param_id(param)} grad norm {param.grad.norm()}")
         if self.grads_in_partition is None:
             self.grads_in_partition_offset = 0
             total_size = 0
@@ -1621,50 +1369,35 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     total_size += param_in_partition.numel()
 
             see_memory_usage(f"before copying {total_size} gradients into partition")
-            self.grads_in_partition = torch.empty(
-                int(total_size),
-                dtype=self.dtype,
-                device=get_accelerator().current_device_name(),
-            )
+            self.grads_in_partition = torch.empty(int(total_size),
+                                                  dtype=self.dtype,
+                                                  device=get_accelerator().current_device_name())
             see_memory_usage(f"after copying {total_size} gradients into partition")
 
         grad_reduc = self.get_gradient_for_reduction(param)
         # The allreduce buffer will be rewritten. Copy the gradients in partition to a new buffer
-        new_grad_tensor = self.grads_in_partition.view(-1).narrow(
-            0, self.grads_in_partition_offset, param.numel()
-        )
+        new_grad_tensor = self.grads_in_partition.view(-1).narrow(0, self.grads_in_partition_offset, param.numel())
         new_grad_tensor.copy_(grad_reduc.view(-1))
         grad_reduc.data = new_grad_tensor.data.view_as(grad_reduc)
-        # print(f"Grad norm after copy to contiguous_buffer {param.grad.data.norm()}")
+        #print(f"Grad norm after copy to contiguous_buffer {param.grad.data.norm()}")
         self.grads_in_partition_offset += param.numel()
 
     def reduce_ipg_grads(self):
         if self.contiguous_gradients:
             if self.extra_large_param_to_reduce is not None:
-                assert (
-                    len(self.params_in_ipg_bucket) == 1
-                ), "more than 1 param in ipg bucket, this shouldn't happen"
+                assert len(self.params_in_ipg_bucket) == 1, "more than 1 param in ipg bucket, this shouldn't happen"
                 _, _, param_id = self.params_in_ipg_bucket[0]
-                assert (
-                    self.get_param_id(self.extra_large_param_to_reduce) == param_id
-                ), "param in ipg bucket does not match extra-large param"
-                extra_large_grad_reduc = self.get_gradient_for_reduction(
-                    self.extra_large_param_to_reduce
-                )
+                assert self.get_param_id(self.extra_large_param_to_reduce
+                                         ) == param_id, "param in ipg bucket does not match extra-large param"
+                extra_large_grad_reduc = self.get_gradient_for_reduction(self.extra_large_param_to_reduce)
                 self.average_tensor(extra_large_grad_reduc.view(-1))
                 self.extra_large_param_to_reduce = None
             else:
-                self.average_tensor(
-                    self.ipg_buffer[self.ipg_index].narrow(
-                        0, 0, self.elements_in_ipg_bucket
-                    )
-                )
+                self.average_tensor(self.ipg_buffer[self.ipg_index].narrow(0, 0, self.elements_in_ipg_bucket))
         else:
-            self.buffered_reduce_fallback(
-                None,
-                self.grads_in_ipg_bucket,
-                elements_per_buffer=self.elements_in_ipg_bucket,
-            )
+            self.buffered_reduce_fallback(None,
+                                          self.grads_in_ipg_bucket,
+                                          elements_per_buffer=self.elements_in_ipg_bucket)
 
         if self.overlap_comm:
             stream = self.reduction_stream
@@ -1680,9 +1413,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for group_idx, param_idx_in_group, param_id in self.params_in_ipg_bucket:
                 param = self.bit16_groups[group_idx][param_idx_in_group]
 
-                assert (
-                    self.params_already_reduced[param_id] == False
-                ), f"The parameter {param_id} has already been reduced. \
+                assert self.params_already_reduced[param_id] == False, \
+                    f"The parameter {param_id} has already been reduced. \
                     Gradient computed twice for this partition. \
                     Multiple gradient reduction is currently not supported"
 
@@ -1700,10 +1432,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     elif self.contiguous_gradients:
                         self.copy_grads_in_partition(param)
                 else:  # zero stage 1 - partition only optimizer state
-                    if (
-                        self.contiguous_gradients
-                        and self.is_param_in_current_partition[param_id]
-                    ):
+                    if self.contiguous_gradients and self.is_param_in_current_partition[param_id]:
                         self.copy_grads_in_partition(param)
 
         self.grads_in_ipg_bucket = []
@@ -1749,30 +1478,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             grad = self.param_dict[key].grad
             total_elements = grad.numel()
             start = self.grad_start_offset[i][partition_id][key]
-            num_elements = min(
-                total_elements - start,
-                self.partition_size[i]
-                - self.grad_partition_insertion_offset[i][partition_id][key],
-            )
+            num_elements = min(total_elements - start,
+                               self.partition_size[i] - self.grad_partition_insertion_offset[i][partition_id][key])
             if not pg_correctness_test:
                 if num_elements == total_elements:
                     return grad
                 else:
-                    return (
-                        grad.contiguous()
-                        .view(-1)
-                        .narrow(0, int(start), int(num_elements))
-                    )
+                    return grad.contiguous().view(-1).narrow(0, int(start), int(num_elements))
             else:
                 if num_elements == total_elements:
                     return grad.clone()
                 else:
-                    return (
-                        grad.clone()
-                        .contiguous()
-                        .view(-1)
-                        .narrow(0, int(start), int(num_elements))
-                    )
+                    return grad.clone().contiguous().view(-1).narrow(0, int(start), int(num_elements))
 
         grads_to_reduce = []
         for key in self.is_grad_computed[i][partition_id]:
@@ -1797,14 +1514,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 param.grad = torch.zeros_like(param)
 
     ######################Reduction Related Methods##############################
-    def allreduce_bucket(
-        self, bucket, rank=None, log=None, divide=True, process_group=None
-    ):
+    def allreduce_bucket(self, bucket, rank=None, log=None, divide=True, process_group=None):
         tensor = self.flatten(bucket)
 
-        process_group = (
-            self.dp_process_group if process_group is None else process_group
-        )
+        process_group = self.dp_process_group if process_group is None else process_group
 
         tensor_to_allreduce = tensor
 
@@ -1817,10 +1530,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             tensor_to_allreduce = tensor.to(communication_data_type)
 
         if divide:
-            tensor_to_allreduce.div_(
-                dist.get_world_size(group=process_group)
-                / float(self.sequence_parallel_size)
-            )
+            tensor_to_allreduce.div_(dist.get_world_size(group=process_group) / float(self.sequence_parallel_size))
 
         if rank is None:
             #    "All Reducing"
@@ -1829,10 +1539,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             global_rank = dist.get_global_rank(process_group, rank)
             dist.reduce(tensor_to_allreduce, global_rank, group=process_group)
 
-        if (
-            communication_data_type != tensor.dtype
-            and tensor is not tensor_to_allreduce
-        ):
+        if communication_data_type != tensor.dtype and tensor is not tensor_to_allreduce:
             if rank is None or rank == dist.get_rank(group=process_group):
                 tensor.copy_(tensor_to_allreduce)
 
@@ -1845,12 +1552,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.previous_reduced_grads = None
 
     # if rank is specified do a reduction instead of an allreduce
-    def allreduce_and_copy(
-        self, small_bucket, rank=None, log=None, divide=True, process_group=None
-    ):
-        process_group = (
-            self.dp_process_group if process_group is None else process_group
-        )
+    def allreduce_and_copy(self, small_bucket, rank=None, log=None, divide=True, process_group=None):
+        process_group = self.dp_process_group if process_group is None else process_group
         if self.overlap_comm:
             if not get_accelerator().resolves_data_dependency():
                 get_accelerator().synchronize()
@@ -1869,9 +1572,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 process_group=process_group,
             )
             if rank is None or rank == dist.get_rank(group=self.dp_process_group):
-                for buf, synced in zip(
-                    small_bucket, self.unflatten(allreduced, small_bucket)
-                ):
+                for buf, synced in zip(small_bucket, self.unflatten(allreduced, small_bucket)):
                     buf.copy_(synced)
 
     def allreduce_no_retain(
@@ -1889,36 +1590,20 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             small_bucket.append(tensor)
             numel = numel + tensor.numel()
             if numel > numel_per_bucket:
-                self.allreduce_and_copy(
-                    small_bucket,
-                    rank=rank,
-                    log=None,
-                    divide=divide,
-                    process_group=process_group,
-                )
+                self.allreduce_and_copy(small_bucket, rank=rank, log=None, divide=divide, process_group=process_group)
                 small_bucket = []
                 numel = 0
 
         if len(small_bucket) > 0:
-            self.allreduce_and_copy(
-                small_bucket,
-                rank=rank,
-                log=log,
-                divide=divide,
-                process_group=process_group,
-            )
+            self.allreduce_and_copy(small_bucket, rank=rank, log=log, divide=divide, process_group=process_group)
 
     # allows using reduction of gradients instead of using all_reduce
 
-    def buffered_reduce_fallback(
-        self, rank, grads, elements_per_buffer=500000000, log=None
-    ):
+    def buffered_reduce_fallback(self, rank, grads, elements_per_buffer=500000000, log=None):
         split_buckets = split_half_float_double(grads)
 
         for i, bucket in enumerate(split_buckets):
-            self.allreduce_no_retain(
-                bucket, numel_per_bucket=elements_per_buffer, rank=rank, log=log
-            )
+            self.allreduce_no_retain(bucket, numel_per_bucket=elements_per_buffer, rank=rank, log=log)
 
     #############################################################################
     #############################################################################
@@ -1966,9 +1651,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             elif current_index < start_index < (current_index + tensor_size):
                 params_in_partition.append(tensor)
 
-                assert (
-                    first_offset == 0
-                ), "This can happen either zero or only once as this must be the first tensor in the partition"
+                assert (first_offset == 0
+                        ), "This can happen either zero or only once as this must be the first tensor in the partition"
                 first_offset = start_index - current_index
 
             else:
@@ -1996,7 +1680,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         p.grad.zero_()
 
     def _model_parallel_all_reduce(self, tensor, op):
-        """Perform all reduce within model parallel group, if any."""
+        """ Perform all reduce within model parallel group, if any.
+        """
         if self.model_parallel_group is None or self.model_parallel_world_size == 1:
             pass
         else:
@@ -2025,9 +1710,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             for g in gradients:
                 all_norms.append(g.data.abs().max().float())
             total_norm = torch.stack(all_norms).max()
-            dist.all_reduce(
-                total_norm, op=dist.ReduceOp.MAX, group=self.dp_process_group
-            )
+            dist.all_reduce(total_norm, op=dist.ReduceOp.MAX, group=self.dp_process_group)
 
             # Take max across all GPUs.
             self._model_parallel_all_reduce(tensor=total_norm, op=dist.ReduceOp.MAX)
@@ -2040,22 +1723,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     continue
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
                     all_norms.append(
-                        torch.linalg.vector_norm(
-                            g.data.double().detach(), ord=norm_type
-                        ).to(get_accelerator().current_device_name())
-                    )
+                        torch.linalg.vector_norm(g.data.double().detach(),
+                                                 ord=norm_type).to(get_accelerator().current_device_name()))
             if len(all_norms) > 0:
                 total_norm = torch.stack(all_norms).square().sum().float()
             else:
                 total_norm = torch.tensor(0.0, dtype=torch.float32).to(self.device)
             # Sum across all model parallel Device.
-            dist.all_reduce(
-                total_norm, op=dist.ReduceOp.SUM, group=self.dp_process_group
-            )
+            dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=self.dp_process_group)
 
             self._model_parallel_all_reduce(tensor=total_norm, op=dist.ReduceOp.SUM)
 
-            total_norm = total_norm.pow(1.0 / norm_type)
+            total_norm = total_norm.pow(1. / norm_type)
 
         mask_nan_or_inf_with_val_inplace(total_norm, device=self.device)
 
@@ -2064,15 +1743,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     # creates a flat fused tensor from the tensor list starting at the first_offset
     # in the first tensor of the list. If there are not enough elements in the tensor
     # list then the flat tensor will be padded with zeros
-    def get_flat_partition(
-        self,
-        tensor_list,
-        first_offset,
-        partition_size,
-        dtype,
-        device,
-        return_tensor_list=False,
-    ):
+    def get_flat_partition(self, tensor_list, first_offset, partition_size, dtype, device, return_tensor_list=False):
         flat_tensor_list = []
         current_size = 0
 
@@ -2097,11 +1768,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             # we need a narrow view of the tensor based on the tensor offset and number of elements that
             # we need from this tensor
             if tensor_offset > 0 or num_elements < tensor.numel():
-                flat_tensor_list.append(
-                    tensor.contiguous()
-                    .view(-1)
-                    .narrow(0, int(tensor_offset), int(num_elements))
-                )
+                flat_tensor_list.append(tensor.contiguous().view(-1).narrow(0, int(tensor_offset), int(num_elements)))
             else:
                 flat_tensor_list.append(tensor)
 
@@ -2109,11 +1776,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         # this means its the last partition and does not align with the dp boundary. We need to pad before flattening
         if current_size < partition_size:
-            flat_tensor_list.append(
-                torch.zeros(
-                    int(partition_size - current_size), dtype=dtype, device=device
-                )
-            )
+            flat_tensor_list.append(torch.zeros(int(partition_size - current_size), dtype=dtype, device=device))
 
         if return_tensor_list:
             return flat_tensor_list
@@ -2140,9 +1803,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def override_loss_scale(self, loss_scale):
         if loss_scale != self.external_loss_scale:
-            logger.info(
-                f"[deepspeed] setting loss scale from {self.external_loss_scale} -> {loss_scale}"
-            )
+            logger.info(f'[deepspeed] setting loss scale from {self.external_loss_scale} -> {loss_scale}')
         self.custom_loss_scaler = True
         self.external_loss_scale = loss_scale
 
@@ -2153,19 +1814,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if self.cpu_offload:
                 # complete complete_grad_norm_calculation_for_cpu_offload return python float, moving back to
                 # torch.tensor as else statement returns tensor as well
-                norm = torch.tensor(
-                    self.complete_grad_norm_calculation_for_cpu_offload(
-                        self.params_in_partition[i]
-                    ),
-                    device=self.device,
-                )
+                norm = torch.tensor(self.complete_grad_norm_calculation_for_cpu_offload(self.params_in_partition[i]),
+                                    device=self.device)
                 norm_groups.append(norm)
             else:
-                norm_groups.append(
-                    self.get_grad_norm_direct(
-                        self.averaged_gradients[i], self.params_in_partition[i]
-                    )
-                )
+                norm_groups.append(self.get_grad_norm_direct(self.averaged_gradients[i], self.params_in_partition[i]))
 
         if self.has_moe_layers:
             self._average_expert_grad_norms(norm_groups)
@@ -2176,18 +1829,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def get_bit16_param_group(self, group_no):
         bit16_partitions = self.parallel_partitioned_bit16_groups[group_no]
         partition_id = dist.get_rank(group=self.real_dp_process_group[group_no])
-        return [
-            bit16_partitions[dist.get_rank(group=self.real_dp_process_group[group_no])]
-        ]
+        return [bit16_partitions[dist.get_rank(group=self.real_dp_process_group[group_no])]]
 
     def _optimizer_step(self, group_no):
         original_param_groups = self.optimizer.param_groups
         self.optimizer.param_groups = [original_param_groups[group_no]]
         # Disabling this as the C++ side copy & synchronize is not working correctly
-        # from deepspeed.ops.adam import DeepSpeedCPUAdam
-        # if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
+        #from deepspeed.ops.adam import DeepSpeedCPUAdam
+        #if type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half:
         #    self.optimizer.step(fp16_param_groups=[self.get_bit16_param_group(group_no)])
-        # else:
+        #else:
         #    self.optimizer.step()
         self.optimizer.step()
         self.optimizer.param_groups = original_param_groups
@@ -2210,14 +1861,14 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         prev_scale = self.loss_scale
         self._update_scale(self.overflow)
         if self.overflow:
-            see_memory_usage("After overflow before clearing gradients")
+            see_memory_usage('After overflow before clearing gradients')
             self.zero_grad(set_to_none=True)
             if self.cpu_offload:
                 self.reset_cpu_buffers()
             else:
                 self.averaged_gradients = {}
 
-            see_memory_usage("After overflow after clearing gradients")
+            see_memory_usage('After overflow after clearing gradients')
 
             for timer in OPTIMIZER_TIMERS:
                 self.timers(timer).start()
@@ -2225,10 +1876,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             return
 
         # Step 1:- Calculate gradient norm using bit-16 grads
-        see_memory_usage("Before norm calculation")
+        see_memory_usage('Before norm calculation')
         scaled_global_grad_norm = self.scaled_global_norm()
         self._global_grad_norm = scaled_global_grad_norm / prev_scale
-        see_memory_usage("After norm before optimizer")
+        see_memory_usage('After norm before optimizer')
 
         # Step 2:- run optimizer and upscaling simultaneously
         for i, group in enumerate(self.bit16_groups):
@@ -2236,29 +1887,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             if self.cpu_offload:
                 single_grad_partition = self.single_partition_of_fp32_groups[i].grad
-                self.unscale_and_clip_grads(
-                    [single_grad_partition], scaled_global_grad_norm
-                )
+                self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
 
                 self.timers(OPTIMIZER_GRADIENTS_TIMER).stop()
                 self.timers(OPTIMIZER_STEP_TIMER).start()
                 self._optimizer_step(i)
 
                 # Disabled, this is not currently working
-                # from deepspeed.ops.adam import DeepSpeedCPUAdam
-                # if not (type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half):
+                #from deepspeed.ops.adam import DeepSpeedCPUAdam
+                #if not (type(self.optimizer) == DeepSpeedCPUAdam and self.dtype == torch.half):
                 #    bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 #    fp32_partition = self.single_partition_of_fp32_groups[i]
                 #    bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 bit16_partitions = self.parallel_partitioned_bit16_groups[i]
                 fp32_partition = self.single_partition_of_fp32_groups[i]
-                bit16_partition_buffer = (
-                    self.param_buffer_of_bit16_for_cpu_offload_groups[i]
-                )
+                bit16_partition_buffer = self.param_buffer_of_bit16_for_cpu_offload_groups[i]
                 bit16_partition_buffer.data.copy_(fp32_partition.data)
-                bit16_partitions[partition_id].data.copy_(
-                    bit16_partition_buffer.data, non_blocking=True
-                )
+                bit16_partitions[partition_id].data.copy_(bit16_partition_buffer.data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:
@@ -2267,25 +1912,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
                 # create a flat gradients for parameters updated by this process
                 # If we are last partition, ensure we have same size grads and partition size, if not pad with zero tensors
-                if (
-                    partition_id
-                    == dist.get_world_size(group=self.real_dp_process_group[i]) - 1
-                ):
+                if partition_id == dist.get_world_size(group=self.real_dp_process_group[i]) - 1:
                     single_grad_partition = self.flatten_dense_tensors_aligned(
-                        self.averaged_gradients[i], int(self.partition_size[i])
-                    ).to(self.single_partition_of_fp32_groups[i].dtype)
+                        self.averaged_gradients[i],
+                        int(self.partition_size[i])).to(self.single_partition_of_fp32_groups[i].dtype)
                 else:
                     single_grad_partition = self.flatten(self.averaged_gradients[i]).to(
-                        self.single_partition_of_fp32_groups[i].dtype
-                    )
-                assert (
-                    single_grad_partition.numel() == self.partition_size[i]
-                ), "averaged gradients have different number of elements that partition size {} {} {} {}".format(
-                    single_grad_partition.numel(),
-                    self.partition_size[i],
-                    i,
-                    partition_id,
-                )
+                        self.single_partition_of_fp32_groups[i].dtype)
+                assert single_grad_partition.numel() == self.partition_size[i], \
+                    "averaged gradients have different number of elements that partition size {} {} {} {}".format(
+                        single_grad_partition.numel(), self.partition_size[i], i, partition_id)
 
                 self.single_partition_of_fp32_groups[i].grad = single_grad_partition
                 # release all the gradient since we have already created a necessary copy in dp_grad_partition(ZeRO stage2)
@@ -2293,9 +1929,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
                 self.averaged_gradients[i] = None
 
-                self.unscale_and_clip_grads(
-                    [single_grad_partition], scaled_global_grad_norm
-                )
+                self.unscale_and_clip_grads([single_grad_partition], scaled_global_grad_norm)
 
                 self.timers(OPTIMIZER_GRADIENTS_TIMER).stop()
 
@@ -2310,20 +1944,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 bit16_partitions[partition_id].data.copy_(fp32_partition.data)
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
 
-        see_memory_usage("After optimizer before all-gather")
+        see_memory_usage('After optimizer before all-gather')
         if self.cpu_offload:
             self.reset_cpu_buffers()
 
         self.timers(OPTIMIZER_ALLGATHER_TIMER).start()
         # Gather the updated weights from everyone.
         # Then all partitions of the model parameters are updated and ready for next round forward.
-        all_gather_dp_groups(
-            groups_flat=self.bit16_groups_flat,
-            partitioned_param_groups=self.parallel_partitioned_bit16_groups,
-            dp_process_group=self.real_dp_process_group,
-            start_alignment_factor=self.nccl_start_alignment_factor,
-            allgather_bucket_size=self.allgather_bucket_size,
-        )
+        all_gather_dp_groups(groups_flat=self.bit16_groups_flat,
+                             partitioned_param_groups=self.parallel_partitioned_bit16_groups,
+                             dp_process_group=self.real_dp_process_group,
+                             start_alignment_factor=self.nccl_start_alignment_factor,
+                             allgather_bucket_size=self.allgather_bucket_size)
         self.timers(OPTIMIZER_ALLGATHER_TIMER).stop()
 
         # TODO: we probably don't need this? just to be safe
@@ -2331,48 +1963,36 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self._update_model_bit16_weights(i)
 
         self.timers.log(OPTIMIZER_TIMERS)
-        see_memory_usage("After zero_optimizer step")
+        see_memory_usage('After zero_optimizer step')
 
         return
 
     @torch.no_grad()
     def update_lp_params(self):
         for i, (bit16_partitions, fp32_partition) in enumerate(
-            zip(
-                self.parallel_partitioned_bit16_groups,
-                self.single_partition_of_fp32_groups,
-            )
-        ):
+                zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups)):
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
             bit16_partitions[partition_id].data.copy_(fp32_partition.data)
 
-        all_gather_dp_groups(
-            groups_flat=self.bit16_groups_flat,
-            partitioned_param_groups=self.parallel_partitioned_bit16_groups,
-            dp_process_group=self.real_dp_process_group,
-            start_alignment_factor=self.nccl_start_alignment_factor,
-            allgather_bucket_size=self.allgather_bucket_size,
-        )
+        all_gather_dp_groups(groups_flat=self.bit16_groups_flat,
+                             partitioned_param_groups=self.parallel_partitioned_bit16_groups,
+                             dp_process_group=self.real_dp_process_group,
+                             start_alignment_factor=self.nccl_start_alignment_factor,
+                             allgather_bucket_size=self.allgather_bucket_size)
 
     def _average_expert_grad_norms(self, norm_groups):
         for i, norm in enumerate(norm_groups):
             if self.is_moe_param_group[i]:
-                scaled_norm_tensor = (
-                    norm
-                    * 1.0
-                    / dist.get_world_size(group=self.real_dp_process_group[i])
-                )
-                if self.device == "cpu":
-                    scaled_norm_tensor = scaled_norm_tensor.to(
-                        get_accelerator().current_device_name()
-                    )
+                scaled_norm_tensor = norm * 1.0 / dist.get_world_size(group=self.real_dp_process_group[i])
+                if self.device == 'cpu':
+                    scaled_norm_tensor = scaled_norm_tensor.to(get_accelerator().current_device_name())
                 dist.all_reduce(scaled_norm_tensor, group=self.real_dp_process_group[i])
                 norm_groups[i] = scaled_norm_tensor.to(self.device)
 
     def unscale_and_clip_grads(self, grad_groups_flat, total_norm):
         # compute combined scale factor for this group
         combined_scale = self.loss_scale
-        if self.clip_grad > 0.0:
+        if self.clip_grad > 0.:
             # norm is in fact norm*scale
             clip = ((total_norm / self.loss_scale) + 1e-6) / self.clip_grad
             clip = torch.clamp(clip, min=1.0)
@@ -2382,27 +2002,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if isinstance(grad, list):
                 sub_partitions = grad
                 for g in sub_partitions:
-                    g.data.mul_(1.0 / combined_scale)
+                    g.data.mul_(1. / combined_scale)
             else:
-                grad.data.mul_(1.0 / combined_scale)
+                grad.data.mul_(1. / combined_scale)
 
     def _check_overflow(self, partition_gradients=True):
         self.overflow = self.has_overflow(partition_gradients)
 
     # `params` is a list / generator of torch.Variable
     def has_overflow_serial(self, params):
-        invalid_grad_count = torch.zeros(
-            [1], dtype=torch.float, device=get_accelerator().current_device_name()
-        )
+        invalid_grad_count = torch.zeros([1], dtype=torch.float, device=get_accelerator().current_device_name())
         for p in params:
             if p.grad is not None:
                 invalid_grad_count += self._has_inf_or_nan(p.grad)
         return invalid_grad_count.bool()
 
     def has_overflow_partitioned_grads_serial(self):
-        invalid_grad_count = torch.zeros(
-            [1], dtype=torch.float, device=get_accelerator().current_device_name()
-        )
+        invalid_grad_count = torch.zeros([1], dtype=torch.float, device=get_accelerator().current_device_name())
         for i in range(len(self.bit16_groups)):
             for j, grad in enumerate(self.averaged_gradients[i]):
                 if grad is not None:
@@ -2411,32 +2027,19 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def has_overflow(self, partition_gradients=True):
         if partition_gradients:
-            overflow = (
-                self.local_overflow
-                if self.cpu_offload
-                else self.has_overflow_partitioned_grads_serial()
-            )
-            overflow_gpu = (
-                get_accelerator().ByteTensor([overflow])
-                if self.cpu_offload
-                else overflow.byte().to(get_accelerator().current_device_name())
-            )
-            """This will capture overflow across all data parallel and expert parallel process
-            Since expert parallel process are a subset of data parallel process"""
-            dist.all_reduce(
-                overflow_gpu, op=dist.ReduceOp.MAX, group=self.dp_process_group
-            )
+            overflow = self.local_overflow if self.cpu_offload else self.has_overflow_partitioned_grads_serial()
+            overflow_gpu = get_accelerator().ByteTensor([overflow]) if self.cpu_offload else overflow.byte().to(
+                get_accelerator().current_device_name())
+            '''This will capture overflow across all data parallel and expert parallel process
+            Since expert parallel process are a subset of data parallel process'''
+            dist.all_reduce(overflow_gpu, op=dist.ReduceOp.MAX, group=self.dp_process_group)
 
         else:
             params = []
             for group in self.bit16_groups:
                 for param in group:
                     params.append(param)
-            overflow_gpu = (
-                self.has_overflow_serial(params)
-                .byte()
-                .to(get_accelerator().current_device_name())
-            )
+            overflow_gpu = self.has_overflow_serial(params).byte().to(get_accelerator().current_device_name())
 
         # Since each model parallel GPU carries only part of the model,
         # make sure overflow flag is synced across all the model parallel GPUs
@@ -2459,20 +2062,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             self.micro_step_id += 1
             if self.contiguous_gradients and self.ipg_buffer is None:
                 self.ipg_buffer = []
-                buf_0 = torch.empty(
-                    int(self.reduce_bucket_size),
-                    dtype=self.dtype,
-                    device=get_accelerator().current_device_name(),
-                )
+                buf_0 = torch.empty(int(self.reduce_bucket_size),
+                                    dtype=self.dtype,
+                                    device=get_accelerator().current_device_name())
                 self.ipg_buffer.append(buf_0)
 
                 # Use double buffers to avoid data access conflict when overlap_comm is enabled.
                 if self.overlap_comm:
-                    buf_1 = torch.empty(
-                        int(self.reduce_bucket_size),
-                        dtype=self.dtype,
-                        device=get_accelerator().current_device_name(),
-                    )
+                    buf_1 = torch.empty(int(self.reduce_bucket_size),
+                                        dtype=self.dtype,
+                                        device=get_accelerator().current_device_name())
                     self.ipg_buffer.append(buf_1)
                 self.ipg_index = 0
             self.ready_for_gradients = True
@@ -2563,10 +2162,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def _get_base_optimizer_state(self):
         optimizer_groups_state = []
         for i, group in enumerate(self.optimizer.param_groups):
-            p = group["params"][0]
-            lean_optimizer_state = self._get_state_without_padding(
-                self.optimizer.state[p], self.groups_padding[i]
-            )
+            p = group['params'][0]
+            lean_optimizer_state = self._get_state_without_padding(self.optimizer.state[p], self.groups_padding[i])
             optimizer_groups_state.append(lean_optimizer_state)
 
         return optimizer_groups_state
@@ -2584,8 +2181,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         """
         state_dict = {}
         state_dict[LOSS_SCALER] = self.loss_scaler
-        state_dict["dynamic_loss_scale"] = self.dynamic_loss_scale
-        state_dict["overflow"] = self.overflow
+        state_dict['dynamic_loss_scale'] = self.dynamic_loss_scale
+        state_dict['overflow'] = self.overflow
         state_dict[CLIP_GRAD] = self.clip_grad
 
         if self.elastic_checkpoint:
@@ -2593,27 +2190,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             if "step" in self.optimizer.param_groups[0]:
                 # Assuming "step" is the only item that changes through training iterations
-                assert all(
-                    group["step"] == self.optimizer.param_groups[0]["step"]
-                    for group in self.optimizer.param_groups
-                ), "All param groups must have the same step value"
-                state_dict[BASE_OPTIMIZER_STATE_STEP] = self.optimizer.param_groups[0][
-                    "step"
-                ]
+                assert all(group["step"] == self.optimizer.param_groups[0]["step"]
+                           for group in self.optimizer.param_groups), "All param groups must have the same step value"
+                state_dict[BASE_OPTIMIZER_STATE_STEP] = self.optimizer.param_groups[0]["step"]
         else:
             state_dict[BASE_OPTIMIZER_STATE] = self.optimizer.state_dict()
 
         # Remove paddings for DP alignment to enable loading for other alignment values
-        fp32_groups_without_padding = self._get_groups_without_padding(
-            self.single_partition_of_fp32_groups
-        )
+        fp32_groups_without_padding = self._get_groups_without_padding(self.single_partition_of_fp32_groups)
         state_dict[SINGLE_PARTITION_OF_FP32_GROUPS] = fp32_groups_without_padding
 
-        state_dict[ZERO_STAGE] = (
-            ZeroStageEnum.gradients
-            if self.partition_gradients
-            else ZeroStageEnum.optimizer_states
-        )
+        state_dict[
+            ZERO_STAGE] = ZeroStageEnum.gradients if self.partition_gradients else ZeroStageEnum.optimizer_states
         state_dict[GROUP_PADDINGS] = self.groups_padding
         state_dict[PARTITION_COUNT] = self.partition_count
 
@@ -2631,35 +2219,23 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         for i in range(len(self.single_partition_of_fp32_groups)):
             partition_id = dist.get_rank(group=self.real_dp_process_group[i])
-            merged_partitions = [
-                sd[SINGLE_PARTITION_OF_FP32_GROUPS][i] for sd in all_state_dict
-            ]
+            merged_partitions = [sd[SINGLE_PARTITION_OF_FP32_GROUPS][i] for sd in all_state_dict]
             if self.is_moe_group(self.optimizer.param_groups[i]):
-                ranks = self.get_ep_ranks(
-                    group_name=self.optimizer.param_groups[i]["name"]
-                )
+                ranks = self.get_ep_ranks(group_name=self.optimizer.param_groups[i]['name'])
                 merged_partitions = [merged_partitions[i] for i in ranks]
             flat_merged_partitions = self.flatten_dense_tensors_aligned(
                 merged_partitions,
-                self.nccl_start_alignment_factor
-                * dist.get_world_size(group=self.real_dp_process_group[i]),
-            )
+                self.nccl_start_alignment_factor * dist.get_world_size(group=self.real_dp_process_group[i]))
             dp_partitions = self.get_data_parallel_partitions(flat_merged_partitions, i)
             merged_single_partition_of_fp32_groups.append(dp_partitions[partition_id])
 
-        for current, saved in zip(
-            self.single_partition_of_fp32_groups, merged_single_partition_of_fp32_groups
-        ):
+        for current, saved in zip(self.single_partition_of_fp32_groups, merged_single_partition_of_fp32_groups):
             current.data.copy_(saved.data)
 
     # Restore base optimizer fp32 weights from ZeRO fp16 or bfloat16 weights
     def _restore_from_bit16_weights(self):
         for group_id, (bit16_partitions, fp32_partition) in enumerate(
-            zip(
-                self.parallel_partitioned_bit16_groups,
-                self.single_partition_of_fp32_groups,
-            )
-        ):
+                zip(self.parallel_partitioned_bit16_groups, self.single_partition_of_fp32_groups)):
             partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
             fp32_partition.data.copy_(bit16_partitions[partition_id].data)
 
@@ -2668,20 +2244,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self._restore_from_bit16_weights()
 
     # Extract optimizer state for current partition from merged states of all partitions
-    def _partition_base_optimizer_state(
-        self, state_key, all_partition_states, group_id
-    ):
+    def _partition_base_optimizer_state(self, state_key, all_partition_states, group_id):
         partition_id = dist.get_rank(group=self.real_dp_process_group[group_id])
-        alignment = self.nccl_start_alignment_factor * dist.get_world_size(
-            group=self.real_dp_process_group[group_id]
-        )
+        alignment = self.nccl_start_alignment_factor * dist.get_world_size(group=self.real_dp_process_group[group_id])
         if torch.is_tensor(all_partition_states[0]):
-            flat_merged_partitions = self.flatten_dense_tensors_aligned(
-                all_partition_states, alignment
-            )
-            dp_partitions = self.get_data_parallel_partitions(
-                flat_merged_partitions, group_id
-            )
+            flat_merged_partitions = self.flatten_dense_tensors_aligned(all_partition_states, alignment)
+            dp_partitions = self.get_data_parallel_partitions(flat_merged_partitions, group_id)
             return dp_partitions[partition_id]
         else:
             # Assume non-tensor states are not partitioned and equal across ranks, so return first one
@@ -2689,23 +2257,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def _restore_step_from_elastic_checkpoint(self, all_state_dict):
         assert BASE_OPTIMIZER_STATE_STEP in all_state_dict[0]
-        assert all(
-            sd[BASE_OPTIMIZER_STATE_STEP]
-            == all_state_dict[0][BASE_OPTIMIZER_STATE_STEP]
-            for sd in all_state_dict
-        ), "State dicts of all partitions must have the same step value"
+        assert all(sd[BASE_OPTIMIZER_STATE_STEP] == all_state_dict[0][BASE_OPTIMIZER_STATE_STEP]
+                   for sd in all_state_dict), "State dicts of all partitions must have the same step value"
         return all_state_dict[0][BASE_OPTIMIZER_STATE_STEP]
 
-    def _restore_base_optimizer_state(
-        self, base_optimizer_group_states, base_optimizer_state_step, group_paddings
-    ):
+    def _restore_base_optimizer_state(self, base_optimizer_group_states, base_optimizer_state_step, group_paddings):
         if type(base_optimizer_group_states) == dict:
-            base_optimizer_group_states = base_optimizer_group_states["state"]
+            base_optimizer_group_states = base_optimizer_group_states['state']
 
         saved_keys = base_optimizer_group_states[0].keys()
 
         for i, group in enumerate(self.optimizer.param_groups):
-            p = group["params"][0]
+            p = group['params'][0]
             padding = 0 if group_paddings is None else group_paddings[i]
             for key in saved_keys:
                 saved = base_optimizer_group_states[i][key]
@@ -2717,20 +2280,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         self.optimizer.state[p][key].data.copy_(src_tensor.data)
                     else:
                         self.optimizer.state[p][key] = _pad_tensor_by_size(
-                            saved,
-                            padding,
-                            torch.float32,
-                            torch.device("cpu") if self.cpu_offload else self.device,
-                        )
+                            saved, padding, torch.float32,
+                            torch.device('cpu') if self.cpu_offload else self.device)
                 else:
                     self.optimizer.state[p][key] = saved
 
         for param_group in self.optimizer.param_groups:
-            param_group["step"] = base_optimizer_state_step
+            param_group['step'] = base_optimizer_state_step
 
     def get_ep_ranks(self, rank=0, group_name=None):
         from deepspeed.utils import groups
-
         expert_parallel_size_ = groups._get_expert_parallel_world_size(group_name)
         world_size = groups._get_data_parallel_world_size()
         rank = groups._get_expert_parallel_rank(group_name)
@@ -2745,62 +2304,39 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         base_optimizer_group_states = []
         for i in range(len(self.optimizer.param_groups)):
             partition_states = {}
-            all_partition_group_states = [
-                sd[BASE_OPTIMIZER_STATE][i] for sd in all_state_dict
-            ]
+            all_partition_group_states = [sd[BASE_OPTIMIZER_STATE][i] for sd in all_state_dict]
 
             if self.is_moe_group(self.optimizer.param_groups[i]):
-                ranks = self.get_ep_ranks(
-                    group_name=self.optimizer.param_groups[i]["name"]
-                )
-                all_partition_group_states = [
-                    all_partition_group_states[i] for i in ranks
-                ]
+                ranks = self.get_ep_ranks(group_name=self.optimizer.param_groups[i]['name'])
+                all_partition_group_states = [all_partition_group_states[i] for i in ranks]
 
             for key in all_partition_group_states[0].keys():
-                all_partition_states = [
-                    all_states[key] for all_states in all_partition_group_states
-                ]
-                partition_states[key] = self._partition_base_optimizer_state(
-                    key, all_partition_states, i
-                )
+                all_partition_states = [all_states[key] for all_states in all_partition_group_states]
+                partition_states[key] = self._partition_base_optimizer_state(key, all_partition_states, i)
             base_optimizer_group_states.append(partition_states)
 
-        self._restore_base_optimizer_state(
-            base_optimizer_group_states,
-            self._restore_step_from_elastic_checkpoint(all_state_dict),
-            None,
-        )
+        self._restore_base_optimizer_state(base_optimizer_group_states,
+                                           self._restore_step_from_elastic_checkpoint(all_state_dict), None)
 
-    def load_state_dict(
-        self,
-        state_dict_list,
-        load_optimizer_states=True,
-        load_from_fp32_weights=False,
-        checkpoint_folder=None,
-        load_serial=None,
-        param_shapes=None,
-    ):
+    def load_state_dict(self,
+                        state_dict_list,
+                        load_optimizer_states=True,
+                        load_from_fp32_weights=False,
+                        checkpoint_folder=None,
+                        load_serial=None,
+                        param_shapes=None):
         if checkpoint_folder:
-            self._load_universal_checkpoint(
-                checkpoint_folder, load_optimizer_states, load_from_fp32_weights
-            )
+            self._load_universal_checkpoint(checkpoint_folder, load_optimizer_states, load_from_fp32_weights)
         else:
-            self._load_legacy_checkpoint(
-                state_dict_list, load_optimizer_states, load_from_fp32_weights
-            )
+            self._load_legacy_checkpoint(state_dict_list, load_optimizer_states, load_from_fp32_weights)
 
-    def _load_universal_checkpoint(
-        self, checkpoint_folder, load_optimizer_states, load_from_fp32_weights
-    ):
-        self.load_hp_checkpoint_state_from_checkpoint_dir(
-            "bit16_groups", checkpoint_folder
-        )
+    def _load_universal_checkpoint(self, checkpoint_folder, load_optimizer_states, load_from_fp32_weights):
+        self.load_hp_checkpoint_state_from_checkpoint_dir("bit16_groups", checkpoint_folder)
 
     def _load_global_state(self, sd):
         self.loss_scaler = sd.get(LOSS_SCALER, self.loss_scaler)
-        self.dynamic_loss_scale = sd.get("dynamic_loss_scale", self.dynamic_loss_scale)
-        self.overflow = sd.get("overflow", self.overflow)
+        self.dynamic_loss_scale = sd.get('dynamic_loss_scale', self.dynamic_loss_scale)
+        self.overflow = sd.get('overflow', self.overflow)
         self.clip_grad = sd.get(CLIP_GRAD, self.clip_grad)
 
         ckpt_version = sd.get(DS_VERSION, False)
@@ -2810,18 +2346,12 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # zero stage 1 mode
         if not self.partition_gradients:
             required_version = pkg_version.parse("0.3.17")
-            error_str = (
-                f"ZeRO stage 1 changed in {required_version} and is not backwards compatible "
-                "with older stage 1 checkpoints. If you'd like to load an old ZeRO-1 checkpoint "
+            error_str = f"ZeRO stage 1 changed in {required_version} and is not backwards compatible " \
+                "with older stage 1 checkpoints. If you'd like to load an old ZeRO-1 checkpoint " \
                 "please use an older version of DeepSpeed (<= 0.5.8) and set 'legacy_stage1': true in your zero config json."
-            )
-            assert (
-                required_version <= ckpt_version
-            ), f"Old version: {ckpt_version} {error_str}"
+            assert required_version <= ckpt_version, f"Old version: {ckpt_version} {error_str}"
 
-    def _load_legacy_checkpoint(
-        self, state_dict_list, load_optimizer_states=True, load_from_fp32_weights=False
-    ):
+    def _load_legacy_checkpoint(self, state_dict_list, load_optimizer_states=True, load_from_fp32_weights=False):
         r"""Loading ZeRO checkpoint
 
         Arguments:
@@ -2875,11 +2405,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     self._restore_elastic_base_optimizer_state(state_dict_list)
                 else:
                     # loading an elastic checkpoint into rigid exec
-                    self._restore_base_optimizer_state(
-                        current_rank_sd[BASE_OPTIMIZER_STATE],
-                        current_rank_sd[BASE_OPTIMIZER_STATE_STEP],
-                        current_rank_sd[GROUP_PADDINGS],
-                    )
+                    self._restore_base_optimizer_state(current_rank_sd[BASE_OPTIMIZER_STATE],
+                                                       current_rank_sd[BASE_OPTIMIZER_STATE_STEP],
+                                                       current_rank_sd[GROUP_PADDINGS])
 
         # At this point, the optimizer's references to the model's fp32 parameters are up to date.
         # The optimizer's hyperparameters and internal buffers are also up to date.
@@ -2902,10 +2430,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self._restore_from_elastic_fp32_weights(state_dict_list)
             else:
                 # For non-elastic checkpoint, simply copying from saved weights of current rank is sufficient.
-                for current, saved in zip(
-                    self.single_partition_of_fp32_groups,
-                    current_rank_sd[SINGLE_PARTITION_OF_FP32_GROUPS],
-                ):
+                for current, saved in zip(self.single_partition_of_fp32_groups,
+                                          current_rank_sd[SINGLE_PARTITION_OF_FP32_GROUPS]):
                     src_tensor = _get_padded_tensor(saved, current.numel())
                     current.data.copy_(src_tensor.data)
         else:
@@ -2918,7 +2444,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
 def _handle_overflow(cpu_sum, x, i):
     import math
-
     rank = dist.get_rank()
     if rank == 0:
         t_i = -1
@@ -2926,18 +2451,14 @@ def _handle_overflow(cpu_sum, x, i):
             if not math.isfinite(float(v)):
                 t_i = v_i
                 break
-        logger.info(
-            f"rank {rank} detected overflow {cpu_sum} in tensor {i}:{t_i} shape {x.shape}"
-        )
+        logger.info(f"rank {rank} detected overflow {cpu_sum} in tensor {i}:{t_i} shape {x.shape}")
 
 
-def estimate_zero2_model_states_mem_needs(
-    total_params,
-    num_gpus_per_node=1,
-    num_nodes=1,
-    cpu_offload=True,
-    additional_buffer_factor=1.5,
-):
+def estimate_zero2_model_states_mem_needs(total_params,
+                                          num_gpus_per_node=1,
+                                          num_nodes=1,
+                                          cpu_offload=True,
+                                          additional_buffer_factor=1.5):
 
     total_gpus = num_nodes * num_gpus_per_node
 
@@ -2955,15 +2476,14 @@ def estimate_zero2_model_states_mem_needs(
 
 def model_to_params(model):
     # shared params calculated only once
-    total_params = sum(
-        dict((p.data_ptr(), p.numel()) for p in model.parameters()).values()
-    )
+    total_params = sum(dict((p.data_ptr(), p.numel()) for p in model.parameters()).values())
     return total_params
 
 
-def estimate_zero2_model_states_mem_needs_all_live(
-    model, num_gpus_per_node=1, num_nodes=1, additional_buffer_factor=1.5
-):
+def estimate_zero2_model_states_mem_needs_all_live(model,
+                                                   num_gpus_per_node=1,
+                                                   num_nodes=1,
+                                                   additional_buffer_factor=1.5):
     """
     Print out estimates on memory usage requirements for ZeRO 2 params, optim states and gradients
     for a given ``model`` and hardware setup.
@@ -2984,17 +2504,16 @@ def estimate_zero2_model_states_mem_needs_all_live(
 
     total_params = model_to_params(model)
 
-    estimate_zero2_model_states_mem_needs_all_cold(
-        total_params=total_params,
-        num_gpus_per_node=num_gpus_per_node,
-        num_nodes=num_nodes,
-        additional_buffer_factor=additional_buffer_factor,
-    )
+    estimate_zero2_model_states_mem_needs_all_cold(total_params=total_params,
+                                                   num_gpus_per_node=num_gpus_per_node,
+                                                   num_nodes=num_nodes,
+                                                   additional_buffer_factor=additional_buffer_factor)
 
 
-def estimate_zero2_model_states_mem_needs_all_cold(
-    total_params, num_gpus_per_node=1, num_nodes=1, additional_buffer_factor=1.5
-):
+def estimate_zero2_model_states_mem_needs_all_cold(total_params,
+                                                   num_gpus_per_node=1,
+                                                   num_nodes=1,
+                                                   additional_buffer_factor=1.5):
     """
     Print out estimates on memory usage requirements for ZeRO 2 params, optim states and gradients
     for a given ``model`` and hardware setup.
@@ -3015,26 +2534,22 @@ def estimate_zero2_model_states_mem_needs_all_cold(
 
     def format_options(cpu_offload):
         enabled = []
-        device = f"{OffloadDeviceEnum.cpu:4}" if cpu_offload else "none"
+        device = f'{OffloadDeviceEnum.cpu:4}' if cpu_offload else "none"
         enabled.append(f"offload_optimizer={device}")
         return ", ".join(enabled)
 
     nodes_str = "nodes" if num_nodes > 1 else "node"
     gpus_str = "GPUs" if num_gpus_per_node > 1 else "GPU"
-    print(
-        "Estimated memory needed for params, optim states and gradients for a:\n"
-        f"HW: Setup with {num_nodes} {nodes_str}, {num_gpus_per_node} {gpus_str} per node.\n"
-        f"SW: Model with {int(total_params/1e6)}M total params."
-    )
+    print("Estimated memory needed for params, optim states and gradients for a:\n"
+          f"HW: Setup with {num_nodes} {nodes_str}, {num_gpus_per_node} {gpus_str} per node.\n"
+          f"SW: Model with {int(total_params/1e6)}M total params.")
     print("  per CPU  |  per GPU |   Options")
     for cpu_offload in [True, False]:
-        cpu_mem, gpu_mem = estimate_zero2_model_states_mem_needs(
-            total_params=total_params,
-            num_gpus_per_node=num_gpus_per_node,
-            num_nodes=num_nodes,
-            cpu_offload=cpu_offload,
-            additional_buffer_factor=additional_buffer_factor,
-        )
+        cpu_mem, gpu_mem = estimate_zero2_model_states_mem_needs(total_params=total_params,
+                                                                 num_gpus_per_node=num_gpus_per_node,
+                                                                 num_nodes=num_nodes,
+                                                                 cpu_offload=cpu_offload,
+                                                                 additional_buffer_factor=additional_buffer_factor)
 
         options_str = format_options(cpu_offload=cpu_offload)
         print(f" {cpu_mem/2**30:7.2f}GB | {gpu_mem/2**30:6.2f}GB | {options_str}")

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1904,7 +1904,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 bit16_partition_buffer = self.param_buffer_of_bit16_for_cpu_offload_groups[i]
                 bit16_partition_buffer.data.copy_(fp32_partition.data)
                 bit16_partitions[partition_id].data.copy_(
-                  bit16_partition_buffer.data, non_blocking=True)
+                    bit16_partition_buffer.data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1903,7 +1903,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 fp32_partition = self.single_partition_of_fp32_groups[i]
                 bit16_partition_buffer = self.param_buffer_of_bit16_for_cpu_offload_groups[i]
                 bit16_partition_buffer.data.copy_(fp32_partition.data)
-                bit16_partitions[partition_id].data.copy_(bit16_partition_buffer.data, non_blocking=True)
+                bit16_partitions[partition_id].data.copy_(
+                  bit16_partition_buffer.data, non_blocking=True)
 
                 self.timers(OPTIMIZER_STEP_TIMER).stop()
             else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -415,8 +415,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                                                fill_value=0.0,
                                                dtype=temp_dtype,
                                                device=weights_partition.device)
-                temp_pinned = get_accelerator().pin_memory(temp_buffer_bit16)
                 if self.cpu_offload_pin_memory:
+                    temp_pinned = get_accelerator().pin_memory(temp_buffer_bit16)
                     self.param_buffer_of_bit16_for_cpu_offload_groups.append(temp_pinned)
                 else:
                     self.param_buffer_of_bit16_for_cpu_offload_groups.append(temp_buffer_bit16)


### PR DESCRIPTION
Signed-off-by: Armin Zhu <mingzhengzhu1998@gmail.com>

Fix the memory usage of ZeRO-Offload with stage 1 and 2. Before the fix, the memory usage is about 3x that of params_FP16. This is caused by the H2D data copy is using different data type. Now the GPU memory usage is about 1x params_FP16. And the H2D memory copy needs a 16bit pinned memory buffer.