### PR TITLE
anchor transformers version

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -17,5 +17,5 @@ sphinx
 sphinx-rtd-theme
 tensorboard
 torchvision
-transformers>=4.39.0
+transformers>=4.51.3
 wandb

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,3 +9,4 @@ py-cpuinfo
 pydantic>=2.0.0
 torch
 tqdm
+transformers>=4.51.3


### PR DESCRIPTION
some features require minimal transformers versions so let's start anchoring.

and fixing tests that break with recent transformers.

I need this fixed to be able to merge https://github.com/deepspeedai/DeepSpeed/pull/7268 which requires `transformers>=4.51.3`