### PR TITLE
`tests/conftest.py`: automatically add local deepspeed repo when running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
 
 # allow having multiple repository checkouts and not needing to remember to rerun
 # 'pip install -e .[dev]' when switching between checkouts and running tests.
-git_repo_path = abspath(join(dirname(dirname(__file__)), "src"))
+git_repo_path = abspath(join(dirname(dirname(__file__)), "deepspeed"))
 sys.path.insert(1, git_repo_path)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@
 import sys
 import pytest
 import os
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname
 import torch
 import warnings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
 
 # allow having multiple repository checkouts and not needing to remember to rerun
 # 'pip install -e .[dev]' when switching between checkouts and running tests.
-git_repo_path = abspath(join(dirname(dirname(__file__)), "deepspeed"))
+git_repo_path = abspath(dirname(dirname(__file__)))
 sys.path.insert(1, git_repo_path)
 
 


### PR DESCRIPTION
This is a follow up to https://github.com/deepspeedai/DeepSpeed/pull/923

my original code was a copy from transformers, which has a different fs layout and I missed that. So this PR is fixing it to actually do the right thing.

Now you can have multiple clones of deepspeed and the tests will use the local repo automatically and not the pre-installed deepspeed.