### PR TITLE
UlyssesPlus Docs take 2

### DIFF
--- a/docs/_tutorials/ulysses-plus-sequence-pallellism.md
+++ b/docs/_tutorials/ulysses-plus-sequence-pallellism.md
@@ -12,11 +12,11 @@ tags: training, sequence-parallelism
 
 It enables training on 0.5M long sequences on a single H100 CPU and a 15M-long sequences on LLama-8B on four 8x H100 nodes.
 
-It's already fully integrated into Arctic Training, see: https://github.com/snowflakedb/ArcticTraining/blob/main/projects/sequence-parallelism/
+It's already fully integrated into Arctic Training, see [this guide](https://github.com/snowflakedb/ArcticTraining/blob/main/projects/sequence-parallelism/).
 
-The rest of the document explains how to integrated it into other frameworks or your own training loop.
+The rest of the document explains how to integrate it into other frameworks or your own training loop.
 
-There is another older version of UlyssesSP which only works with Megatron-Deepspeed and can be found here https://www.deepspeed.ai/tutorials/ds-sequence/
+There is another older version of UlyssesSP which only works with Megatron-Deepspeed and can be found [here](https://www.deepspeed.ai/tutorials/ds-sequence/)
 
 ## Part 1: Ulysses Sequence Parallelism for HF Transformers
 

--- a/docs/_tutorials/ulysses-plus-sequence-pallellism.md
+++ b/docs/_tutorials/ulysses-plus-sequence-pallellism.md
@@ -16,7 +16,7 @@ It's already fully integrated into Arctic Training, see [this guide](https://git
 
 The rest of the document explains how to integrate it into other frameworks or your own training loop.
 
-There is another older version of UlyssesSP which only works with Megatron-Deepspeed and can be found [here](https://www.deepspeed.ai/tutorials/ds-sequence/)
+There is another older version of UlyssesSP which only works with Megatron-Deepspeed and can be found [here](https://www.deepspeed.ai/tutorials/ds-sequence/).
 
 ## Part 1: Ulysses Sequence Parallelism for HF Transformers
 


### PR DESCRIPTION
bare md urls don't get automatically linked, so fixing that.