### PR TITLE
Update config_utils.py

### DIFF
--- a/deepspeed/runtime/config_utils.py
+++ b/deepspeed/runtime/config_utils.py
@@ -97,7 +97,7 @@ class DeepSpeedConfigModel(BaseModel):
                     raise e
 
     def _deprecated_fields_check(self):
-        fields = self.model_fields
+        fields = type(self).model_fields
         for field_name, field_info in fields.items():
             if field_info.json_schema_extra and field_info.json_schema_extra.get("deprecated", False):
                 self._process_deprecated_field(field_name)


### PR DESCRIPTION
Fixes this warning:

```
 /fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/deepspeed/runtime/config_utils.py:100: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    fields = self.model_fields
```