### PR TITLE
Fix pytest  version to 8.3.5 in hpu-gaudi actions

### DIFF
--- a/.github/workflows/hpu-gaudi2-nightly.yml
+++ b/.github/workflows/hpu-gaudi2-nightly.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip install .[dev,autotuning]
+          pip install pytest==8.3.5 # pin pytest to avoid issues with pytest 8.4.0
           ds_report
 
       - name: Python environment

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Install deepspeed
         run: |
           pip install .[dev,autotuning]
+          pip install pytest==8.3.5 # pin pytest to avoid issues with pytest 8.4.0
           ds_report
 
       - name: Python environment


### PR DESCRIPTION
This is needed to avoid the issue of ci failure in #7330 PR.