### PR TITLE
fix: fix FileNotFoundError for build_win.bat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,8 +203,12 @@ for op_name, builder in ALL_OPS.items():
 print(f'Install Ops={install_ops}')
 
 # Write out version/git info.
-git_hash_cmd = shlex.split("bash -c \"git rev-parse --short HEAD\"")
-git_branch_cmd = shlex.split("bash -c \"git rev-parse --abbrev-ref HEAD\"")
+if sys.platform == "win32":
+    git_hash_cmd = shlex.split("git rev-parse --short HEAD")
+    git_branch_cmd = shlex.split("git rev-parse --abbrev-ref HEAD")
+else:
+    git_hash_cmd = shlex.split("bash -c \"git rev-parse --short HEAD\"")
+    git_branch_cmd = shlex.split("bash -c \"git rev-parse --abbrev-ref HEAD\"")
 if command_exists('git') and not is_env_set('DS_BUILD_STRING'):
     try:
         result = subprocess.check_output(git_hash_cmd)


### PR DESCRIPTION
fix FileNotFoundError for build_win.bat

`FileNotFoundError: [WinError 2] 系统找不到指定的文件。ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel`