### PR TITLE
Improvements to Communication Logger

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -431,14 +431,159 @@ def monitored_barrier(group=None,
     return cdb.monitored_barrier(group=group, timeout=timeout, wait_all_ranks=wait_all_ranks)
 
 
-def log_summary(show_straggler=False):
+def log_summary(show_straggler=False, return_dict=False):
+    """
+    Print and/or return communication operation statistics across all ranks.
+
+    This function synchronizes all ranks and logs communication statistics.
+    Only rank 0 prints to console by default, but all ranks can return the dictionary.
+
+    Args:
+        show_straggler (bool, optional): Whether to include straggler effect analysis.
+            When True, computes the time difference between the fastest and slowest ranks
+            for each communication operation. Defaults to False.
+        return_dict (bool, optional): Whether to return statistics as a dictionary.
+            When True, returns a comprehensive dictionary with communication metrics.
+            Defaults to False.
+
+    Returns:
+        dict or None: If return_dict=True, returns communication statistics dictionary.
+        The structure is identical to CommsLogger.log_all() return value.
+        Returns None if return_dict=False.
+
+        Dictionary structure (when return_dict=True):
+        {
+            "summary": {
+                "operation_name": {
+                    message_size_bytes: {
+                        "count": int,
+                        "total_latency_ms": float,
+                        "avg_latency_ms": float,
+                        "tput_avg_gbps": float,
+                        "busbw_avg_gbps": float,
+                        "msg_size_bytes": int,
+                        "msg_size_str": str
+                    }
+                }
+            },
+            "straggler_analysis": {...} if show_straggler else None,
+            "metadata": {
+                "world_size": int,
+                "rank": int,
+                "timestamp": str
+            }
+        }
+
+    Note:
+        - This function includes barriers for synchronization across all ranks
+        - Straggler analysis requires additional all_reduce operations
+        - All ranks return the same data when return_dict=True
+        - Only rank 0 prints to console when print_log=True (default behavior)
+
+    Example:
+        # Print summary only (backward compatible)
+        deepspeed.comm.log_summary()
+
+        # Get dictionary and print summary
+        stats = deepspeed.comm.log_summary(return_dict=True)
+
+        # Include straggler analysis
+        stats = deepspeed.comm.log_summary(show_straggler=True, return_dict=True)
+
+        # Access specific operation data
+        if stats and "all_reduce" in stats["summary"]:
+            all_reduce_stats = stats["summary"]["all_reduce"]
+    """
     global cdb
     barrier(log_name='log_summary_barrier')
+
+    result = None
     if cdb.get_rank() == 0:
-        comms_logger.log_all(print_log=True, show_straggler=show_straggler)
+        result = comms_logger.log_all(print_log=True, show_straggler=show_straggler, return_dict=return_dict)
     else:
-        comms_logger.log_all(print_log=False, show_straggler=show_straggler)
+        # Non-rank-0 processes: don't print but may still return dict if requested
+        result = comms_logger.log_all(print_log=False, show_straggler=show_straggler, return_dict=return_dict)
+
     barrier(log_name='log_summary_barrier')
+    return result
+
+
+def reset_log():
+    """
+    Clear all accumulated communication logging data.
+
+    This function clears the communication logger's internal data dictionary,
+    allowing for epoch-by-epoch or interval-based logging. After calling this
+    function, subsequent log_summary() calls will only show statistics for
+    communication operations that occur after the reset.
+
+    Note:
+        - This affects the global communication logger
+        - All accumulated statistics will be lost
+        - This function is useful for getting per-epoch or per-interval statistics
+
+    Example:
+        # Training loop with per-epoch communication logging
+        for epoch in range(num_epochs):
+            # Reset logger at start of epoch
+            deepspeed.comm.reset_log()
+
+            # Train for one epoch
+            train_one_epoch(model, dataloader)
+
+            # Get communication stats for this epoch only
+            epoch_stats = deepspeed.comm.log_summary(return_dict=True)
+            print(f"Epoch {epoch} communication stats: {epoch_stats}")
+    """
+    global comms_logger
+    comms_logger.reset_data()
+
+
+def has_comm_data():
+    """
+    Check if any communication data has been logged.
+
+    Returns:
+        bool: True if communication operations have been logged, False otherwise
+
+    Example:
+        if deepspeed.comm.has_comm_data():
+            stats = deepspeed.comm.log_summary(return_dict=True)
+        else:
+            print("No communication operations logged yet")
+    """
+    global comms_logger
+    return comms_logger.has_data()
+
+
+def get_comm_operation_count():
+    """
+    Get the total number of communication operations logged.
+
+    Returns:
+        int: Total count of all communication operations across all types
+
+    Example:
+        total_ops = deepspeed.comm.get_comm_operation_count()
+        print(f"Total communication operations this epoch: {total_ops}")
+    """
+    global comms_logger
+    return comms_logger.get_total_operations()
+
+
+def get_logged_comm_ops():
+    """
+    Get list of communication operation types that have been logged.
+
+    Returns:
+        list: List of operation names that have been logged (e.g., ['all_reduce', 'broadcast'])
+
+    Example:
+        ops = deepspeed.comm.get_logged_comm_ops()
+        print(f"Communication operations used: {ops}")
+    """
+    global comms_logger
+    return comms_logger.get_operation_names()
 
 
 @timed_op
@@ -657,9 +802,9 @@ def init_distributed(dist_backend=None,
         distributed_port: Optional (int). torch distributed backend port
         verbose: Optional (bool). verbose logging
         timeout: Optional (timedelta). Timeout for operations executed against the process group. The default value of 30 minutes can be overridden by the environment variable `DEEPSPEED_TIMEOUT`.
-        init_method: Optional (string). Torch distributed, URL specifying how to initialize the process group. Default is “env://” if no init_method or store is specified.
+        init_method: Optional (string). Torch distributed, URL specifying how to initialize the process group. Default is "env://" if no init_method or store is specified.
         config: Optional (dict). DeepSpeed configuration for setting up comms options (e.g. Comms profiling)
-        rank: Optional (int). The current manually specified rank. Some init_method like “tcp://” need the rank and world_size as well (see: https://pytorch.org/docs/stable/distributed.html#tcp-initialization)
+        rank: Optional (int). The current manually specified rank. Some init_method like "tcp://" need the rank and world_size as well (see: https://pytorch.org/docs/stable/distributed.html#tcp-initialization)
         world_size: Optional (int). Desired world_size for the TCP or Shared file-system initialization.
     '''
     global cdb

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -96,6 +96,7 @@ class ProfilingInterpreter(Interpreter):
         args: inputs to the graph. Tensors in the inpusts must be real tensors, not fake tensors. args can contain ds parameters.
         returns: The output of the graph. Tensor in the output is real tensors.
         """
+        return_val = None
         try:
             assert _all_real_if_tensor(args), "Inputs must be real tensors"
             self.nz3.enable_profiling(True)
@@ -242,6 +243,7 @@ class MemoryProfilingInterpreter(Interpreter):
         self.debug_log = debug_log
 
     def run(self, *args) -> Any:
+        return_val = None
         try:
             assert _all_real_if_tensor(args), "Inputs must be real tensors"
             self.nz3.enable_profiling(True)

--- a/deepspeed/utils/comms_logging.py
+++ b/deepspeed/utils/comms_logging.py
@@ -128,6 +128,8 @@ class CommsLogger:
         from deepspeed.utils.timer import trim_mean
         import deepspeed.comm as dist
         from deepspeed.comm.reduce_op import ReduceOp
+        from deepspeed.accelerator import get_accelerator
+
         if print_log:
             print(
                 f"{'Comm. Op': <20}{'Message Size': <20}{'Count': <20}{'Total Latency(ms)': <20}{'Avg Latency(ms)': <20}{'tput_avg (Gbps)': <20}{'busbw_avg (Gbps)': <20}"
@@ -158,6 +160,7 @@ class CommsLogger:
                 print(
                     f"{'Comm. Op': <20}{'Message Size': <20}{'Count': <20}{'Total comm lat(ms)': <20}{'Total straggler(ms)': <20}{'Avg comm lat(ms)': <20}{'Avg straggler(ms)': <20}"
                 )
+            device = get_accelerator().current_device_name()
             for record_name in self.comms_dict.keys():
                 if print_log:
                     print(record_name)
@@ -165,8 +168,8 @@ class CommsLogger:
                     # vals[0] is the count for each msg size
                     count = vals[0]
                     # vals[1] is a list of latency records for each msg size
-                    lats = torch.tensor(vals[1])
-                    min_lats = torch.tensor(vals[1])
+                    lats = torch.tensor(vals[1], device=device)
+                    min_lats = torch.tensor(vals[1], device=device)
                     dist.all_reduce(min_lats, op=ReduceOp.MIN)
                     total_lat = min_lats.sum().item()
                     total_straggler = (lats - min_lats).sum().item()

--- a/deepspeed/utils/comms_logging.py
+++ b/deepspeed/utils/comms_logging.py
@@ -122,21 +122,174 @@ class CommsLogger:
             log_str = f"comm op: {record_name} | time (ms): {latency:.2f} | msg size: {convert_size(msg_size)} | algbw (Gbps): {algbw:.2f} | busbw (Gbps): {busbw:.2f}"
             log_dist(log_str, [0])
 
+    def get_raw_data(self):
+        """
+        Get the raw communication data dictionary.
+
+        Returns:
+            dict: Raw communication data in format {record_name: {msg_size: [count, [latencies], [algbws], [busbws]]}}
+        """
+        return self.comms_dict.copy()
+
+    def has_data(self):
+        """
+        Check if any communication data has been logged.
+
+        Returns:
+            bool: True if communication data exists, False otherwise
+        """
+        return len(self.comms_dict) > 0
+
+    def reset_data(self):
+        """
+        Clear all logged communication data.
+        """
+        self.comms_dict.clear()
+
+    def get_operation_names(self):
+        """
+        Get list of all logged communication operation names.
+
+        Returns:
+            list: List of operation names that have been logged
+        """
+        return list(self.comms_dict.keys())
+
+    def get_total_operations(self):
+        """
+        Get total number of communication operations logged across all types.
+
+        Returns:
+            int: Total count of operations
+        """
+        total = 0
+        for record_name in self.comms_dict:
+            for msg_size in self.comms_dict[record_name]:
+                total += self.comms_dict[record_name][msg_size][0]  # count is at index 0
+        return total
+
+    def get_operation_summary(self, operation_name):
+        """
+        Get summary statistics for a specific operation type.
+
+        Args:
+            operation_name (str): Name of the communication operation
+
+        Returns:
+            dict: Summary statistics for the operation, or None if operation not found
+        """
+        if operation_name not in self.comms_dict:
+            return None
+
+        from deepspeed.utils.timer import trim_mean
+
+        op_data = self.comms_dict[operation_name]
+        summary = {}
+
+        for msg_size, vals in op_data.items():
+            count = vals[0]
+            total_lat = sum(vals[1])
+            avg_lat = trim_mean(vals[1], 0.1)
+            avg_algbw = trim_mean(vals[2], 0.1)
+            avg_busbw = trim_mean(vals[3], 0.1)
+
+            summary[msg_size] = {
+                "count": count,
+                "total_latency_ms": total_lat,
+                "avg_latency_ms": avg_lat,
+                "tput_avg_gbps": avg_algbw,
+                "busbw_avg_gbps": avg_busbw,
+                "msg_size_bytes": msg_size,
+                "msg_size_str": convert_size(msg_size)
+            }
+
+        return summary
+
     # Print summary at end of iteration, epoch, or training
-    def log_all(self, print_log=True, show_straggler=False):
+    def log_all(self, print_log=True, show_straggler=False, return_dict=False):
+        """
+        Print and/or return communication operation statistics.
+
+        Args:
+            print_log (bool, optional): Whether to print the summary to console. Defaults to True.
+            show_straggler (bool, optional): Whether to include straggler effect analysis. Defaults to False.
+            return_dict (bool, optional): Whether to return statistics as a dictionary. Defaults to False.
+
+        Returns:
+            dict or None: If return_dict=True, returns a comprehensive dictionary with the following structure:
+            {
+                "summary": {
+                    "operation_name": {
+                        message_size_bytes: {
+                            "count": int,                    # Number of operations with this message size
+                            "total_latency_ms": float,      # Sum of all latencies for this message size
+                            "avg_latency_ms": float,        # Average latency (outliers trimmed)
+                            "tput_avg_gbps": float,         # Average algorithmic bandwidth in Gbps
+                            "busbw_avg_gbps": float,        # Average bus bandwidth in Gbps
+                            "msg_size_bytes": int,          # Message size in bytes
+                            "msg_size_str": str             # Human-readable message size (e.g., "678.86 MB")
+                        }
+                    }
+                },
+                "straggler_analysis": {                     # Only present if show_straggler=True
+                    "operation_name": {
+                        message_size_bytes: {
+                            "count": int,                    # Number of operations
+                            "total_comm_lat_ms": float,     # Total communication latency (min across ranks)
+                            "total_straggler_ms": float,    # Total straggler effect
+                            "avg_comm_lat_ms": float,       # Average communication latency
+                            "avg_straggler_ms": float,      # Average straggler effect
+                            "msg_size_bytes": int,          # Message size in bytes
+                            "msg_size_str": str             # Human-readable message size
+                        }
+                    }
+                } if show_straggler else None,
+                "metadata": {
+                    "world_size": int,                      # Number of processes in distributed setup
+                    "rank": int,                            # Current process rank
+                    "timestamp": str                        # ISO format timestamp when log_all was called
+                }
+            }
+
+            Returns None if return_dict=False.
+
+        Note:
+            - Statistics use trimmed mean (10% trimmed from both ends) to remove outliers
+            - Straggler analysis requires distributed communication and may impact performance
+            - All bandwidth values are in Gbps (Gigabits per second)
+            - Latency values are in milliseconds
+        """
         import torch
         from deepspeed.utils.timer import trim_mean
         import deepspeed.comm as dist
         from deepspeed.comm.reduce_op import ReduceOp
         from deepspeed.accelerator import get_accelerator
+        from datetime import datetime
+
+        # Initialize return dictionary structure
+        result_dict = {
+            "summary": {},
+            "straggler_analysis": None,
+            "metadata": {
+                "world_size": dist.get_world_size() if dist.is_initialized() else 1,
+                "rank": dist.get_rank() if dist.is_initialized() else 0,
+                "timestamp": datetime.now().isoformat()
+            }
+        } if return_dict else None
 
         if print_log:
             print(
                 f"{'Comm. Op': <20}{'Message Size': <20}{'Count': <20}{'Total Latency(ms)': <20}{'Avg Latency(ms)': <20}{'tput_avg (Gbps)': <20}{'busbw_avg (Gbps)': <20}"
             )
+
         for record_name in self.comms_dict.keys():
             if print_log:
                 print(record_name)
+
+            # Initialize operation entry in result dict
+            if return_dict:
+                result_dict["summary"][record_name] = {}
+
             for msg_size, vals in sorted(self.comms_dict[record_name].items()):
                 # vals[0] is the count for each msg size
                 count = vals[0]
@@ -147,12 +300,28 @@ class CommsLogger:
                 avg_lat = trim_mean(vals[1], 0.1)
                 avg_algbw = trim_mean(vals[2], 0.1)
                 avg_busbw = trim_mean(vals[3], 0.1)
+
+                # Store data in result dictionary
+                if return_dict:
+                    result_dict["summary"][record_name][msg_size] = {
+                        "count": count,
+                        "total_latency_ms": total_lat,
+                        "avg_latency_ms": avg_lat,
+                        "tput_avg_gbps": avg_algbw,
+                        "busbw_avg_gbps": avg_busbw,
+                        "msg_size_bytes": msg_size,
+                        "msg_size_str": convert_size(msg_size)
+                    }
+
                 if print_log:
                     print(
                         f"{' ': <20}{convert_size(msg_size): <20}{count: <20}{total_lat: <20.2f}{avg_lat: <20.2f}{avg_algbw: <20.2f}{avg_busbw: <20.2f}"
                     )
 
         if show_straggler:
+            if return_dict:
+                result_dict["straggler_analysis"] = {}
+
             if print_log:
                 print("_______________________________")
                 print("Breakdown with straggler effect")
@@ -160,10 +329,16 @@ class CommsLogger:
                 print(
                     f"{'Comm. Op': <20}{'Message Size': <20}{'Count': <20}{'Total comm lat(ms)': <20}{'Total straggler(ms)': <20}{'Avg comm lat(ms)': <20}{'Avg straggler(ms)': <20}"
                 )
+
             device = get_accelerator().current_device_name()
             for record_name in self.comms_dict.keys():
                 if print_log:
                     print(record_name)
+
+                # Initialize operation entry in straggler dict
+                if return_dict:
+                    result_dict["straggler_analysis"][record_name] = {}
+
                 for msg_size, vals in sorted(self.comms_dict[record_name].items()):
                     # vals[0] is the count for each msg size
                     count = vals[0]
@@ -175,7 +350,23 @@ class CommsLogger:
                     total_straggler = (lats - min_lats).sum().item()
                     avg_lat = trim_mean(min_lats.tolist(), 0.1)
                     avg_straggler = trim_mean((lats - min_lats).tolist(), 0.1)
+
+                    # Store straggler data in result dictionary
+                    if return_dict:
+                        result_dict["straggler_analysis"][record_name][msg_size] = {
+                            "count": count,
+                            "total_comm_lat_ms": total_lat,
+                            "total_straggler_ms": total_straggler,
+                            "avg_comm_lat_ms": avg_lat,
+                            "avg_straggler_ms": avg_straggler,
+                            "msg_size_bytes": msg_size,
+                            "msg_size_str": convert_size(msg_size)
+                        }
+
                     if print_log:
                         print(
                             f"{' ': <20}{convert_size(msg_size): <20}{count: <20}{total_lat: <20.2f}{total_straggler: <20.2f}{avg_lat: <20.2f}{avg_straggler: <20.2f}"
                         )
+
+        # Return the dictionary if requested
+        return result_dict if return_dict else None


### PR DESCRIPTION
These changes add
- ability to return communication logs as dictionaries, rather than only printing to stdout
- convenience helper functions for getting information about current logs
- ability to clear existing log operations
- additional documentation for logging operations

These address points made in #7403 