### PR TITLE
[BUGFIX] Reset `bucket.elements` after reduction in ZeRO Stage 3

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -1335,6 +1335,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             self.partition_grads(params_in_bucket, grad_partitions)
 
             params_in_bucket.clear()
+            bucket.elements = 0
 
             if not get_accelerator().handles_memory_backpressure():
                 event = get_accelerator().Event()


### PR DESCRIPTION
closes #7415 

# Description
Resets `bucket.elements` after reduction in ZeRO Stage 3.
Without this, the bucket grows indefinitely, reducing only one param at a time.
Added `bucket.elements = 0` after `params_in_bucket.clear()`.

