### PR TITLE
fix `deepspeed --venv_script`

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -101,7 +101,7 @@ class PDSHRunner(MultiNodeRunner):
             f"--master_port={self.args.master_port}"
         ]
         if self.args.venv_script is not None:
-            deepspeed_launch = [f"source {self.args.venv_script}"] + deepspeed_launch
+            deepspeed_launch = [f"source {self.args.venv_script}";] + deepspeed_launch
         if self.args.no_python:
             deepspeed_launch.append("--no_python")
         if self.args.module:


### PR DESCRIPTION
currently passing `--venv_script foo.sh` ends up with cmd like:

```
pdsh -S -f 1024 -w 10.4.11.15,10.4.10.1 source foo.sh export NCCL_NET_PLUGIN=blah; ...
```
you can see, `;` is missing. It should be:


```
pdsh -S -f 1024 -w 10.4.11.15,10.4.10.1 source foo.sh; export NCCL_NET_PLUGIN=blah; ...
```

This PR is fixing it.