### PR TITLE
Add index to HPU devices

### DIFF
--- a/accelerator/hpu_accelerator.py
+++ b/accelerator/hpu_accelerator.py
@@ -54,8 +54,9 @@ class HPU_Accelerator(DeepSpeedAccelerator):
         return True
 
     def device_name(self, device_index=None):
-        # ignoring device_index.
-        return 'hpu'
+        if device_index is None:
+            return self._name
+        return '{}:{}'.format(self._name, device_index)
 
     def device(self, device_index=None):
         return torch.device(self.device_name(device_index))


### PR DESCRIPTION
The [PR #7266](https://github.com/deepspeedai/DeepSpeed/pull/7266) enforces the devices having explicit device indices (i.e. 'hpu:0', 'cuda:0', etc).

This PR aligns HPU devices to the requirement.