### PR TITLE
fix `_disable_dynamo_if_unsupported` not found

### DIFF
--- a/deepspeed/ops/adam/zenflow_torch_adam.py
+++ b/deepspeed/ops/adam/zenflow_torch_adam.py
@@ -26,6 +26,15 @@ if _ZENFLOW_AVAILABLE:
         )
     except ImportError as e:
         print(f"[WARNING] ZenFlow disabled: torch internal optimizer symbols could not be imported: {e}")
+        # safe disable dynamo if unsupported
+        def _disable_dynamo_if_unsupported(**kwargs):
+    
+            def wrapper(fn):
+                return fn
+    
+            return wrapper
+    
+        _ZENFLOW_AVAILABLE = False
         _ZENFLOW_AVAILABLE = False
 else:
     # safe disable dynamo if unsupported


### PR DESCRIPTION
If torch > 2.1 and 
 `from torch.optim.optimizer import _disable_dynamo_if_unsupported` fails, we will have following error: 

```
[2025-08-21 17:42:31,780] [INFO] [real_accelerator.py:260:get_accelerator] Setting ds_accelerator to cuda (auto detect)
[WARNING] ZenFlow disabled: torch internal optimizer symbols could not be imported: cannot import name '_disable_dynamo_if_unsupported' from 'torch.optim.optimizer' (/usr/local/lib/python3.10/dist-packages/torch/optim/optimizer.py)
Traceback (most recent call last):
  File "/usr/local/bin/mmtrain", line 5, in <module>
    from multimolecule.apis.run import train
  File "/root/multimolecule/multimolecule/__init__.py", line 24, in <module>
    from .apis import evaluate, infer, train
  File "/root/multimolecule/multimolecule/apis/__init__.py", line 22, in <module>
    from .run import evaluate, infer, train
  File "/root/multimolecule/multimolecule/apis/run.py", line 31, in <module>
    import danling as dl
  File "/root/danling/danling/__init__.py", line 30, in <module>
    from .optim import OPTIMIZERS, SCHEDULERS, LRScheduler
  File "/root/danling/danling/optim/__init__.py", line 21, in <module>
    from .registry import OPTIMIZERS
  File "/root/danling/danling/optim/registry.py", line 30, in <module>
    import deepspeed as ds
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/__init__.py", line 25, in <module>
    from . import ops
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/ops/__init__.py", line 6, in <module>
    from . import adam
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/ops/adam/__init__.py", line 9, in <module>
    from .zenflow_torch_adam import ZenFlowSelectiveAdamW
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/ops/adam/zenflow_torch_adam.py", line 685, in <module>
    @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_adamw)
NameError: name '_disable_dynamo_if_unsupported' is not defined
```