### PR TITLE
fix get_cuda_compile_flag

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -431,6 +431,7 @@ class OpBuilder(ABC):
             print(f"{WARNING} {self.name} cuda is missing or is incompatible with installed torch, "
                   "only cpu ops can be compiled!")
             return '-D__DISABLE_CUDA__'
+        return '-D__DISABLE_CUDA__'
 
     def _backup_cpuinfo(self):
         # Construct cpu_info dict from lscpu that is similar to what py-cpuinfo provides

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -432,7 +432,6 @@ class OpBuilder(ABC):
         except MissingCUDAException:
             print(f"{WARNING} {self.name} cuda is missing or is incompatible with installed torch, "
                   "only cpu ops can be compiled!")
-            return '-D__DISABLE_CUDA__'
         return '-D__DISABLE_CUDA__'
 
     def _backup_cpuinfo(self):


### PR DESCRIPTION
command: python3 -c 'import deepspeed;deepspeed.ops.adam.cpu_adam.CPUAdamBuilder().load()'
when running on the rocm platform, it encounter an error:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py", line 538, in load
    return self.jit_load(verbose)
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py", line 570, in jit_load
    cxx_args = self.strip_empty_entries(self.cxx_args())
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py", line 401, in strip_empty_entries
    return [x for x in args if len(x) > 0]
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py", line 401, in <listcomp>
    return [x for x in args if len(x) > 0]
TypeError: object of type 'NoneType' has no len()

Compare with version 0.16.5: https://github.com/deepspeedai/DeepSpeed/blob/v0.16.5/op_builder/builder.py#L435 The current version of code is missing a return when self.is_rocm_pytorch() is True. Just add return '-D__DISABLE_CUDA__' is ok!