### PR TITLE
[Deepspeed]Fix Muon optimizer import error

### DIFF
--- a/deepspeed/runtime/zero/utils.py
+++ b/deepspeed/runtime/zero/utils.py
@@ -47,7 +47,7 @@ ZERO_SUPPORTED_OPTIMIZERS = [
 
 # Add MuonWithAuxAdam to supported list if muon is installed
 try:
-    from deepspeed.runtime.muon_optimizer import MuonWithAuxAdam
+    from deepspeed.runtime.zero.muon.muon_optimizer import MuonWithAuxAdam
     ZERO_SUPPORTED_OPTIMIZERS.append(MuonWithAuxAdam)
 except ImportError:
     pass


### PR DESCRIPTION
This is a quick fix of import Muon optimizer in the utils.py