### PR TITLE
Improve error message and reduce validation in autocast test

### DIFF
--- a/tests/unit/runtime/zero/test_zero_autocast.py
+++ b/tests/unit/runtime/zero/test_zero_autocast.py
@@ -163,8 +163,8 @@ def compare_loss(model_cls,
 class TestZeroAutoCast(DistributedTest):
     world_size = 2
 
-    @pytest.mark.parametrize("zero_stage", [3])
-    @pytest.mark.parametrize("dtype", [torch.bfloat16])
+    @pytest.mark.parametrize("zero_stage", [0, 1, 2, 3])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
     def test(self, enable, zero_stage, dtype):
         lower_precision_safe_modules = [torch.nn.Linear]
         autocast_conf = {"enabled": enable, "dtype": str(dtype)}

--- a/tests/unit/runtime/zero/test_zero_autocast.py
+++ b/tests/unit/runtime/zero/test_zero_autocast.py
@@ -18,7 +18,6 @@ import deepspeed
 from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.zero import GatheredParameters
 from deepspeed.runtime.torch_autocast import PARAM_COMM_DTYPE_ATTR_NAME, get_comm_dtype
-from deepspeed.utils import logger
 
 RTOL = 0.1
 ATOL = 0.0
@@ -62,8 +61,6 @@ def step_amp(enabled, baseline_model, baseline_optimizer, target_engine, dtype, 
     # reduce-scatter in `dtype` makes a difference in the loss.
     if step <= 1 and expect_match:
         allclose_local = torch.allclose(baseline_loss.float(), target_loss.float(), rtol=rtol, atol=atol)
-        if not allclose_local:
-            logger.error(f"Losses do not match: baseline_loss={baseline_loss}, target_loss={target_loss}")
         if not reduce_boolean_flags(allclose_local, all):
             assert False, f"Losses do not match on one or more ranks: baseline_loss={baseline_loss}, target_loss={target_loss}"
 

--- a/tests/unit/runtime/zero/test_zero_autocast.py
+++ b/tests/unit/runtime/zero/test_zero_autocast.py
@@ -64,7 +64,7 @@ def step_amp(enabled, baseline_model, baseline_optimizer, target_engine, dtype, 
         if not allclose_local:
             print(f"Losses do not match: baseline_loss={baseline_loss}, target_loss={target_loss}")
         # Ensure all ranks either pass or fail together.
-        # If some rank fail while others pass, subsequent tests or iterations may hang.
+        # If some ranks fail while others pass, subsequent tests or iterations may hang.
         if not reduce_boolean_flags(allclose_local, all):
             assert False, f"Losses do not match on one or more ranks."
 


### PR DESCRIPTION
This PR improves error logging and relaxes loss value checks in the autocast test.

Previously, the test displayed error messages and mismatched loss values on all ranks, even if the mismatch only occurred on some ranks. This was confusing, since logs from other ranks could appear correct. This PR changes the behavior so that error messages are shown only on the ranks where the mismatch occurs.

Additionally, this PR skips loss value validation for `test_lower_precision_model`, where we intentionally use a different communication dtype from the baseline (standard PyTorch autocast).