### PR TITLE
Limit random seed range in tests

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -103,8 +103,13 @@ def set_random_seed(seed):
     import numpy
     import random
     random.seed(seed)
-    numpy.random.seed(seed)
-    torch.manual_seed(seed)
+
+    # pytest-randomly passes a too large seed
+    # `numpy.random.default_rng` could be a better approach, but it requires more changes to use rngs explicitly
+    # numpy.random accepts only 32-bit integers
+    numpy.random.seed(seed % (2**32))
+    # torch.manual_seed accepts only 64-bit integers
+    torch.manual_seed(seed % (2**63))
 
 
 def is_model_parallel_parameter(p) -> bool:


### PR DESCRIPTION
`pytest-randomly` often passes a large seed value to `set_random_seed` and causes an error ([example](https://github.com/deepspeedai/DeepSpeed/actions/runs/17620450004/job/50064585974))
```
E ValueError: Seed must be between 0 and 2**32 - 1
```

This PR limits the range of seed values by taking a modulo.