### PR TITLE
[RFC] Deepcompile: Fix bugs when applying deepcompile to VLA-like models

### DIFF
--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -22,6 +22,7 @@ TORCH_LIBRARY(dc, m)
     m.def("wait_reload(Tensor a, int id, int id) -> Tensor");
     m.def("offload_parameter(Tensor a, int id, int id) -> ()");
     m.def("reload_parameter(Tensor a, int id, int id) -> ()");
+    m.def("end_backward(int graph_id) -> ()");
 
     m.def("test_call(Tensor a) -> Tensor");
 }
@@ -74,6 +75,10 @@ TORCH_LIBRARY_IMPL(dc, Meta, m)
     m.impl("offload_parameter", &dc::offload_parameter_meta);
 }
 
+// The "Undefined" dispatch key is for operations whose arguments do not contain
+// a tensor.
+TORCH_LIBRARY_IMPL(dc, Undefined, m) { m.impl("end_backward", &dc::end_backward); }
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
     m.def("set_persistent", &dc::set_persistent, "Set persistent flag for a parameter");
@@ -95,7 +100,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("start_forward", &dc::start_forward, "Start forward pass");
     m.def("end_forward", &dc::end_forward, "End forward pass");
     m.def("start_backward", &dc::start_backward, "Start backward pass");
-    // m.def("end_backward", &dc::end_backward, "End backward pass");
     m.def("cleanup", &dc::cleanup, "Clean up DeepCompile");
     m.def("reset", &dc::reset, "Reset the state");
     m.def("invalidate_gathered_param", &dc::invalidate_gathered_param, "Invalidate gathered param");

--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -13,7 +13,7 @@ TORCH_LIBRARY(dc, m)
     m.def("allgather_param(Tensor a, int graph_id, int id) -> Tensor");
     m.def("prefetch_params_fused(int graph_id, Tensor[] params, int[] ids) -> ()");
     m.def("wait_allgather(Tensor a, int graph_id, int id) -> Tensor");
-    m.def("release_param(Tensor a, int graph_id, int id, int n_users) -> Tensor");
+    m.def("release_param(Any a, int graph_id, int id, int n_users) -> Any");
     m.def("reduce_grad(Tensor a, int graph_id, int id) -> Tensor");
     m.def("free_tensors(Tensor[] a) -> ()");
     m.def("offload_tensor(Tensor a, int id, int id) -> Tensor");
@@ -77,7 +77,11 @@ TORCH_LIBRARY_IMPL(dc, Meta, m)
 
 // The "Undefined" dispatch key is for operations whose arguments do not contain
 // a tensor.
-TORCH_LIBRARY_IMPL(dc, Undefined, m) { m.impl("end_backward", &dc::end_backward); }
+TORCH_LIBRARY_IMPL(dc, Undefined, m)
+{
+    m.impl("release_param", &dc::release_param);
+    m.impl("end_backward", &dc::end_backward);
+}
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -455,16 +455,17 @@ at::Tensor allgather_param_meta(at::Tensor param_tensor, long graph_id, long ds_
     return output_buf;
 }
 
-at::Tensor release_param(at::Tensor dummy, long graph_id, long ds_id, long n_users)
+c10::IValue release_param(c10::IValue dummy, long graph_id, long ds_id, long n_users)
 {
     auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
     executor->releaseParam(ds_id, n_users);
 
-    if (clone_custom_op_output) { return dummy.clone(); }
+    // TODO: check is dummy is a tensor or tuple
+    // if (clone_custom_op_output) { return dummy.clone(); }
     return dummy;
 }
 
-at::Tensor release_param_meta(at::Tensor dummy, long graph_id, long ds_id, long n_users)
+c10::IValue release_param_meta(c10::IValue dummy, long graph_id, long ds_id, long n_users)
 {
     return dummy;
 }

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -48,6 +48,8 @@ public:
 
     void endBackward() override
     {
+        CustomOpExecutor::endBackward();
+
         if (param_updated_) {
             for (auto& it : has_acc_grad_) {
                 it.second = false;
@@ -520,5 +522,11 @@ void offload_parameter(at::Tensor tensor, long graph_id, long ds_id)
 }
 void reload_parameter_meta(at::Tensor param_tensor, long graph_id, long ds_id) {}
 void offload_parameter_meta(at::Tensor tensor, long graph_id, long ds_id) {}
+
+void end_backward(long graph_id)
+{
+    auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
+    executor->endBackward();
+}
 
 }  // namespace dc

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -45,4 +45,5 @@ void reload_parameter(at::Tensor tensor, long graph_id, long id);
 void offload_parameter(at::Tensor tensor, long graph_id, long id);
 void reload_parameter_meta(at::Tensor tensor, long graph_id, long id);
 void offload_parameter_meta(at::Tensor tensor, long graph_id, long id);
+void end_backward(long graph_id);
 }  // namespace dc

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -33,8 +33,8 @@ void prefetch_params_fused_meta(long graph_id,
 void invalidate_gathered_param(long ds_id);
 void clear_all_gathered_params();
 at::Tensor allgather_param_meta(at::Tensor param_tensor, long graph_id, long ds_id);
-at::Tensor release_param(at::Tensor dummy, long graph_id, long ds_id, long n_users);
-at::Tensor release_param_meta(at::Tensor dummy, long graph_id, long ds_id, long n_users);
+c10::IValue release_param(c10::IValue dummy, long graph_id, long ds_id, long n_users);
+c10::IValue release_param_meta(c10::IValue dummy, long graph_id, long ds_id, long n_users);
 at::Tensor wait_allgather(at::Tensor v, long graph_id, const long ds_id);
 at::Tensor wait_allgather_meta(at::Tensor v, long graph_id, long ds_id);
 at::Tensor offload_tensor(at::Tensor tensor, long graph_id, long id);

--- a/deepspeed/compile/list_schedule.py
+++ b/deepspeed/compile/list_schedule.py
@@ -343,8 +343,9 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
 
                 schedule_until_free = schedule_until_ag + diff_required_nodes
                 for release_node in release_nodes[ds_id]:
-                    if release_node not in schedule_until_free:
-                        schedule_until_free.append(release_node)
+                    for release_dep_node in get_node_requirements(release_node, scheduled + schedule_until_free):
+                        if release_dep_node not in schedule_until_free:
+                            schedule_until_free.append(release_dep_node)
 
                 n_scheduled_ags = len(
                     [n for n in schedule_until_free if n.target == torch.ops.dc.allgather_param.default])

--- a/deepspeed/compile/passes/zero3_compile.py
+++ b/deepspeed/compile/passes/zero3_compile.py
@@ -174,6 +174,9 @@ def add_z3_gather_release_bw(gm: GraphModule,
         0,  # unused
         debug_log=debug_log)
 
+    with gm.graph.inserting_before(get_output_node(gm.graph)):
+        gm.graph.create_node("call_function", torch.ops.dc.end_backward.default, (graph_id, ))
+
     return gm
 
 

--- a/deepspeed/compile/passes/zero3_compile.py
+++ b/deepspeed/compile/passes/zero3_compile.py
@@ -70,6 +70,9 @@ def add_gather_and_release(graph_id: int, graph: Graph, param_manager, param_nod
 
     node_to_uses = get_real_uses(graph)
     for pn in param_nodes:
+        if len(pn.users) == 0:
+            continue
+
         add_allgather(graph_id, graph, pn, param_manager.ds_ids[pn.name])
         ds_id = param_manager.ds_ids[pn.name]
         users = node_to_uses[pn]
@@ -85,6 +88,8 @@ def add_gather_and_reduce(graph_id: int, graph: Graph, param_manager, param_node
     add_gather_and_release(graph_id, graph, param_manager, param_nodes_bw)
 
     for param_name in param_manager.param_names:
+        if param_name_to_grad[param_name] is None:
+            continue
         add_reduce(graph_id, graph, param_name_to_grad[param_name], param_name, param_manager.ds_ids[param_name])
 
     return move_primals_to_head(graph)


### PR DESCRIPTION
**Describe the bug**

When applying deepcompile to the OpenVLA model (which is composed of two vision transformers and a llama-7B), I met the following issues:

a. Not all parameters are trained, which leads to compile-time exceptions as well as incorrect invocation of `endBackward()`.
b. A use-before-define error in `fast_free_schedule()`.
c. `release_param()` can be passed a tuple, not a tensor.

This PR attempts to fix all of those issues. Patch 1~2 resolves a, 3 resolves b and 4 resolves c.

**To Reproduce the issues**
Use this script: https://gist.github.com/eternalNight/3c2cf8c703f1e9e7742d3b7f9e1edae3

1. `deepspeed --num_gpus=N openvla-like.py -c`

**Remaining issues**
This PR is currently under draft due to the following issue:

1. `release_param()` does not clone tensors in the passed tuple when using the inductor backend.