### PR TITLE
logging: Also set log level of logger handlers

### DIFF
--- a/deepspeed/utils/logging.py
+++ b/deepspeed/utils/logging.py
@@ -155,6 +155,8 @@ def set_log_level_from_string(log_level_str, custom_logger=None):
     if custom_logger is None:
         custom_logger = logger
     custom_logger.setLevel(log_level)
+    for ch in custom_logger.handlers:
+        ch.setLevel(log_level)
 
 
 def get_current_level():


### PR DESCRIPTION
After #7526 the default logger passes logs to a StreamHandler, which has its own log level. Changing the log level of the logger alone does not take effect in such case.

Update the log level of all handlers when changing the parent logger's.