### PR TITLE
Fix deepcompile+stage 3 fails start

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2211,7 +2211,7 @@ class DeepSpeedEngine(Module):
     def allreduce_gradients(self, bucket_size=MEMORY_OPT_ALLREDUCE_SIZE):
         # Skip gradient reduction when DeepCompile is enabled
         # DeepCompile handles its own gradient reduction through compiled graph operations
-        if self.is_deepcompile_enabled():
+        if self.is_deepcompile_enabled() and self.zero_optimization_stage()!=3:
             return
 
         # Pass (PP) gas boundary flag to optimizer (required for zero)


### PR DESCRIPTION
Start training for Deepcompile+zero s3 fails due change introduced in this [#7548](https://github.com/deepspeedai/DeepSpeed/pull/7548)

```
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/transformers/trainer.py", line 4071, in training_step
[rank3]:     self.accelerator.backward(loss, **kwargs)
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/accelerate/accelerator.py", line 2726, in backward
[rank3]:     self.deepspeed_engine_wrapped.backward(loss, sync_gradients=self.sync_gradients, **kwargs)
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/accelerate/utils/deepspeed.py", line 281, in backward
[rank3]:     self.engine.step()
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/deepspeed/runtime/engine.py", line 2495, in step
[rank3]:     self._take_model_step(lr_kwargs)
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/deepspeed/runtime/engine.py", line 2390, in _take_model_step
[rank3]:     self.optimizer.step()
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/deepspeed/utils/nvtx.py", line 20, in wrapped_fn
[rank3]:     ret_val = func(*args, **kwargs)
[rank3]:               ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/deepspeed/runtime/zero/stage3.py", line 2131, in step
[rank3]:     norm_groups = self._get_norm_groups()
[rank3]:                   ^^^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/deepspeed/utils/nvtx.py", line 20, in wrapped_fn
[rank3]:     ret_val = func(*args, **kwargs)
[rank3]:               ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/usr/local/lib/python3.11/dist-packages/deepspeed/runtime/zero/stage3.py", line 1910, in _get_norm_groups
[rank3]:     norm_groups.append(self.get_grad_norm_direct(self.averaged_gradients[i], self.fp16_groups[i]))
[rank3]:                                                  ~~~~~~~~~~~~~~~~~~~~~~~^^^
[rank3]: KeyError: 0
```

Error because we skip `allreduce_gradients` if deepcompile enable so `self.averaged_gradients` alway are empty dict, but it need assign values via [`self.optimizer.overlapping_partition_gradients_reduce_epilogue()`](https://github.com/deepspeedai/DeepSpeed/blob/b75654001a2bb95b4205ac2deeab401a2524ee68/deepspeed/runtime/engine.py#L2221) in the `allreduce_gradients`.

This pr fix it by only skip `allreduce_gradients` when deepcompile enable + not stage 3.

## Evaluation
- [x] Check loss is same when enable and disable deepcompile.