### PR TITLE
Add assertion to make sure compile() is called with DeepCompile enabled

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2155,9 +2155,14 @@ class DeepSpeedEngine(Module):
         if self.autotuning_profile_model_info():
             ma = get_ma_status()
 
-        if self.is_deepcompile_enabled() and hasattr(self, "launch_compile_passes"):
-            # We can't have this in forward prologue as the compiler compiles hooks including the forward prologue.
-            self.launch_compile_passes(self.global_steps)
+        if self.is_deepcompile_enabled():
+            assert self.is_compiled, (
+                "DeepCompile requires `engine.compile()` to be called before the forward pass. "
+                "Invoke `engine.compile()` after initializing DeepSpeed when DeepCompile is enabled.")
+
+            if hasattr(self, "launch_compile_passes"):
+                # We can't have this in forward prologue as the compiler compiles hooks including the forward prologue.
+                self.launch_compile_passes(self.global_steps)
 
         with autocast_if_enabled(self):
             loss = self.module(*inputs, **kwargs)


### PR DESCRIPTION
This PR add an assertion that checks compile() is called when DeepCompile is enabled.
See #7598.