### PR TITLE
fix: correct DistributedAttention output shape and pad uneven sequence lengths (#7842)

### DIFF
--- a/deepspeed/sequence/__init__.py
+++ b/deepspeed/sequence/__init__.py
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team
+
+from .layer import DistributedAttention, _SeqAllToAll  # noqa: F401


### PR DESCRIPTION
## What this PR does / why we need it

`DistributedAttention` produced numerically incorrect results whenever the global sequence length was not evenly divisible by the sequence-parallel world size.  Two bugs were found and fixed:

**Bug 1 – Wrong output shape formula (silent corruption even with divisible lengths)**

In `_generate_layout_params`, the `post_all2all_res_shape` for the `batch_dim_idx=1, scatter_idx < 2` path (seq-first layout, output all-to-all) was computed as `[bs, seq_world_size * global_seq_len, num_local_head // seq_world_size, head_dim]`.  After the permute, the tensor is `[S/P, B, P, H/P, D]`; collapsing the two head dimensions must yield `[S/P, B, H, D]`, not the formula above.  This caused the returned tensor to have the right number of elements but the wrong shape, silently misinterpreting data.

**Bug 2 – Unequal local sequence lengths crash `dist.all_to_all_single`**

When `S % P != 0` different ranks hold different numbers of tokens (`ceil(S/P)` vs `floor(S/P)`).  `dist.all_to_all_single` with implicit equal splits then silently reads/writes beyond allocated buffers, producing garbage outputs with no exception raised.

## Fix

- **`deepspeed/sequence/layer.py`**: correct `post_all2all_res_shape` for the `batch_dim_idx=1, scatter_idx<2` case; add `DistributedAttention._pad_to_seq_world_size()`; in `forward()`, call `_get_max_local_seq_len()` to align all ranks to the same local sequence length, pad Q/K/V before the all-to-all, and slice the output back to the original length.  `F.pad` is differentiable so gradients flow correctly without extra ctx bookkeeping.
- **`deepspeed/utils/groups.py`**: add `_get_max_local_seq_len(local_seq_len, group)` — a single `allreduce(MAX)` so that all ranks can agree on the padded sequence length without multiple round trips.
- **`deepspeed/sequence/fpdt_layer.py`**: replace the hard `assert global_seq_len % sp_size == 0` in `FPDT_InputConstruct.__init__` with graceful zero-padding of tokens/labels/loss_mask/position_ids to the nearest multiple of `sp_size`.
- **`deepspeed/sequence/__init__.py`**: export `DistributedAttention` and `_SeqAllToAll` for easier downstream imports.

Fixes #7842
