### PR TITLE
fix: topkgating major bug

### DIFF
--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -384,14 +384,16 @@ def topkgating(
     """Implements TopKGating on logits."""
 
     # everything is in fp32 in this function
-    # get topk gates
-    top_gate, top_idx = torch.topk(logits, k=k, dim=1)
     # gating decisions
     gates = F.softmax(logits, dim=1)
     num_experts = int(gates.shape[1])
 
+    # get topk gates — use softmax probs so non-assigned slots (zero) never
+    # outrank legitimately-assigned tokens that happen to have negative logits
+    top_gate, top_idx = torch.topk(gates, k=k, dim=1)
+
     # get topk mask
-    topk_masked_gates = torch.zeros_like(logits).scatter(1, top_idx, top_gate)
+    topk_masked_gates = torch.zeros_like(gates).scatter(1, top_idx, top_gate)
 
     mask = torch.zeros_like(gates, dtype=torch.bool).scatter_(1, top_idx, 1)
 

--- a/deepspeed/moe/sharded_moe.py
+++ b/deepspeed/moe/sharded_moe.py
@@ -388,12 +388,8 @@ def topkgating(
     gates = F.softmax(logits, dim=1)
     num_experts = int(gates.shape[1])
 
-    # get topk gates — use softmax probs so non-assigned slots (zero) never
-    # outrank legitimately-assigned tokens that happen to have negative logits
+    # get topk gates
     top_gate, top_idx = torch.topk(gates, k=k, dim=1)
-
-    # get topk mask
-    topk_masked_gates = torch.zeros_like(gates).scatter(1, top_idx, top_gate)
 
     mask = torch.zeros_like(gates, dtype=torch.bool).scatter_(1, top_idx, 1)
 
@@ -410,9 +406,10 @@ def topkgating(
         # update mask and locations by capacity
 
         if drop_policy == 'probs':
-            capacity_probs, capacity_indices = torch.topk(topk_masked_gates, k=capacity, dim=0, sorted=False)
-            capacity_mask = torch.zeros_like(logits).scatter(0, capacity_indices, 1)
-            mask = torch.logical_and(mask, capacity_mask)
+            topk_masked_gates = torch.zeros_like(gates).scatter(1, top_idx, top_gate)
+            _, capacity_indices = torch.topk(topk_masked_gates, k=capacity, dim=0, sorted=False)
+            capacity_mask = torch.zeros_like(gates, dtype=torch.bool).scatter_(0, capacity_indices, True)
+            mask &= capacity_mask
             locations = torch.cumsum(mask, dim=0) - 1
 
         elif drop_policy == "position":


### PR DESCRIPTION
`topk_masked_gates` was previously being used across the tokens dimension to determine which tokens had the highest importance for each expert. However, it was using logits rather than probabilities to determine this.

This was causing print statements like
```
            if dist.get_rank() == 0:
                print(f"Mask mean: {mask.float().mean()}")
                print(f"Capacity mask mean: {capacity_mask.mean()}")
            mask = torch.logical_and(mask, capacity_mask)
            if dist.get_rank() == 0:
                print(f"Mask (after AND) mean: {mask.float().mean()}")
```

to often yield values like
```
Mask mean: 0.0625
Capacity mask mean: 0.0625
Mask (after AND) mean: 0.005908316932618618
```

and in turn the average number of routed experts per token was as low as `0.001`.