### PR TITLE
Fix eigenvalue monitor logging

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2837,13 +2837,7 @@ class DeepSpeedEngine(Module):
 
                     if (self.eigenvalue_enabled()
                             and not self.gas_boundary_ctr % self.eigenvalue_gas_boundary_resolution()):
-                        ev_values = self.block_eigenvalue.values()
-                        for i in range(len(ev_values)):
-                            self.summary_events.append((
-                                f"Train/Eigenvalues/ModelBlockParam_{i}",
-                                self.ev_values[i][0],
-                                self.global_samples,
-                            ))
+                        self.summary_events.extend(self._get_eigenvalue_monitor_events())
                     self.monitor.write_events(self.summary_events)
 
         # Check flops profiling
@@ -2962,6 +2956,11 @@ class DeepSpeedEngine(Module):
                 ),
             ]
             self.monitor.write_events(self.summary_events)
+
+    def _get_eigenvalue_monitor_events(self):
+        ev_values = list(self.block_eigenvalue.values())
+        return [(f"Train/Eigenvalues/ModelBlockParam_{i}", value[0], self.global_samples)
+                for i, value in enumerate(ev_values)]
 
     def _get_optimizer_param(self, param_name):
         result = []

--- a/tests/unit/runtime/test_engine.py
+++ b/tests/unit/runtime/test_engine.py
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from deepspeed.runtime.engine import DeepSpeedEngine
+
+
+def test_eigenvalue_monitor_events_use_block_eigenvalue_values(capsys):
+    engine = DeepSpeedEngine.__new__(DeepSpeedEngine)
+    engine.block_eigenvalue = {
+        "first_param": (0.25, 0),
+        "second_param": (0.5, 1),
+    }
+    engine.global_samples = 32
+    expected_events = [
+        ("Train/Eigenvalues/ModelBlockParam_0", 0.25, 32),
+        ("Train/Eigenvalues/ModelBlockParam_1", 0.5, 32),
+    ]
+    actual_events = engine._get_eigenvalue_monitor_events()
+
+    with capsys.disabled():
+        print(f"\nblock_eigenvalue: {engine.block_eigenvalue}")
+        print(f"generated eigenvalue monitor events: {actual_events}")
+
+    assert actual_events == expected_events


### PR DESCRIPTION
## Summary

Fixes #7983.

This PR fixes eigenvalue monitor logging by generating monitor events from the local `block_eigenvalue` values instead of the nonexistent `self.ev_values`, and by converting the `dict_values` view into an indexable list before event generation.

The release workflow/version check change from the earlier revision was removed so this PR now addresses only the eigenvalue monitor issue.

## Changes

- Add `_get_eigenvalue_monitor_events()` for focused eigenvalue monitor event generation.
- Replace the broken `self.ev_values` monitor logging path with the helper.
- Add a focused regression test for eigenvalue monitor events.

## Tests

- `git diff --check master`
- `python -m py_compile deepspeed/runtime/engine.py tests/unit/runtime/test_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit/runtime/test_engine.py -v`
  - passed: 1 test