### PR TITLE
Add DeepSpeed NVTX domain support

### DIFF
--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -8,6 +8,7 @@ from abc import ABC
 
 
 class DeepSpeedAccelerator(ABC):
+    supports_nvtx_domain = False
 
     def __init__(self):
         self._name = None
@@ -183,11 +184,11 @@ class DeepSpeedAccelerator(ABC):
         ...
 
     @abc.abstractmethod
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         ...
 
     @abc.abstractmethod
-    def range_pop(self):
+    def range_pop(self, domain=None):
         ...
 
     @abc.abstractmethod

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -202,12 +202,12 @@ class CPU_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return True
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         # TODO itt is currently not supported yet
         # return torch.profiler.itt.range_push(msg)
         return
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         # TODO itt is currently not supported yet
         # return torch.profiler.itt.range_pop()
         return

--- a/accelerator/cuda_accelerator.py
+++ b/accelerator/cuda_accelerator.py
@@ -17,16 +17,23 @@ try:
 except ImportError:
     pass
 
+try:
+    import nvtx
+except ImportError:
+    nvtx = None
+
 # Delay import pynvml to avoid import error when CUDA is not available
 pynvml = None
 
 
 class CUDA_Accelerator(DeepSpeedAccelerator):
+    supports_nvtx_domain = True
 
     def __init__(self):
         self._name = 'cuda'
         self._communication_backend_name = 'nccl' if sys.platform != 'win32' else 'gloo'
         self._compile_backend = "inductor"
+        self._nvtx_domains = {}
         if pynvml is None:
             self._init_pynvml()
 
@@ -225,13 +232,28 @@ class CUDA_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return torch.cuda.is_available()
 
-    def range_push(self, msg):
-        if hasattr(torch.cuda.nvtx, 'range_push'):
-            return torch.cuda.nvtx.range_push(msg)
+    def _get_nvtx_domain(self, domain):
+        if nvtx is None or domain is None:
+            return None
+        if domain not in self._nvtx_domains:
+            self._nvtx_domains[domain] = nvtx.get_domain(domain)
+        return self._nvtx_domains[domain]
 
-    def range_pop(self):
-        if hasattr(torch.cuda.nvtx, 'range_pop'):
-            return torch.cuda.nvtx.range_pop()
+    def range_push(self, msg, domain=None, category=None):
+        nvtx_domain = self._get_nvtx_domain(domain)
+        if nvtx_domain is not None:
+            return nvtx_domain.push_range(message=msg, category=category)
+        torch_nvtx = getattr(torch.cuda, 'nvtx', None)
+        if torch_nvtx is not None and hasattr(torch_nvtx, 'range_push'):
+            return torch_nvtx.range_push(msg)
+
+    def range_pop(self, domain=None):
+        nvtx_domain = self._get_nvtx_domain(domain)
+        if nvtx_domain is not None:
+            return nvtx_domain.pop_range()
+        torch_nvtx = getattr(torch.cuda, 'nvtx', None)
+        if torch_nvtx is not None and hasattr(torch_nvtx, 'range_pop'):
+            return torch_nvtx.range_pop()
 
     def lazy_call(self, callback):
         return torch.cuda._lazy_call(callback)

--- a/accelerator/hpu_accelerator.py
+++ b/accelerator/hpu_accelerator.py
@@ -176,10 +176,10 @@ class HPU_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return self.hpu.is_available()
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         return
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         return
 
     def lazy_call(self, callback):

--- a/accelerator/mlu_accelerator.py
+++ b/accelerator/mlu_accelerator.py
@@ -165,11 +165,11 @@ class MLU_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return torch.mlu.is_available()
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         if hasattr(torch.mlu.cnpx, 'range_push'):
             return torch.mlu.cnpx.range_push(msg)
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         if hasattr(torch.mlu.cnpx, 'range_pop'):
             return torch.mlu.cnpx.range_pop()
 

--- a/accelerator/mps_accelerator.py
+++ b/accelerator/mps_accelerator.py
@@ -159,10 +159,10 @@ class MPS_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         return
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         return
 
     def lazy_call(self, callback):

--- a/accelerator/npu_accelerator.py
+++ b/accelerator/npu_accelerator.py
@@ -166,10 +166,10 @@ class NPU_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return torch.npu.is_available()
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         return
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         return
 
     def lazy_call(self, callback):

--- a/accelerator/sdaa_accelerator.py
+++ b/accelerator/sdaa_accelerator.py
@@ -195,10 +195,10 @@ class SDAA_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return torch.sdaa.is_available()
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         return
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         return
 
     def lazy_call(self, callback):

--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -156,12 +156,12 @@ class XPU_Accelerator(DeepSpeedAccelerator):
     def is_available(self):
         return torch.xpu.is_available()
 
-    def range_push(self, msg):
+    def range_push(self, msg, domain=None, category=None):
         # TODO itt is currently not supported yet
         # return torch.profiler.itt.range_push(msg)
         return
 
-    def range_pop(self):
+    def range_pop(self, domain=None):
         # TODO itt is currently not supported yet
         # return torch.profiler.itt.range_pop()
         return

--- a/deepspeed/utils/nvtx.py
+++ b/deepspeed/utils/nvtx.py
@@ -7,6 +7,19 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.compiler import is_compiling
 
 enable_nvtx = True
+DEEPSPEED_NVTX_DOMAIN = "DeepSpeed"
+
+
+def _range_push(accelerator, msg):
+    if getattr(accelerator, "supports_nvtx_domain", False):
+        return accelerator.range_push(msg, domain=DEEPSPEED_NVTX_DOMAIN)
+    return accelerator.range_push(msg)
+
+
+def _range_pop(accelerator):
+    if getattr(accelerator, "supports_nvtx_domain", False):
+        return accelerator.range_pop(domain=DEEPSPEED_NVTX_DOMAIN)
+    return accelerator.range_pop()
 
 
 def instrument_w_nvtx(func):
@@ -16,10 +29,10 @@ def instrument_w_nvtx(func):
 
     def wrapped_fn(*args, **kwargs):
         if enable_nvtx and not is_compiling():
-            get_accelerator().range_push(func.__qualname__)
+            _range_push(get_accelerator(), func.__qualname__)
         ret_val = func(*args, **kwargs)
         if enable_nvtx and not is_compiling():
-            get_accelerator().range_pop()
+            _range_pop(get_accelerator())
         return ret_val
 
     return wrapped_fn

--- a/tests/unit/utils/test_nvtx.py
+++ b/tests/unit/utils/test_nvtx.py
@@ -1,0 +1,139 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import deepspeed.utils.nvtx as ds_nvtx
+import accelerator.cuda_accelerator as cuda_accelerator
+from accelerator.cuda_accelerator import CUDA_Accelerator
+
+
+def _sample_nvtx_function():
+    return "ok"
+
+
+def test_instrument_w_nvtx_uses_deepspeed_domain(monkeypatch, capsys):
+    calls = []
+
+    class FakeAccelerator:
+        supports_nvtx_domain = True
+
+        def range_push(self, msg, domain=None, category=None):
+            calls.append(("push", msg, domain, category))
+
+        def range_pop(self, domain=None):
+            calls.append(("pop", domain))
+
+    monkeypatch.setattr(ds_nvtx, "enable_nvtx", True)
+    monkeypatch.setattr(ds_nvtx, "is_compiling", lambda: False)
+    monkeypatch.setattr(ds_nvtx, "get_accelerator", lambda: FakeAccelerator())
+
+    wrapped_fn = ds_nvtx.instrument_w_nvtx(_sample_nvtx_function)
+
+    assert wrapped_fn() == "ok"
+
+    with capsys.disabled():
+        print(f"\nNVTX instrumentation calls: {calls}")
+
+    assert calls == [
+        ("push", "_sample_nvtx_function", ds_nvtx.DEEPSPEED_NVTX_DOMAIN, None),
+        ("pop", ds_nvtx.DEEPSPEED_NVTX_DOMAIN),
+    ]
+
+
+def test_instrument_w_nvtx_supports_legacy_accelerator_methods(monkeypatch, capsys):
+    calls = []
+
+    class LegacyAccelerator:
+
+        def range_push(self, msg):
+            calls.append(("push", msg))
+
+        def range_pop(self):
+            calls.append(("pop", ))
+
+    monkeypatch.setattr(ds_nvtx, "enable_nvtx", True)
+    monkeypatch.setattr(ds_nvtx, "is_compiling", lambda: False)
+    monkeypatch.setattr(ds_nvtx, "get_accelerator", lambda: LegacyAccelerator())
+
+    wrapped_fn = ds_nvtx.instrument_w_nvtx(_sample_nvtx_function)
+
+    assert wrapped_fn() == "ok"
+
+    with capsys.disabled():
+        print(f"\nLegacy NVTX instrumentation calls: {calls}")
+
+    assert calls == [
+        ("push", "_sample_nvtx_function"),
+        ("pop", ),
+    ]
+
+
+def test_cuda_accelerator_uses_nvtx_domain_when_available(monkeypatch, capsys):
+
+    class FakeDomain:
+
+        def __init__(self):
+            self.calls = []
+
+        def push_range(self, message=None, category=None):
+            self.calls.append(("push", message, category))
+            return "domain-push"
+
+        def pop_range(self):
+            self.calls.append(("pop", ))
+            return "domain-pop"
+
+    class FakeNvtx:
+
+        def __init__(self):
+            self.domains = {}
+
+        def get_domain(self, name):
+            self.domains.setdefault(name, FakeDomain())
+            return self.domains[name]
+
+    fake_nvtx = FakeNvtx()
+    accelerator = CUDA_Accelerator.__new__(CUDA_Accelerator)
+    accelerator._nvtx_domains = {}
+    monkeypatch.setattr(cuda_accelerator, "nvtx", fake_nvtx)
+
+    assert accelerator.range_push("my_range", domain="DeepSpeed", category="zero") == "domain-push"
+    assert accelerator.range_pop(domain="DeepSpeed") == "domain-pop"
+
+    with capsys.disabled():
+        print(f"\nCUDA NVTX domain calls: {fake_nvtx.domains['DeepSpeed'].calls}")
+
+    assert fake_nvtx.domains["DeepSpeed"].calls == [
+        ("push", "my_range", "zero"),
+        ("pop", ),
+    ]
+
+
+def test_cuda_accelerator_falls_back_to_torch_nvtx_without_nvtx_package(monkeypatch, capsys):
+    calls = []
+
+    class FakeTorchNvtx:
+
+        def range_push(self, msg):
+            calls.append(("push", msg))
+            return "torch-push"
+
+        def range_pop(self):
+            calls.append(("pop", ))
+            return "torch-pop"
+
+    accelerator = CUDA_Accelerator.__new__(CUDA_Accelerator)
+    monkeypatch.setattr(cuda_accelerator, "nvtx", None)
+    monkeypatch.setattr(cuda_accelerator.torch.cuda, "nvtx", FakeTorchNvtx())  #ignore-cuda
+
+    assert accelerator.range_push("my_range", domain="DeepSpeed", category="zero") == "torch-push"
+    assert accelerator.range_pop(domain="DeepSpeed") == "torch-pop"
+
+    with capsys.disabled():
+        print(f"\nCUDA torch.nvtx fallback calls: {calls}")
+
+    assert calls == [
+        ("push", "my_range"),
+        ("pop", ),
+    ]


### PR DESCRIPTION
## Summary

Addresses #7912.

This PR adds DeepSpeed-specific NVTX domain support for instrumentation ranges while preserving the existing fallback behavior.

## Changes

- Add a `DeepSpeed` NVTX domain name for `instrument_w_nvtx`.
- Extend accelerator `range_push` / `range_pop` APIs with optional `domain` and `category` arguments.
- Use the NVIDIA `nvtx` package domain API in the CUDA accelerator when available.
- Fall back to `torch.cuda.nvtx` when the `nvtx` package is unavailable.
- Keep non-CUDA accelerator behavior unchanged by accepting and ignoring the optional arguments.
- Add focused unit tests for domain instrumentation, CUDA domain usage, and fallback behavior.

## Tests

### Compile check

```bash
PYTHONNOUSERSITE=1 /home/xdu/anaconda3/envs/simlingo/bin/python -m py_compile \
  deepspeed/utils/nvtx.py \
  accelerator/abstract_accelerator.py \
  accelerator/cuda_accelerator.py \
  accelerator/cpu_accelerator.py \
  accelerator/hpu_accelerator.py \
  accelerator/mlu_accelerator.py \
  accelerator/mps_accelerator.py \
  accelerator/npu_accelerator.py \
  accelerator/sdaa_accelerator.py \
  accelerator/xpu_accelerator.py \
  tests/unit/utils/test_nvtx.py
````

Output:

```text
Passed with no output.
```

### Unit tests

```bash
PYTHONNOUSERSITE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/xdu/anaconda3/envs/simlingo/bin/python -m pytest \
  tests/unit/utils/test_nvtx.py \
  tests/unit/accelerator/test_accelerator.py -v
```

Key output:

```text
NVTX instrumentation calls: [('push', '_sample_nvtx_function', 'DeepSpeed', None), ('pop', 'DeepSpeed')]
CUDA NVTX domain calls: [('push', 'my_range', 'zero'), ('pop',)]
CUDA torch.nvtx fallback calls: [('push', 'my_range'), ('pop',)]
11 passed, 4 warnings in 1.88s
```

### Pre-commit

```bash
PRE_COMMIT_HOME=/tmp/pre-commit-cache PYTHONNOUSERSITE=1 /home/xdu/anaconda3/envs/simlingo/bin/python -m pre_commit run --files \
  accelerator/abstract_accelerator.py \
  accelerator/cpu_accelerator.py \
  accelerator/cuda_accelerator.py \
  accelerator/hpu_accelerator.py \
  accelerator/mlu_accelerator.py \
  accelerator/mps_accelerator.py \
  accelerator/npu_accelerator.py \
  accelerator/sdaa_accelerator.py \
  accelerator/xpu_accelerator.py \
  deepspeed/utils/nvtx.py \
  tests/unit/utils/test_nvtx.py
```

Output:

```text
All hooks passed.
```

````
````
