### PR TITLE
Fix ZeRO-3 forward crash on modules with plain dict _parameters

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -31,7 +31,7 @@ from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 from deepspeed.runtime.zenflow.zenflow_stage_1_and_2 import ZenFlowZeroOptimizer
 from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
 from deepspeed.runtime.zero.utils import is_zero_supported_optimizer, ZeRORuntimeException
-from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload
+from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload, ZeROOrderedDict, ensure_zero_ordered_dict
 from deepspeed.runtime.zero.config import ZERO_OPTIMIZATION
 from deepspeed.runtime.zenflow.engine import (configure_zenflow, zenflow_step, is_zenflow_update_boundary,
                                               sync_zenflow_optimizer_lr)
@@ -2304,6 +2304,7 @@ class DeepSpeedEngine(Module):
             # Enable automated discovery of external parameters by indicating that
             # we are in a forward pass.
             for module in self.module.modules():
+                ensure_zero_ordered_dict(module)
                 module._parameters._in_forward = True
 
         if self.fp16_auto_cast():
@@ -2317,7 +2318,8 @@ class DeepSpeedEngine(Module):
         if self.zero_optimization_partition_weights():
             # Disable automated discovery of external parameters
             for module in self.module.modules():
-                module._parameters._in_forward = False
+                if isinstance(module._parameters, ZeROOrderedDict):
+                    module._parameters._in_forward = False
 
         self._stop_timers(self.engine_timers.forward_timers)
 

--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -86,6 +86,29 @@ def _inject_parameters(module, cls):
         module._parameters = new_param
 
 
+def ensure_zero_ordered_dict(module):
+    """Wrap ``module._parameters`` in :class:`ZeROOrderedDict` if not already.
+
+    PyTorch 2.5+ defaults ``nn.Module._parameters`` to a plain ``dict``
+    (pytorch/pytorch#129164), which rejects the ``_in_forward`` attribute
+    the forward prologue sets. Modules not converted by ``_inject_parameters``
+    at engine init (e.g. submodules attached after ``deepspeed.initialize``,
+    or restored by ``deepspeed/compile/init_z3.py``) hit issue #6961.
+    Idempotent; no-op if already wrapped, missing, or a non-dict container.
+    """
+    params = getattr(module, "_parameters", None)
+    if isinstance(params, ZeROOrderedDict) or not isinstance(params, dict):
+        return
+    # Preserve the original container only on first wrap so the un-injection
+    # path in ``deepspeed/compile/init_z3.py`` can restore it.
+    if not hasattr(module, "_original_parameters"):
+        module._original_parameters = params
+    new_param = ZeROOrderedDict(parent_module=module)
+    for key, param in params.items():
+        new_param[key] = param
+    module._parameters = new_param
+
+
 class DeepSpeedZeRoOffload(object):
 
     def __init__(

--- a/tests/unit/runtime/zero/test_zero_late_module_attach.py
+++ b/tests/unit/runtime/zero/test_zero_late_module_attach.py
@@ -1,0 +1,136 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Regression tests for issue #6961.
+
+ZeRO-3 forward used to crash with ``AttributeError: 'dict' object has no
+attribute '_in_forward'`` when a submodule's ``_parameters`` was a plain
+``dict`` instead of a ``ZeROOrderedDict``. PyTorch 2.5+ defaults
+``nn.Module._parameters`` to ``dict`` (pytorch/pytorch#129164), and any
+module not converted at ``DeepSpeedZeRoOffload`` init time hits the crash.
+The tests force the plain-dict condition explicitly so they exercise the
+fix on every supported torch version, not only torch 2.5+.
+"""
+
+import torch
+
+import deepspeed
+from deepspeed.runtime.zero.parameter_offload import (ZeROOrderedDict, ensure_zero_ordered_dict)
+
+from unit.common import DistributedTest, preferred_dtype
+
+
+class _Tiny(torch.nn.Module):
+
+    def __init__(self, hidden_dim=16):
+        super().__init__()
+        self.fc = torch.nn.Linear(hidden_dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+def _zero3_config(dtype):
+    return {
+        "train_batch_size": 1,
+        "fp16": {
+            "enabled": dtype is torch.float16
+        },
+        "bf16": {
+            "enabled": dtype is torch.bfloat16
+        },
+        "zero_optimization": {
+            "stage": 3
+        },
+    }
+
+
+class TestZero3LateModuleAttach(DistributedTest):
+    world_size = 1
+
+    def test_forward_after_late_submodule_attach(self):
+        """Attaching a fresh ``nn.Linear`` after ``initialize`` must not crash."""
+        hidden = 16
+        dtype = preferred_dtype()
+        model = _Tiny(hidden)
+        engine, *_ = deepspeed.initialize(model=model,
+                                          config=_zero3_config(dtype),
+                                          model_parameters=list(model.parameters()))
+
+        late = torch.nn.Linear(hidden, hidden, bias=False).to(device=engine.device, dtype=dtype)
+        # Force the post-pytorch/pytorch#129164 condition deterministically so
+        # the test exercises the fix regardless of the installed torch version.
+        late._parameters = dict(late._parameters)
+        engine.module.late = late
+
+        x = torch.randn(2, hidden, dtype=dtype, device=engine.device)
+        engine(x)
+
+        # Prologue must have lazily converted the late submodule.
+        assert isinstance(engine.module.late._parameters, ZeROOrderedDict)
+
+    def test_idempotent_on_already_injected_modules(self):
+        """Repeated forwards must not re-wrap an already-converted ``_parameters``."""
+        hidden = 16
+        dtype = preferred_dtype()
+        model = _Tiny(hidden)
+        engine, *_ = deepspeed.initialize(model=model,
+                                          config=_zero3_config(dtype),
+                                          model_parameters=list(model.parameters()))
+
+        first_pdict = engine.module.fc._parameters
+        assert isinstance(first_pdict, ZeROOrderedDict)
+
+        x = torch.randn(2, hidden, dtype=dtype, device=engine.device)
+        engine(x)
+        engine(x)
+
+        assert engine.module.fc._parameters is first_pdict
+
+
+class TestEnsureZeroOrderedDict:
+    """Direct unit tests for the helper. No distributed harness needed."""
+
+    def test_skips_already_converted(self):
+        m = torch.nn.Linear(4, 4, bias=False)
+        m._parameters = ZeROOrderedDict(parent_module=m)
+        before = m._parameters
+        ensure_zero_ordered_dict(m)
+        assert m._parameters is before
+
+    def test_wraps_plain_dict(self):
+        m = torch.nn.Linear(4, 4, bias=False)
+        m._parameters = dict(m._parameters)
+        ensure_zero_ordered_dict(m)
+        assert isinstance(m._parameters, ZeROOrderedDict)
+        assert "weight" in m._parameters
+        assert m._original_parameters is not m._parameters
+
+    def test_preserves_existing_original_parameters(self):
+        """Subsequent wraps must not clobber the first-saved original.
+
+        ``_inject_parameters`` at engine init records the true torch-native
+        container in ``_original_parameters``; the deepcompile path in
+        ``init_z3.py`` reads it back to un-inject. If the helper later runs
+        after some intermediate replacement of ``_parameters``, it must not
+        overwrite that saved reference.
+        """
+        m = torch.nn.Linear(4, 4, bias=False)
+        sentinel = m._parameters
+        m._original_parameters = sentinel
+        m._parameters = dict(sentinel)  # different object, same contents
+        ensure_zero_ordered_dict(m)
+        assert m._original_parameters is sentinel
+
+    def test_noop_when_parameters_missing(self):
+        """Helper must not raise when ``_parameters`` is missing or None."""
+
+        class Bare:
+            pass
+
+        m = Bare()
+        ensure_zero_ordered_dict(m)  # no-op, no exception
+        m._parameters = None
+        ensure_zero_ordered_dict(m)  # no-op, no exception
+        assert m._parameters is None


### PR DESCRIPTION
## Summary

Fixes #6961

ZeRO-3 forward crashes with `AttributeError: 'dict' object has no attribute '_in_forward'` since torch 2.5. PyTorch changed `nn.Module._parameters` from `OrderedDict` to plain `dict` (pytorch/pytorch#129164), and a plain `dict` does not allow attribute assignment.

DeepSpeed wraps every module into `ZeROOrderedDict` at engine init via `_inject_parameters`. Any module not present at that point keeps the plain dict and crashes the next forward. This includes a submodule attached after `deepspeed.initialize()` (PEFT/LoRA adapters), or a module restored by `deepspeed/compile/init_z3.py:35`.

The fix adds `ensure_zero_ordered_dict()` and calls it from the forward prologue. It wraps lazily, is idempotent, and keeps the original container so the deepcompile un-injection path still works. The epilogue gets an `isinstance` guard for modules that show up between the two hooks.

This only fixes the crash. Late-attached parameters are still not in the optimizer and not partitioned by ZeRO-3. For full ZeRO-3 semantics on a late adapter, build it inside `deepspeed.zero.Init()`.

## Tests

`tests/unit/runtime/zero/test_zero_late_module_attach.py`

- forward after attaching a Linear post-init, with `_parameters` forced to plain dict so the bug reproduces on any torch version
- repeated forwards do not re-wrap an already-wrapped module