### PR TITLE
Remove stale step() docstring from DeepSpeedCPUAdam

### DIFF
--- a/deepspeed/ops/adam/cpu_adam.py
+++ b/deepspeed/ops/adam/cpu_adam.py
@@ -38,11 +38,6 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
         the overhead of the optimizer's latency on CPU. Please refer to ZeRO-Offload tutorial
         (https://www.deepspeed.ai/tutorials/zero-offload/) for more information on how to enable this technology.
 
-        For calling step function, there are two options available: (1) update optimizer's states and (2) update
-        optimizer's states and copy the parameters back to GPU at the same time. We have seen that the second
-        option can bring 30% higher throughput than the doing the copy separately using option one.
-
-
         .. note::
                 We recommend using our `config
                 <https://www.deepspeed.ai/docs/config-json/#optimizer-parameters>`_


### PR DESCRIPTION
## What

Removes an obsolete paragraph from the `DeepSpeedCPUAdam` constructor docstring.

## Why

The docstring described a `step()` option that "updates optimizer states and
copies the parameters back to GPU at the same time" — the old `adam_update_copy`
kernel, invoked via `step(fp16_param_groups=...)`. That fused-copy path no longer
exists in the codebase:

- `csrc/adam/cpu_adam.cpp` binds only `adam_update` (no `adam_update_copy`).
- `DeepSpeedCPUAdam.step()` / `step_subgroup()` take no `fp16_param_groups`
  argument and only call `adam_update`.

So the "two options" text is stale and misleading to anyone reading the API.
Docstring-only change; no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)