### PR TITLE
[fix] fix test_zf.py hang bug

### DIFF
--- a/deepspeed/runtime/zenflow/engine_stage3.py
+++ b/deepspeed/runtime/zenflow/engine_stage3.py
@@ -278,6 +278,8 @@ def _process_selected_fp32_groups_grad(optimizer_z3, params_to_update, grad_part
         else:
             grad_2d = grad_partition.narrow(0, param.complete_column_offset,
                                             param.complete_numel).view(param.complete_numel // num_row, num_row)
+            if param.selected_indices.numel() == 0:
+                param.selected_indices = param.selected_indices.long()
             param.selected_grad = grad_2d[param.selected_indices, :].clone().detach()
 
             if optimizer_z3.auto_update:


### PR DESCRIPTION
fix:When running following test command, it may hang.
```pytest -v runtime/zenflow/test_zf.py::TestZenFlowDistributed::test_zenflow_distributed[epoch-1-4-False-0-3]```
The reason is that when param.selected_indices got an empty result, its dtype would be torch.float32 instead of torch.int64. However, if the float32 empty tensor is used as an index just like grad_2d[param.selected_indices, :], it would cause a hang. So in order to solve this bug, I add a dtype cast to int64 when judge the param.selected_indices is empty, which means its original dtype is torch.float32.