### PR TITLE
Make GitHub Actions job names unique

### DIFF
--- a/.github/workflows/amd-mi200.yml
+++ b/.github/workflows/amd-mi200.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   amd-tests:
+    name: amd-mi200 / AMD MI200 tests
     # The type of runner that the job will run on
     runs-on: [self-hosted, amd, mi200]
 

--- a/.github/workflows/aws-accelerate.yml
+++ b/.github/workflows/aws-accelerate.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   check-paths:
-    name: Check Paths
+    name: aws-accelerate / check paths
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.run_tests }}
@@ -43,7 +43,7 @@ jobs:
               - '!tests/unit/inference/v2/**'
 
   accelerate-tests:
-    name: Accelerate Integration Tests
+    name: aws-accelerate / accelerate integration tests
     needs: check-paths
     if: needs.check-paths.outputs.should_run == 'true'
     runs-on: [self-hosted, gpu-ci, gpu-l40s, l40s-1gpu, aws]

--- a/.github/workflows/aws-torch-latest.yml
+++ b/.github/workflows/aws-torch-latest.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   check-paths:
-    name: Check Paths
+    name: aws-torch-latest / check paths
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.run_tests }}
@@ -42,7 +42,7 @@ jobs:
               - '!tests/unit/inference/v2/**'
 
   unit-tests:
-    name: Unit Tests (V1)
+    name: aws-torch-latest / unit tests (v1)
     needs: check-paths
     if: needs.check-paths.outputs.should_run == 'true'
     runs-on: [self-hosted, gpu-ci, gpu-l40s, l40s-4gpu, aws]

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    name: cpu-torch-latest / unit tests
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -18,6 +18,7 @@ jobs:
 
   # formatting and basic install on cpu-only machine
   unit-tests:
+    name: formatting / formatting checks
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/hpu-gaudi2-nightly.yml
+++ b/.github/workflows/hpu-gaudi2-nightly.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   unit-tests:
+    name: hpu-gaudi2-nightly / unit tests
     # The type of runner that the job will run on
     runs-on: [self-hosted, intel, gaudi2]
     container:

--- a/.github/workflows/hpu-gaudi2.yml
+++ b/.github/workflows/hpu-gaudi2.yml
@@ -36,6 +36,7 @@ permissions:
 
 jobs:
   unit-tests:
+    name: hpu-gaudi2 / unit tests
     # The type of runner that the job will run on
     runs-on: [self-hosted, intel, gaudi2]
     container:

--- a/.github/workflows/modal-accelerate.yml
+++ b/.github/workflows/modal-accelerate.yml
@@ -41,7 +41,7 @@ concurrency:
 
 jobs:
   collect-tests:
-    name: Collect tests to run
+    name: modal-accelerate / collect tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,7 +69,7 @@ jobs:
               - 'csrc/**'
 
   deploy:
-    name: DeepSpeedAI CI
+    name: modal-accelerate / DeepSpeedAI CI
     runs-on: ubuntu-latest
     needs: collect-tests
     env:

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   collect-tests:
-    name: Collect tests to run
+    name: modal-torch-latest / collect tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -65,7 +65,7 @@ jobs:
               - 'csrc/**'
 
   deploy:
-    name: DeepSpeedAI CI
+    name: modal-torch-latest / DeepSpeedAI CI
     runs-on: ubuntu-latest
     needs: collect-tests
     env:

--- a/.github/workflows/no-torch.yml
+++ b/.github/workflows/no-torch.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   unit-tests:
+    name: no-torch / source distribution build
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/nv-a6000.yml
+++ b/.github/workflows/nv-a6000.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    name: nv-a6000 / inference and MII tests
     runs-on: [self-hosted, nvidia, a6000]
     container:
       image: nvcr.io/nvidia/pytorch:25.01-py3

--- a/.github/workflows/nv-ds-chat.yml
+++ b/.github/workflows/nv-ds-chat.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   unit-tests:
+    name: nv-ds-chat / DeepSpeed-Chat tests
     runs-on: [self-hosted, nvidia, cu124, v100]
 
     steps:

--- a/.github/workflows/nv-flash-attn.yml
+++ b/.github/workflows/nv-flash-attn.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    name: nv-flash-attn / sequence parallelism tests
     runs-on: [self-hosted, nvidia, a6000]
     container:
       image: nvcr.io/nvidia/pytorch:24.12-py3

--- a/.github/workflows/nv-inference.yml
+++ b/.github/workflows/nv-inference.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    name: nv-inference / inference tests
     runs-on: [self-hosted, nvidia, cu124, v100]
 
     steps:

--- a/.github/workflows/nv-pre-compile-ops.yml
+++ b/.github/workflows/nv-pre-compile-ops.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    name: nv-pre-compile-ops / precompile ops
     runs-on: ubuntu-24.04
     container:
       image: nvidia/cuda:12.6.3-devel-ubuntu22.04

--- a/.github/workflows/nv-sd.yml
+++ b/.github/workflows/nv-sd.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   sd-tests:
+    name: nv-sd / stable diffusion tests
     runs-on: [self-hosted, nvidia, a6000]
     container:
       image: nvcr.io/nvidia/pytorch:24.03-py3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    name: python / install smoke (Python ${{ matrix.pyVersion }})
     strategy:
       matrix:
         pyVersion: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/xpu-compile.yml
+++ b/.github/workflows/xpu-compile.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   compile-tests:
+    name: xpu-compile / compile tests
     runs-on: [self-hosted, intel, xpu]
     container:
       image: intel/oneapi-basekit:2025.0.2-0-devel-ubuntu22.04

--- a/.github/workflows/xpu-max1100.yml
+++ b/.github/workflows/xpu-max1100.yml
@@ -34,6 +34,7 @@ permissions:
 
 jobs:
   unit-tests:
+    name: xpu-max1100 / unit tests
     runs-on: [self-hosted, intel, xpu]
     container:
       image: intel/oneapi-basekit:2025.0.2-0-devel-ubuntu22.04


### PR DESCRIPTION
This PR makes GitHub Actions check names unique so required status checks can be configured reliably.

GitHub's protected-branch documentation recommends unique job names across workflows when requiring specific status checks: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches