### PR TITLE
Run FastFileWriter fd-close test outside pytest-forked

### DIFF
--- a/.github/workflows/aws-torch-latest-full.yml
+++ b/.github/workflows/aws-torch-latest-full.yml
@@ -282,7 +282,7 @@ jobs:
           echo "Running sequential tests with TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST on $GPU_COUNT GPUs"
           cd tests
           rm -rf /mnt/aio/pytest
-          pytest --instafail --timeout 600 --forked -m 'sequential' --basetemp=/mnt/aio/pytest unit/ \
+          pytest --instafail --timeout 600 -m 'sequential' --basetemp=/mnt/aio/pytest unit/ \
             --ignore=unit/runtime/zero/test_nvme_checkpointing.py \
             --ignore=unit/ops/aio/test_gds.py \
             --ignore=unit/launcher/test_user_args.py \

--- a/tests/unit/ops/aio/test_fast_file_writer_fd_close.py
+++ b/tests/unit/ops/aio/test_fast_file_writer_fd_close.py
@@ -24,8 +24,6 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.ops.op_builder import AsyncIOBuilder
 from deepspeed.io import FastFileWriter, FastFileWriterConfig
 
-pytestmark = pytest.mark.sequential
-
 if not deepspeed.ops.__compatible_ops__[AsyncIOBuilder.NAME]:
     pytest.skip("async_io op is not compatible on this system", allow_module_level=True)
 
@@ -72,6 +70,7 @@ def _build_writer(file_path):
     return FastFileWriter(file_path=str(file_path), config=cfg)
 
 
+@pytest.mark.sequential
 def test_close_releases_fd_after_unlink(tmp_path):
     """Single save + unlink must not leave a deleted-fd reference."""
     target = tmp_path / "ckpt_single.pt"
@@ -89,6 +88,7 @@ def test_close_releases_fd_after_unlink(tmp_path):
                              f"This indicates _fini() did not os.close(self._aio_fd).")
 
 
+@pytest.mark.sequential
 @pytest.mark.parametrize("n_iters", [5, 20])
 def test_rotation_loop_does_not_leak(tmp_path, n_iters):
     """N iterations of save+close+unlink should leave zero deleted-fds.

--- a/tests/unit/ops/aio/test_fast_file_writer_fd_close.py
+++ b/tests/unit/ops/aio/test_fast_file_writer_fd_close.py
@@ -24,6 +24,8 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.ops.op_builder import AsyncIOBuilder
 from deepspeed.io import FastFileWriter, FastFileWriterConfig
 
+pytestmark = pytest.mark.sequential
+
 if not deepspeed.ops.__compatible_ops__[AsyncIOBuilder.NAME]:
     pytest.skip("async_io op is not compatible on this system", allow_module_level=True)
 
@@ -33,15 +35,10 @@ if not sys.platform.startswith("linux"):
 if get_accelerator().device_name() != 'cuda':
     pytest.skip("FastFileWriter requires CUDA-pinned tensors", allow_module_level=True)
 
-BLOCK_SIZE = 4 * 1024
+BLOCK_SIZE = 1 * 1024 * 1024
 QUEUE_DEPTH = 8
-PINNED_BYTES = 8 * BLOCK_SIZE
-PAYLOAD_BYTES = 4 * BLOCK_SIZE
-
-try:
-    torch.zeros(PINNED_BYTES, dtype=torch.uint8).pin_memory()
-except RuntimeError:
-    pytest.skip("FastFileWriter requires a working CUDA-pinned host buffer", allow_module_level=True)
+PINNED_BYTES = 8 * 1024 * 1024
+PAYLOAD_BYTES = 1 * 1024 * 1024
 
 
 def _count_deleted_fds(target_dir):

--- a/tests/unit/ops/aio/test_fast_file_writer_fd_close.py
+++ b/tests/unit/ops/aio/test_fast_file_writer_fd_close.py
@@ -33,10 +33,15 @@ if not sys.platform.startswith("linux"):
 if get_accelerator().device_name() != 'cuda':
     pytest.skip("FastFileWriter requires CUDA-pinned tensors", allow_module_level=True)
 
-BLOCK_SIZE = 1 * 1024 * 1024
+BLOCK_SIZE = 4 * 1024
 QUEUE_DEPTH = 8
-PINNED_BYTES = 8 * 1024 * 1024
-PAYLOAD_BYTES = 1 * 1024 * 1024
+PINNED_BYTES = 8 * BLOCK_SIZE
+PAYLOAD_BYTES = 4 * BLOCK_SIZE
+
+try:
+    torch.zeros(PINNED_BYTES, dtype=torch.uint8).pin_memory()
+except RuntimeError:
+    pytest.skip("FastFileWriter requires a working CUDA-pinned host buffer", allow_module_level=True)
 
 
 def _count_deleted_fds(target_dir):


### PR DESCRIPTION
Run the FastFileWriter fd-close regression in the sequential CI bucket without pytest-forked.

The test exercises the real torch.save() through FastFileWriter with async I/O and pinned memory. The scheduled AWS [full CI failure](https://github.com/deepspeedai/DeepSpeed/pull/8015) happens before the fd-close assertion because the sequential bucket still runs under --forked, and CUDA-backed pinned memory is not safe in that forked worker context.

Marking this regression as sequential keeps it out of the parallel bucket, and removing --forked from the sequential run lets it test the intended close/unlink behavior.