### PR TITLE
Add configurable torch-latest dependency versions

### DIFF
--- a/.github/workflows/aws-torch-latest-full.yml
+++ b/.github/workflows/aws-torch-latest-full.yml
@@ -326,6 +326,23 @@ jobs:
           pip install --no-build-isolation .[dev,1bit,autotuning,deepcompile]
           ds_report
 
+      - name: Reinstall selected Transformers
+        run: |
+          case "$TRANSFORMERS_SOURCE" in
+            'pypi')
+              pip install --no-deps --force-reinstall "transformers==$TRANSFORMERS_VERSION"
+              ;;
+            'git')
+              cd /tmp/transformers
+              pip install --no-deps --force-reinstall .
+              ;;
+            *)
+              echo "Unsupported TRANSFORMERS_SOURCE: $TRANSFORMERS_SOURCE" >&2
+              exit 1
+              ;;
+          esac
+          python -c "import transformers; print('transformers:', transformers.__version__, transformers)"
+
       - name: Python environment
         run: |
           pip list

--- a/.github/workflows/aws-torch-latest-full.yml
+++ b/.github/workflows/aws-torch-latest-full.yml
@@ -34,6 +34,19 @@ on:
         required: false
         default: '4.50.0'
         type: string
+      transformers_source:
+        description: Hugging Face Transformers source for manual runs
+        required: false
+        default: 'pypi'
+        type: choice
+        options:
+          - 'pypi'
+          - 'git'
+      transformers_ref:
+        description: Hugging Face Transformers git ref to install when source is git
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -87,7 +100,9 @@ jobs:
 
     env:
       DEFAULT_TORCH_PRESET: '2.7.1-cu126'
+      DEFAULT_TRANSFORMERS_SOURCE: 'pypi'
       DEFAULT_TRANSFORMERS_VERSION: '4.50.0'
+      DEFAULT_TRANSFORMERS_REF: ''
       CUTLASS_PATH: /opt/cutlass
       # Disable reuse_dist_env to prevent pool worker cleanup hangs in full test runs
       DS_DISABLE_REUSE_DIST_ENV: '1'
@@ -108,7 +123,9 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MANUAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '' }}
+          MANUAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || '' }}
           MANUAL_TRANSFORMERS_VERSION: ${{ github.event.inputs.transformers_version || '' }}
+          MANUAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || '' }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TORCH_PRESET" ]; then
             selected_preset="$MANUAL_TORCH_PRESET"
@@ -116,10 +133,26 @@ jobs:
             selected_preset="$DEFAULT_TORCH_PRESET"
           fi
 
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_SOURCE" ]; then
+            transformers_source="$MANUAL_TRANSFORMERS_SOURCE"
+          else
+            transformers_source="$DEFAULT_TRANSFORMERS_SOURCE"
+          fi
+
           if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_VERSION" ]; then
             transformers_version="$MANUAL_TRANSFORMERS_VERSION"
           else
             transformers_version="$DEFAULT_TRANSFORMERS_VERSION"
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_REF" ]; then
+            transformers_ref="$MANUAL_TRANSFORMERS_REF"
+          else
+            transformers_ref="$DEFAULT_TRANSFORMERS_REF"
+          fi
+
+          if [ "$transformers_source" = 'git' ] && [ -z "$transformers_ref" ]; then
+            transformers_ref='main'
           fi
 
           case "$selected_preset" in
@@ -177,14 +210,18 @@ jobs:
             echo "TORCH_TEST_VERSION=$torch_test_version"
             echo "CUDA_TEST_VERSION=$cuda_test_version"
             echo "PYTORCH_INDEX_URL=$pytorch_index_url"
+            echo "TRANSFORMERS_SOURCE=$transformers_source"
             echo "TRANSFORMERS_VERSION=$transformers_version"
+            echo "TRANSFORMERS_REF=$transformers_ref"
           } >> "$GITHUB_ENV"
 
           echo "Selected PyTorch preset: $selected_preset"
           echo "Resolved install tuple: torch==$torch_install_version torchvision==$torchvision_install_version torchaudio==$torchaudio_install_version"
           echo "Resolved test expectations: torch=$torch_test_version cuda=$cuda_test_version"
           echo "Resolved PyTorch index: $pytorch_index_url"
+          echo "Resolved Transformers source: $transformers_source"
           echo "Resolved Transformers version: $transformers_version"
+          echo "Resolved Transformers ref: $transformers_ref"
 
       - name: Install CUTLASS
         run: |
@@ -202,7 +239,24 @@ jobs:
 
       - name: Install Transformers
         run: |
-          pip install "transformers==$TRANSFORMERS_VERSION"
+          case "$TRANSFORMERS_SOURCE" in
+            'pypi')
+              pip install "transformers==$TRANSFORMERS_VERSION"
+              ;;
+            'git')
+              git clone --filter=blob:none https://github.com/huggingface/transformers /tmp/transformers
+              cd /tmp/transformers
+              git checkout "$TRANSFORMERS_REF"
+              resolved_ref="$(git rev-parse HEAD)"
+              echo "TRANSFORMERS_RESOLVED_REF=$resolved_ref" >> "$GITHUB_ENV"
+              echo "Resolved Transformers git ref: $resolved_ref"
+              pip install .
+              ;;
+            *)
+              echo "Unsupported TRANSFORMERS_SOURCE: $TRANSFORMERS_SOURCE" >&2
+              exit 1
+              ;;
+          esac
           python -c "import transformers; print('transformers:', transformers.__version__, transformers)"
 
       - name: Install Python dependencies
@@ -220,7 +274,10 @@ jobs:
           echo "Install tuple: torch==$TORCH_INSTALL_VERSION torchvision==$TORCHVISION_INSTALL_VERSION torchaudio==$TORCHAUDIO_INSTALL_VERSION"
           echo "PyTorch index URL: $PYTORCH_INDEX_URL"
           echo "Expected test versions: torch=$TORCH_TEST_VERSION cuda=$CUDA_TEST_VERSION"
+          echo "Transformers source: $TRANSFORMERS_SOURCE"
           echo "Transformers version: $TRANSFORMERS_VERSION"
+          echo "Transformers ref: $TRANSFORMERS_REF"
+          echo "Transformers resolved ref: ${TRANSFORMERS_RESOLVED_REF:-}"
           echo ""
           echo "=== GPU Information ==="
           nvidia-smi

--- a/.github/workflows/aws-torch-latest-full.yml
+++ b/.github/workflows/aws-torch-latest-full.yml
@@ -21,7 +21,7 @@ on:
       torch_preset:
         description: PyTorch preset to install for manual runs
         required: false
-        default: '2.7.1-cu126'
+        default: '2.10.0-cu126'
         type: choice
         options:
           - '2.7.1-cu126'
@@ -37,7 +37,7 @@ on:
       transformers_source:
         description: Hugging Face Transformers source for manual runs
         required: false
-        default: 'pypi'
+        default: 'git'
         type: choice
         options:
           - 'pypi'
@@ -45,7 +45,7 @@ on:
       transformers_ref:
         description: Hugging Face Transformers git ref to install when source is git
         required: false
-        default: ''
+        default: 'main'
         type: string
 
 concurrency:
@@ -99,10 +99,10 @@ jobs:
       options: --gpus all --shm-size "32G" -v /mnt/aio:/mnt/aio
 
     env:
-      DEFAULT_TORCH_PRESET: '2.7.1-cu126'
-      DEFAULT_TRANSFORMERS_SOURCE: 'pypi'
+      DEFAULT_TORCH_PRESET: '2.10.0-cu126'
+      DEFAULT_TRANSFORMERS_SOURCE: 'git'
       DEFAULT_TRANSFORMERS_VERSION: '4.50.0'
-      DEFAULT_TRANSFORMERS_REF: ''
+      DEFAULT_TRANSFORMERS_REF: 'main'
       CUTLASS_PATH: /opt/cutlass
       # Disable reuse_dist_env to prevent pool worker cleanup hangs in full test runs
       DS_DISABLE_REUSE_DIST_ENV: '1'

--- a/.github/workflows/aws-torch-latest-full.yml
+++ b/.github/workflows/aws-torch-latest-full.yml
@@ -29,6 +29,11 @@ on:
           - '2.9.1-cu126'
           - '2.10.0-cu126'
           - '2.11.0-cu126'
+      transformers_version:
+        description: Hugging Face Transformers PyPI package version to install
+        required: false
+        default: '4.50.0'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -82,6 +87,7 @@ jobs:
 
     env:
       DEFAULT_TORCH_PRESET: '2.7.1-cu126'
+      DEFAULT_TRANSFORMERS_VERSION: '4.50.0'
       CUTLASS_PATH: /opt/cutlass
       # Disable reuse_dist_env to prevent pool worker cleanup hangs in full test runs
       DS_DISABLE_REUSE_DIST_ENV: '1'
@@ -98,15 +104,22 @@ jobs:
         with:
           lfs: true
 
-      - name: Resolve PyTorch preset
+      - name: Resolve dependency inputs
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MANUAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '' }}
+          MANUAL_TRANSFORMERS_VERSION: ${{ github.event.inputs.transformers_version || '' }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TORCH_PRESET" ]; then
             selected_preset="$MANUAL_TORCH_PRESET"
           else
             selected_preset="$DEFAULT_TORCH_PRESET"
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_VERSION" ]; then
+            transformers_version="$MANUAL_TRANSFORMERS_VERSION"
+          else
+            transformers_version="$DEFAULT_TRANSFORMERS_VERSION"
           fi
 
           case "$selected_preset" in
@@ -164,12 +177,14 @@ jobs:
             echo "TORCH_TEST_VERSION=$torch_test_version"
             echo "CUDA_TEST_VERSION=$cuda_test_version"
             echo "PYTORCH_INDEX_URL=$pytorch_index_url"
+            echo "TRANSFORMERS_VERSION=$transformers_version"
           } >> "$GITHUB_ENV"
 
-          echo "Selected preset: $selected_preset"
+          echo "Selected PyTorch preset: $selected_preset"
           echo "Resolved install tuple: torch==$torch_install_version torchvision==$torchvision_install_version torchaudio==$torchaudio_install_version"
           echo "Resolved test expectations: torch=$torch_test_version cuda=$cuda_test_version"
           echo "Resolved PyTorch index: $pytorch_index_url"
+          echo "Resolved Transformers version: $transformers_version"
 
       - name: Install CUTLASS
         run: |
@@ -185,12 +200,10 @@ jobs:
             torchaudio=="$TORCHAUDIO_INSTALL_VERSION" \
             --index-url "$PYTORCH_INDEX_URL"
 
-      - name: Install transformers
+      - name: Install Transformers
         run: |
-          git clone https://github.com/huggingface/transformers
-          cd transformers
-          git checkout 981c276
-          pip install .
+          pip install "transformers==$TRANSFORMERS_VERSION"
+          python -c "import transformers; print('transformers:', transformers.__version__, transformers)"
 
       - name: Install Python dependencies
         run: |
@@ -207,6 +220,7 @@ jobs:
           echo "Install tuple: torch==$TORCH_INSTALL_VERSION torchvision==$TORCHVISION_INSTALL_VERSION torchaudio==$TORCHAUDIO_INSTALL_VERSION"
           echo "PyTorch index URL: $PYTORCH_INDEX_URL"
           echo "Expected test versions: torch=$TORCH_TEST_VERSION cuda=$CUDA_TEST_VERSION"
+          echo "Transformers version: $TRANSFORMERS_VERSION"
           echo ""
           echo "=== GPU Information ==="
           nvidia-smi

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -6,7 +6,7 @@ on:
       torch_preset:
         description: PyTorch CPU preset to install for manual runs
         required: false
-        default: '2.7.1-cpu'
+        default: '2.10.0-cpu'
         type: choice
         options:
           - '2.7.1-cpu'
@@ -21,7 +21,7 @@ on:
       transformers_source:
         description: Hugging Face Transformers source for manual runs
         required: false
-        default: 'pypi'
+        default: 'git'
         type: choice
         options:
           - 'pypi'
@@ -29,7 +29,7 @@ on:
       transformers_ref:
         description: Hugging Face Transformers git ref to install when source is git
         required: false
-        default: ''
+        default: 'main'
         type: string
   pull_request:
     paths-ignore:
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      DEFAULT_TORCH_PRESET: '2.7.1-cpu'
-      DEFAULT_TRANSFORMERS_SOURCE: 'pypi'
+      DEFAULT_TORCH_PRESET: '2.10.0-cpu'
+      DEFAULT_TRANSFORMERS_SOURCE: 'git'
       DEFAULT_TRANSFORMERS_VERSION: '4.50.0'
-      DEFAULT_TRANSFORMERS_REF: ''
+      DEFAULT_TRANSFORMERS_REF: 'main'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -18,6 +18,19 @@ on:
         required: false
         default: '4.50.0'
         type: string
+      transformers_source:
+        description: Hugging Face Transformers source for manual runs
+        required: false
+        default: 'pypi'
+        type: choice
+        options:
+          - 'pypi'
+          - 'git'
+      transformers_ref:
+        description: Hugging Face Transformers git ref to install when source is git
+        required: false
+        default: ''
+        type: string
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -39,7 +52,9 @@ jobs:
 
     env:
       DEFAULT_TORCH_PRESET: '2.7.1-cpu'
+      DEFAULT_TRANSFORMERS_SOURCE: 'pypi'
       DEFAULT_TRANSFORMERS_VERSION: '4.50.0'
+      DEFAULT_TRANSFORMERS_REF: ''
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +70,9 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MANUAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '' }}
+          MANUAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || '' }}
           MANUAL_TRANSFORMERS_VERSION: ${{ github.event.inputs.transformers_version || '' }}
+          MANUAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || '' }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TORCH_PRESET" ]; then
             selected_preset="$MANUAL_TORCH_PRESET"
@@ -63,10 +80,26 @@ jobs:
             selected_preset="$DEFAULT_TORCH_PRESET"
           fi
 
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_SOURCE" ]; then
+            transformers_source="$MANUAL_TRANSFORMERS_SOURCE"
+          else
+            transformers_source="$DEFAULT_TRANSFORMERS_SOURCE"
+          fi
+
           if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_VERSION" ]; then
             transformers_version="$MANUAL_TRANSFORMERS_VERSION"
           else
             transformers_version="$DEFAULT_TRANSFORMERS_VERSION"
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_REF" ]; then
+            transformers_ref="$MANUAL_TRANSFORMERS_REF"
+          else
+            transformers_ref="$DEFAULT_TRANSFORMERS_REF"
+          fi
+
+          if [ "$transformers_source" = 'git' ] && [ -z "$transformers_ref" ]; then
+            transformers_ref='main'
           fi
 
           case "$selected_preset" in
@@ -102,13 +135,17 @@ jobs:
             echo "TORCHVISION_INSTALL_VERSION=$torchvision_install_version"
             echo "TORCH_TEST_VERSION=$torch_test_version"
             echo "PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu"
+            echo "TRANSFORMERS_SOURCE=$transformers_source"
             echo "TRANSFORMERS_VERSION=$transformers_version"
+            echo "TRANSFORMERS_REF=$transformers_ref"
           } >> "$GITHUB_ENV"
 
           echo "Selected PyTorch preset: $selected_preset"
           echo "Resolved install tuple: torch==$torch_install_version torchvision==$torchvision_install_version"
           echo "Resolved test expectation: torch=$torch_test_version"
+          echo "Resolved Transformers source: $transformers_source"
           echo "Resolved Transformers version: $transformers_version"
+          echo "Resolved Transformers ref: $transformers_ref"
 
       - name: Install PyTorch
         run: |
@@ -121,7 +158,24 @@ jobs:
 
       - name: Install Transformers
         run: |
-          pip install "transformers==$TRANSFORMERS_VERSION"
+          case "$TRANSFORMERS_SOURCE" in
+            'pypi')
+              pip install "transformers==$TRANSFORMERS_VERSION"
+              ;;
+            'git')
+              git clone --filter=blob:none https://github.com/huggingface/transformers /tmp/transformers
+              cd /tmp/transformers
+              git checkout "$TRANSFORMERS_REF"
+              resolved_ref="$(git rev-parse HEAD)"
+              echo "TRANSFORMERS_RESOLVED_REF=$resolved_ref" >> "$GITHUB_ENV"
+              echo "Resolved Transformers git ref: $resolved_ref"
+              pip install .
+              ;;
+            *)
+              echo "Unsupported TRANSFORMERS_SOURCE: $TRANSFORMERS_SOURCE" >&2
+              exit 1
+              ;;
+          esac
           python -c "import transformers; print('transformers:', transformers.__version__, transformers)"
 
       - name: Install deepspeed

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -2,6 +2,22 @@ name: cpu-torch-latest
 
 on:
   workflow_dispatch:
+    inputs:
+      torch_preset:
+        description: PyTorch CPU preset to install for manual runs
+        required: false
+        default: '2.7.1-cpu'
+        type: choice
+        options:
+          - '2.7.1-cpu'
+          - '2.8.0-cpu'
+          - '2.9.1-cpu'
+          - '2.10.0-cpu'
+      transformers_ref:
+        description: Hugging Face Transformers git ref/SHA to install
+        required: false
+        default: '981c276'
+        type: string
   pull_request:
     paths-ignore:
       - 'docs/**'
@@ -21,6 +37,10 @@ jobs:
   unit-tests:
     runs-on: ubuntu-24.04
 
+    env:
+      DEFAULT_TORCH_PRESET: '2.7.1-cpu'
+      DEFAULT_TRANSFORMERS_REF: '981c276'
+
     steps:
       - uses: actions/checkout@v4
 
@@ -31,18 +51,79 @@ jobs:
         run: |
           sudo apt-get install -y numactl pdsh
 
-      - name: Install pytorch
+      - name: Resolve dependency inputs
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          MANUAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '' }}
+          MANUAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || '' }}
         run: |
-          pip install torch==2.7.1 torchvision==0.22.1 --index-url https://download.pytorch.org/whl/cpu
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TORCH_PRESET" ]; then
+            selected_preset="$MANUAL_TORCH_PRESET"
+          else
+            selected_preset="$DEFAULT_TORCH_PRESET"
+          fi
+
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_REF" ]; then
+            transformers_ref="$MANUAL_TRANSFORMERS_REF"
+          else
+            transformers_ref="$DEFAULT_TRANSFORMERS_REF"
+          fi
+
+          case "$selected_preset" in
+            '2.7.1-cpu')
+              torch_install_version='2.7.1'
+              torchvision_install_version='0.22.1'
+              torch_test_version='2.7'
+              ;;
+            '2.8.0-cpu')
+              torch_install_version='2.8.0'
+              torchvision_install_version='0.23.0'
+              torch_test_version='2.8'
+              ;;
+            '2.9.1-cpu')
+              torch_install_version='2.9.1'
+              torchvision_install_version='0.24.1'
+              torch_test_version='2.9'
+              ;;
+            '2.10.0-cpu')
+              torch_install_version='2.10.0'
+              torchvision_install_version='0.25.0'
+              torch_test_version='2.10'
+              ;;
+            *)
+              echo "Unsupported torch_preset: $selected_preset" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "SELECTED_TORCH_PRESET=$selected_preset"
+            echo "TORCH_INSTALL_VERSION=$torch_install_version"
+            echo "TORCHVISION_INSTALL_VERSION=$torchvision_install_version"
+            echo "TORCH_TEST_VERSION=$torch_test_version"
+            echo "PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu"
+            echo "TRANSFORMERS_REF=$transformers_ref"
+          } >> "$GITHUB_ENV"
+
+          echo "Selected PyTorch preset: $selected_preset"
+          echo "Resolved install tuple: torch==$torch_install_version torchvision==$torchvision_install_version"
+          echo "Resolved test expectation: torch=$torch_test_version"
+          echo "Resolved Transformers ref: $transformers_ref"
+
+      - name: Install PyTorch
+        run: |
+          pip install \
+            torch=="$TORCH_INSTALL_VERSION" \
+            torchvision=="$TORCHVISION_INSTALL_VERSION" \
+            --index-url "$PYTORCH_INDEX_URL"
           python -c "import torch; print('torch:', torch.__version__, torch)"
           python -c "import torch; print('CUDA available:', torch.cuda.is_available())"
 
-      - name: Install transformers
+      - name: Install Transformers
         run: |
           git clone https://github.com/huggingface/transformers
           cd transformers
-          # if needed switch to the last known good SHA until transformers@master is fixed
-          # git checkout 981c276
+          git checkout "$TRANSFORMERS_REF"
           git rev-parse --short HEAD
           pip install .
 
@@ -59,5 +140,5 @@ jobs:
         run: |
           unset TORCH_CUDA_ARCH_LIST # only jit compile for current arch
           cd tests
-          HF_HOME=/tmp/hf_home/ pytest $PYTEST_OPTS --forked -n 4 unit/ --torch_ver="2.7.1+cpu"
-          HF_HOME=/tmp/hf_home/ pytest $PYTEST_OPTS --forked -m 'sequential' unit/ --torch_ver="2.7.1+cpu"
+          HF_HOME=/tmp/hf_home/ pytest $PYTEST_OPTS --forked -n 4 unit/ --torch_ver="$TORCH_TEST_VERSION"
+          HF_HOME=/tmp/hf_home/ pytest $PYTEST_OPTS --forked -m 'sequential' unit/ --torch_ver="$TORCH_TEST_VERSION"

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -183,6 +183,23 @@ jobs:
           pip install .[dev,autotuning]
           ds_report
 
+      - name: Reinstall selected Transformers
+        run: |
+          case "$TRANSFORMERS_SOURCE" in
+            'pypi')
+              pip install --no-deps --force-reinstall "transformers==$TRANSFORMERS_VERSION"
+              ;;
+            'git')
+              cd /tmp/transformers
+              pip install --no-deps --force-reinstall .
+              ;;
+            *)
+              echo "Unsupported TRANSFORMERS_SOURCE: $TRANSFORMERS_SOURCE" >&2
+              exit 1
+              ;;
+          esac
+          python -c "import transformers; print('transformers:', transformers.__version__, transformers)"
+
       - name: Python environment
         run: |
           pip list

--- a/.github/workflows/cpu-torch-latest.yml
+++ b/.github/workflows/cpu-torch-latest.yml
@@ -13,10 +13,10 @@ on:
           - '2.8.0-cpu'
           - '2.9.1-cpu'
           - '2.10.0-cpu'
-      transformers_ref:
-        description: Hugging Face Transformers git ref/SHA to install
+      transformers_version:
+        description: Hugging Face Transformers PyPI package version to install
         required: false
-        default: '981c276'
+        default: '4.50.0'
         type: string
   pull_request:
     paths-ignore:
@@ -39,7 +39,7 @@ jobs:
 
     env:
       DEFAULT_TORCH_PRESET: '2.7.1-cpu'
-      DEFAULT_TRANSFORMERS_REF: '981c276'
+      DEFAULT_TRANSFORMERS_VERSION: '4.50.0'
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           MANUAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '' }}
-          MANUAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || '' }}
+          MANUAL_TRANSFORMERS_VERSION: ${{ github.event.inputs.transformers_version || '' }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TORCH_PRESET" ]; then
             selected_preset="$MANUAL_TORCH_PRESET"
@@ -63,10 +63,10 @@ jobs:
             selected_preset="$DEFAULT_TORCH_PRESET"
           fi
 
-          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_REF" ]; then
-            transformers_ref="$MANUAL_TRANSFORMERS_REF"
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ] && [ -n "$MANUAL_TRANSFORMERS_VERSION" ]; then
+            transformers_version="$MANUAL_TRANSFORMERS_VERSION"
           else
-            transformers_ref="$DEFAULT_TRANSFORMERS_REF"
+            transformers_version="$DEFAULT_TRANSFORMERS_VERSION"
           fi
 
           case "$selected_preset" in
@@ -102,13 +102,13 @@ jobs:
             echo "TORCHVISION_INSTALL_VERSION=$torchvision_install_version"
             echo "TORCH_TEST_VERSION=$torch_test_version"
             echo "PYTORCH_INDEX_URL=https://download.pytorch.org/whl/cpu"
-            echo "TRANSFORMERS_REF=$transformers_ref"
+            echo "TRANSFORMERS_VERSION=$transformers_version"
           } >> "$GITHUB_ENV"
 
           echo "Selected PyTorch preset: $selected_preset"
           echo "Resolved install tuple: torch==$torch_install_version torchvision==$torchvision_install_version"
           echo "Resolved test expectation: torch=$torch_test_version"
-          echo "Resolved Transformers ref: $transformers_ref"
+          echo "Resolved Transformers version: $transformers_version"
 
       - name: Install PyTorch
         run: |
@@ -121,11 +121,8 @@ jobs:
 
       - name: Install Transformers
         run: |
-          git clone https://github.com/huggingface/transformers
-          cd transformers
-          git checkout "$TRANSFORMERS_REF"
-          git rev-parse --short HEAD
-          pip install .
+          pip install "transformers==$TRANSFORMERS_VERSION"
+          python -c "import transformers; print('transformers:', transformers.__version__, transformers)"
 
       - name: Install deepspeed
         run: |

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -102,7 +102,7 @@ jobs:
       # and it too is then updated at https://github.com/deepspeedai/deepspeed/settings/secrets/actions
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
-    if: needs.collect-tests.outputs.deepspeed == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.collect-tests.outputs.deepspeed == 'true'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -16,6 +16,18 @@ name: modal-torch-latest
 
 on:
   workflow_dispatch:
+    inputs:
+      torch_preset:
+        description: Modal PyTorch/CUDA image preset for manual runs
+        required: false
+        default: '2.9.1-cuda12.8'
+        type: choice
+        options:
+          - '2.7.1-cuda12.8'
+          - '2.8.0-cuda12.8'
+          - '2.9.1-cuda12.8'
+          - '2.10.0-cuda12.8'
+          - '2.11.0-cuda12.8'
 
   push:
     branches:
@@ -96,5 +108,7 @@ jobs:
           uv pip install --system modal
 
       - name: Run tests
+        env:
+          MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.9.1-cuda12.8' }}
         run: |
           modal run -m ci.torch_latest

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -28,6 +28,19 @@ on:
           - '2.9.1-cuda12.8'
           - '2.10.0-cuda12.8'
           - '2.11.0-cuda12.8'
+      transformers_source:
+        description: Hugging Face Transformers source for manual runs
+        required: false
+        default: 'requirements'
+        type: choice
+        options:
+          - 'requirements'
+          - 'git'
+      transformers_ref:
+        description: Hugging Face Transformers git ref to install when source is git
+        required: false
+        default: ''
+        type: string
 
   push:
     branches:
@@ -64,7 +77,7 @@ jobs:
           lfs: true
 
       - name: Filter changed files
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -110,5 +123,7 @@ jobs:
       - name: Run tests
         env:
           MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.9.1-cuda12.8' }}
+          MODAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || 'requirements' }}
+          MODAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || '' }}
         run: |
           modal run -m ci.torch_latest

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -20,7 +20,7 @@ on:
       torch_preset:
         description: Modal PyTorch/CUDA image preset for manual runs
         required: false
-        default: '2.9.1-cuda12.8'
+        default: '2.10.0-cuda12.8'
         type: choice
         options:
           - '2.7.1-cuda12.8'
@@ -31,7 +31,7 @@ on:
       transformers_source:
         description: Hugging Face Transformers source for manual runs
         required: false
-        default: 'requirements'
+        default: 'git'
         type: choice
         options:
           - 'requirements'
@@ -39,7 +39,7 @@ on:
       transformers_ref:
         description: Hugging Face Transformers git ref to install when source is git
         required: false
-        default: ''
+        default: 'main'
         type: string
 
   push:
@@ -122,8 +122,8 @@ jobs:
 
       - name: Run tests
         env:
-          MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.9.1-cuda12.8' }}
-          MODAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || 'requirements' }}
-          MODAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || '' }}
+          MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.10.0-cuda12.8' }}
+          MODAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || 'git' }}
+          MODAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || 'main' }}
         run: |
           modal run -m ci.torch_latest

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -99,6 +99,11 @@ MODAL_CUDA_TEST_VERSION = MODAL_TORCH_CONFIG["cuda_test_version"]
 # yapf: disable
 image = (modal.Image
          .from_registry(MODAL_TORCH_IMAGE, add_python="3.10")
+         .env({
+             "MODAL_TORCH_PRESET": MODAL_TORCH_CONFIG["preset"],
+             "MODAL_TRANSFORMERS_SOURCE": MODAL_TRANSFORMERS_CONFIG["source"],
+             "MODAL_TRANSFORMERS_REF": MODAL_TRANSFORMERS_CONFIG["ref"],
+         })
          .run_commands("apt update && apt install -y git libaio-dev")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-dev.txt", gpu="any")

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import modal
 
 ROOT_PATH = Path(__file__).parents[1]
-DEFAULT_MODAL_TORCH_PRESET = "2.9.1-cuda12.8"
-DEFAULT_MODAL_TRANSFORMERS_SOURCE = "requirements"
+DEFAULT_MODAL_TORCH_PRESET = "2.10.0-cuda12.8"
+DEFAULT_MODAL_TRANSFORMERS_SOURCE = "git"
 MODAL_TORCH_PRESETS = {
     "2.7.1-cuda12.8": {
         "image": "pytorch/pytorch:2.7.1-cuda12.8-cudnn9-devel",

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -4,12 +4,14 @@
 # DeepSpeed Team
 
 import os
+import shlex
 from pathlib import Path
 
 import modal
 
 ROOT_PATH = Path(__file__).parents[1]
 DEFAULT_MODAL_TORCH_PRESET = "2.9.1-cuda12.8"
+DEFAULT_MODAL_TRANSFORMERS_SOURCE = "requirements"
 MODAL_TORCH_PRESETS = {
     "2.7.1-cuda12.8": {
         "image": "pytorch/pytorch:2.7.1-cuda12.8-cudnn9-devel",
@@ -53,7 +55,43 @@ def resolve_modal_torch_config():
     }
 
 
+def resolve_modal_transformers_config():
+    transformers_source = os.environ.get("MODAL_TRANSFORMERS_SOURCE") or DEFAULT_MODAL_TRANSFORMERS_SOURCE
+    supported_sources = {"requirements", "git"}
+    if transformers_source not in supported_sources:
+        supported = ", ".join(sorted(supported_sources))
+        raise ValueError(
+            f"Unsupported MODAL_TRANSFORMERS_SOURCE={transformers_source!r}; supported values: {supported}"
+        )
+
+    transformers_ref = os.environ.get("MODAL_TRANSFORMERS_REF") or ""
+    if transformers_source == "git" and not transformers_ref:
+        transformers_ref = "main"
+
+    return {
+        "source": transformers_source,
+        "ref": transformers_ref,
+    }
+
+
+def transformers_override_commands():
+    if MODAL_TRANSFORMERS_CONFIG["source"] == "requirements":
+        return ()
+
+    transformers_ref = shlex.quote(MODAL_TRANSFORMERS_CONFIG["ref"])
+    return (
+        "rm -rf /tmp/transformers",
+        "git clone --filter=blob:none https://github.com/huggingface/transformers /tmp/transformers",
+        "cd /tmp/transformers && "
+        f"git checkout {transformers_ref} && "
+        "resolved_ref=$(git rev-parse HEAD) && "
+        "echo \"Resolved Transformers git ref: ${resolved_ref}\" && "
+        "pip install .",
+    )
+
+
 MODAL_TORCH_CONFIG = resolve_modal_torch_config()
+MODAL_TRANSFORMERS_CONFIG = resolve_modal_transformers_config()
 MODAL_TORCH_IMAGE = MODAL_TORCH_CONFIG["image"]
 MODAL_TORCH_TEST_VERSION = MODAL_TORCH_CONFIG["torch_test_version"]
 MODAL_CUDA_TEST_VERSION = MODAL_TORCH_CONFIG["cuda_test_version"]
@@ -61,10 +99,17 @@ MODAL_CUDA_TEST_VERSION = MODAL_TORCH_CONFIG["cuda_test_version"]
 # yapf: disable
 image = (modal.Image
          .from_registry(MODAL_TORCH_IMAGE, add_python="3.10")
-         .run_commands("apt update && apt install -y libaio-dev")
+         .run_commands("apt update && apt install -y git libaio-dev")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-dev.txt", gpu="any")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-deepcompile.txt", gpu="any")
+        )
+
+transformers_commands = transformers_override_commands()
+if transformers_commands:
+    image = image.run_commands(*transformers_commands)
+
+image = (image
          .add_local_dir(ROOT_PATH , remote_path="/root/", copy=True)
          .run_commands("pip install /root")
          .add_local_dir(ROOT_PATH / "accelerator", remote_path="/root/deepspeed/accelerator")

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -15,30 +15,41 @@ DEFAULT_MODAL_TRANSFORMERS_SOURCE = "requirements"
 MODAL_TORCH_PRESETS = {
     "2.7.1-cuda12.8": {
         "image": "pytorch/pytorch:2.7.1-cuda12.8-cudnn9-devel",
+        "torch_package": "torch==2.7.1",
+        "torchvision_package": "torchvision==0.22.1",
         "torch_test_version": "2.7",
         "cuda_test_version": "12.8",
     },
     "2.8.0-cuda12.8": {
         "image": "pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel",
+        "torch_package": "torch==2.8.0",
+        "torchvision_package": "torchvision==0.23.0",
         "torch_test_version": "2.8",
         "cuda_test_version": "12.8",
     },
     "2.9.1-cuda12.8": {
         "image": "pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel",
+        "torch_package": "torch==2.9.1",
+        "torchvision_package": "torchvision==0.24.1",
         "torch_test_version": "2.9",
         "cuda_test_version": "12.8",
     },
     "2.10.0-cuda12.8": {
         "image": "pytorch/pytorch:2.10.0-cuda12.8-cudnn9-devel",
+        "torch_package": "torch==2.10.0",
+        "torchvision_package": "torchvision==0.25.0",
         "torch_test_version": "2.10",
         "cuda_test_version": "12.8",
     },
     "2.11.0-cuda12.8": {
         "image": "pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel",
+        "torch_package": "torch==2.11.0",
+        "torchvision_package": "torchvision==0.26.0",
         "torch_test_version": "2.11",
         "cuda_test_version": "12.8",
     },
 }
+PYTORCH_CUDA_128_INDEX_URL = "https://download.pytorch.org/whl/cu128"
 
 
 def resolve_modal_torch_config():
@@ -90,6 +101,20 @@ def transformers_override_commands():
     )
 
 
+def torch_package_reinstall_command():
+    command = [
+        "pip",
+        "install",
+        "--force-reinstall",
+        "--no-cache-dir",
+        "--index-url",
+        PYTORCH_CUDA_128_INDEX_URL,
+        MODAL_TORCH_CONFIG["torch_package"],
+        MODAL_TORCH_CONFIG["torchvision_package"],
+    ]
+    return " ".join(shlex.quote(part) for part in command)
+
+
 MODAL_TORCH_CONFIG = resolve_modal_torch_config()
 MODAL_TRANSFORMERS_CONFIG = resolve_modal_transformers_config()
 MODAL_TORCH_IMAGE = MODAL_TORCH_CONFIG["image"]
@@ -108,6 +133,7 @@ image = (modal.Image
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-dev.txt", gpu="any")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-deepcompile.txt", gpu="any")
+         .run_commands(torch_package_reinstall_command())
         )
 
 transformers_commands = transformers_override_commands()
@@ -132,6 +158,22 @@ app = modal.App("deepspeedai-torch-latest-ci", image=image)
 )
 def pytest():
     import subprocess
+
+    subprocess.run(
+        [
+            "python",
+            "-c",
+            "import json, torch, torchvision, transformers; "
+            "print('Modal Python package versions: ' + json.dumps({"
+            "'torch': torch.__version__, "
+            "'torch_cuda': torch.version.cuda, "
+            "'torchvision': torchvision.__version__, "
+            "'transformers': transformers.__version__"
+            "}, sort_keys=True))",
+        ],
+        check=True,
+        cwd=ROOT_PATH / ".",
+    )
     subprocess.run(
         f"pytest -n 4 --verbose tests/unit/v1/ --torch_ver={MODAL_TORCH_TEST_VERSION} "
         f"--cuda_ver={MODAL_CUDA_TEST_VERSION}".split(),

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -3,15 +3,64 @@
 
 # DeepSpeed Team
 
+import os
 from pathlib import Path
 
 import modal
 
 ROOT_PATH = Path(__file__).parents[1]
+DEFAULT_MODAL_TORCH_PRESET = "2.9.1-cuda12.8"
+MODAL_TORCH_PRESETS = {
+    "2.7.1-cuda12.8": {
+        "image": "pytorch/pytorch:2.7.1-cuda12.8-cudnn9-devel",
+        "torch_test_version": "2.7",
+        "cuda_test_version": "12.8",
+    },
+    "2.8.0-cuda12.8": {
+        "image": "pytorch/pytorch:2.8.0-cuda12.8-cudnn9-devel",
+        "torch_test_version": "2.8",
+        "cuda_test_version": "12.8",
+    },
+    "2.9.1-cuda12.8": {
+        "image": "pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel",
+        "torch_test_version": "2.9",
+        "cuda_test_version": "12.8",
+    },
+    "2.10.0-cuda12.8": {
+        "image": "pytorch/pytorch:2.10.0-cuda12.8-cudnn9-devel",
+        "torch_test_version": "2.10",
+        "cuda_test_version": "12.8",
+    },
+    "2.11.0-cuda12.8": {
+        "image": "pytorch/pytorch:2.11.0-cuda12.8-cudnn9-devel",
+        "torch_test_version": "2.11",
+        "cuda_test_version": "12.8",
+    },
+}
+
+
+def resolve_modal_torch_config():
+    selected_preset = os.environ.get("MODAL_TORCH_PRESET") or DEFAULT_MODAL_TORCH_PRESET
+    try:
+        preset_config = MODAL_TORCH_PRESETS[selected_preset]
+    except KeyError as exc:
+        supported = ", ".join(sorted(MODAL_TORCH_PRESETS))
+        raise ValueError(f"Unsupported MODAL_TORCH_PRESET={selected_preset!r}; supported values: {supported}") from exc
+
+    return {
+        "preset": selected_preset,
+        **preset_config,
+    }
+
+
+MODAL_TORCH_CONFIG = resolve_modal_torch_config()
+MODAL_TORCH_IMAGE = MODAL_TORCH_CONFIG["image"]
+MODAL_TORCH_TEST_VERSION = MODAL_TORCH_CONFIG["torch_test_version"]
+MODAL_CUDA_TEST_VERSION = MODAL_TORCH_CONFIG["cuda_test_version"]
 
 # yapf: disable
 image = (modal.Image
-         .from_registry("pytorch/pytorch:2.9.1-cuda12.8-cudnn9-devel", add_python="3.10")
+         .from_registry(MODAL_TORCH_IMAGE, add_python="3.10")
          .run_commands("apt update && apt install -y libaio-dev")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-dev.txt", gpu="any")
@@ -34,7 +83,8 @@ app = modal.App("deepspeedai-torch-latest-ci", image=image)
 def pytest():
     import subprocess
     subprocess.run(
-        "pytest -n 4 --verbose tests/unit/v1/ --torch_ver=2.9 --cuda_ver=12.8".split(),
+        f"pytest -n 4 --verbose tests/unit/v1/ --torch_ver={MODAL_TORCH_TEST_VERSION} "
+        f"--cuda_ver={MODAL_CUDA_TEST_VERSION}".split(),
         check=True,
         cwd=ROOT_PATH / ".",
     )

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -72,8 +72,7 @@ def resolve_modal_transformers_config():
     if transformers_source not in supported_sources:
         supported = ", ".join(sorted(supported_sources))
         raise ValueError(
-            f"Unsupported MODAL_TRANSFORMERS_SOURCE={transformers_source!r}; supported values: {supported}"
-        )
+            f"Unsupported MODAL_TRANSFORMERS_SOURCE={transformers_source!r}; supported values: {supported}")
 
     transformers_ref = os.environ.get("MODAL_TRANSFORMERS_REF") or ""
     if transformers_source == "git" and not transformers_ref:


### PR DESCRIPTION
## Summary

The modal test now shows the error because of the combination of PyTorch v2.7 and Transformer `main` branch, and it is blocking PRs. To address it, we improve our test workflows as follows.

- Add manual dependency version inputs for the torch-latest CI workflows and default the torch-latest family to PyTorch 2.10 plus Transformers git `main`.
- Let CPU and AWS full torch-latest runs select either released Transformers package versions or an explicit Transformers git ref for manual validation.
- Let Modal torch-latest runs select supported PyTorch/CUDA image presets and an optional Transformers git ref, defaulting to `2.10.0-cuda12.8` and Transformers git `main`.

## Known follow-up

- The AWS full real CI lane for PyTorch 2.10 plus Transformers main reached `Unit tests (parallel)` but failed with 33 failures. Some of these may overlap with fixes in #8015; I am opening this PR now so the workflow/input changes can be reviewed while those failures are handled separately.
- CPU and Modal real CI validation for the requested tuple passed.