### PR TITLE
Sort and dedupe -gencode flags emitted by op_builder.builder

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -689,41 +689,47 @@ class CUDAOpBuilder(OpBuilder):
             raise RuntimeError(
                 f"Unable to load {self.name} op due to no compute capabilities remaining after filtering")
 
-        # Sort and dedupe so the emitted -gencode sequence is deterministic and
-        # matches PyTorch's own canonicalisation (see #7871). Use a tuple key
-        # of (major, minor, has_PTX) so X.Y stays distinct from X.Y+PTX and the
-        # +PTX variant always sorts after the bare arch, with no ties left for
-        # hash-ordered iteration to resolve non-deterministically.
-        def _cc_sort_key(cc):
+        # Canonicalize by numeric (major, minor) so the emitted -gencode
+        # sequence matches PyTorch's own dedupe (see #7871). For mixed inputs
+        # such as "8.0;8.0+PTX" or "8.0+PTX;8.0", PyTorch collapses to one
+        # sm_80 entry plus one compute_80 PTX entry. Track has_PTX per arch
+        # as the OR across all variants of that arch so any +PTX appearance
+        # carries through after dedupe.
+        canonical = {}
+        for cc in ccs:
             major = int(cc[0])
             minor_part = cc[1]
             has_ptx = minor_part.endswith('+PTX')
             minor = int(minor_part.split('+')[0])
-            return (major, minor, has_ptx)
-
-        unique_ccs = {tuple(cc): None for cc in ccs}
-        ccs = [list(cc) for cc in sorted(unique_ccs, key=_cc_sort_key)]
+            key = (major, minor)
+            canonical[key] = canonical.get(key, False) or has_ptx
+        canonical_archs = sorted(canonical.items())
 
         self.enable_bf16 = True
-        for cc in ccs:
-            if int(cc[0]) <= 7:
+        for (major, _minor), _has_ptx in canonical_archs:
+            if major <= 7:
                 self.enable_bf16 = False
 
         # Keep TORCH_CUDA_ARCH_LIST in sync with the filtered arch list so
-        # PyTorch does not re-add archs that filter_ccs() removed.
-        arch_list = ";".join(f"{cc[0]}.{cc[1]}" for cc in ccs)
-        os.environ["TORCH_CUDA_ARCH_LIST"] = arch_list
+        # PyTorch does not re-add archs that filter_ccs() removed. Emit one
+        # token per arch using the X.Y or X.Y+PTX form, matching PyTorch's
+        # canonical parsing where +PTX on an arch token already implies both
+        # the sm and PTX emissions for that arch.
+        arch_tokens = [f"{major}.{minor}{'+PTX' if has_ptx else ''}" for (major, minor), has_ptx in canonical_archs]
+        os.environ["TORCH_CUDA_ARCH_LIST"] = ";".join(arch_tokens)
 
         if self.jit_mode:
             # Let PyTorch generate -gencode flags from the env var.
             return []
 
         # Non-JIT: return explicit flags per builder for extra_compile_args.
+        # Emit exactly one sm_X line per arch, followed by one compute_X PTX
+        # line when any variant of that arch carried +PTX.
         args = []
-        for cc in ccs:
-            num = cc[0] + cc[1].split('+')[0]
+        for (major, minor), has_ptx in canonical_archs:
+            num = f"{major}{minor}"
             args.append(f'-gencode=arch=compute_{num},code=sm_{num}')
-            if cc[1].endswith('+PTX'):
+            if has_ptx:
                 args.append(f'-gencode=arch=compute_{num},code=compute_{num}')
 
         return args

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -689,6 +689,21 @@ class CUDAOpBuilder(OpBuilder):
             raise RuntimeError(
                 f"Unable to load {self.name} op due to no compute capabilities remaining after filtering")
 
+        # Sort and dedupe so the emitted -gencode sequence is deterministic and
+        # matches PyTorch's own canonicalisation (see #7871). Use a tuple key
+        # of (major, minor, has_PTX) so X.Y stays distinct from X.Y+PTX and the
+        # +PTX variant always sorts after the bare arch, with no ties left for
+        # hash-ordered iteration to resolve non-deterministically.
+        def _cc_sort_key(cc):
+            major = int(cc[0])
+            minor_part = cc[1]
+            has_ptx = minor_part.endswith('+PTX')
+            minor = int(minor_part.split('+')[0])
+            return (major, minor, has_ptx)
+
+        unique_ccs = {tuple(cc): None for cc in ccs}
+        ccs = [list(cc) for cc in sorted(unique_ccs, key=_cc_sort_key)]
+
         self.enable_bf16 = True
         for cc in ccs:
             if int(cc[0]) <= 7:

--- a/tests/unit/ops/test_op_builder.py
+++ b/tests/unit/ops/test_op_builder.py
@@ -179,20 +179,39 @@ def test_non_jit_branch_sorts_and_dedupes_gencode_flags():
     ]
 
 
-def test_non_jit_branch_orders_ptx_after_bare_arch_deterministically():
-    # Regression for hash-ordered set iteration with mixed X.Y and X.Y+PTX
-    # entries. X.Y and X.Y+PTX must stay distinct and the +PTX variant must
-    # always sort after the bare arch, regardless of input order or hash seed.
-    expected_arch_list = "7.5;8.0;8.0+PTX"
+def test_non_jit_branch_canonicalizes_mixed_ptx_variants_to_one_sm_and_one_ptx():
+    # For mixed inputs such as "8.0;8.0+PTX" or "8.0+PTX;8.0", PyTorch
+    # canonicalizes the architecture to one sm_80 entry plus one compute_80
+    # PTX entry. Dedupe by the canonical numeric arch so we match.
+    expected_arch_list = "7.5;8.0+PTX"
     expected_args = [
         "-gencode=arch=compute_75,code=sm_75",
-        "-gencode=arch=compute_80,code=sm_80",
         "-gencode=arch=compute_80,code=sm_80",
         "-gencode=arch=compute_80,code=compute_80",
     ]
 
     for arch_input in ("8.0;8.0+PTX;7.5", "7.5;8.0+PTX;8.0", "8.0+PTX;7.5;8.0", "8.0;7.5;8.0+PTX"):
         builder = make_builder(jit_mode=False)
+        with patch.dict(os.environ, {"TORCH_CUDA_ARCH_LIST": arch_input}, clear=False):
+            args = builder.compute_capability_args()
+            assert os.environ["TORCH_CUDA_ARCH_LIST"] == expected_arch_list, arch_input
+        assert args == expected_args, arch_input
+
+
+def test_non_jit_branch_canonical_dedupe_mixed_ptx_combinations():
+    # Lock in the four mixed-PTX combinations for a single arch so the dedupe
+    # behavior cannot regress on either ordering or duplication.
+    builder = make_builder(jit_mode=False)
+    cases = [
+        ("8.0;8.0+PTX", "8.0+PTX",
+         ["-gencode=arch=compute_80,code=sm_80", "-gencode=arch=compute_80,code=compute_80"]),
+        ("8.0+PTX;8.0", "8.0+PTX",
+         ["-gencode=arch=compute_80,code=sm_80", "-gencode=arch=compute_80,code=compute_80"]),
+        ("8.0;8.0", "8.0", ["-gencode=arch=compute_80,code=sm_80"]),
+        ("8.0+PTX;8.0+PTX", "8.0+PTX",
+         ["-gencode=arch=compute_80,code=sm_80", "-gencode=arch=compute_80,code=compute_80"]),
+    ]
+    for arch_input, expected_arch_list, expected_args in cases:
         with patch.dict(os.environ, {"TORCH_CUDA_ARCH_LIST": arch_input}, clear=False):
             args = builder.compute_capability_args()
             assert os.environ["TORCH_CUDA_ARCH_LIST"] == expected_arch_list, arch_input

--- a/tests/unit/ops/test_op_builder.py
+++ b/tests/unit/ops/test_op_builder.py
@@ -163,3 +163,37 @@ def test_non_jit_branch_unchanged():
         "-gencode=arch=compute_89,code=sm_89",
         "-gencode=arch=compute_89,code=compute_89",
     ]
+
+
+def test_non_jit_branch_sorts_and_dedupes_gencode_flags():
+    builder = make_builder(jit_mode=False)
+
+    with patch.dict(os.environ, {"TORCH_CUDA_ARCH_LIST": "8.0;7.5;8.0;7.0"}, clear=False):
+        args = builder.compute_capability_args()
+        assert os.environ["TORCH_CUDA_ARCH_LIST"] == "7.0;7.5;8.0"
+
+    assert args == [
+        "-gencode=arch=compute_70,code=sm_70",
+        "-gencode=arch=compute_75,code=sm_75",
+        "-gencode=arch=compute_80,code=sm_80",
+    ]
+
+
+def test_non_jit_branch_orders_ptx_after_bare_arch_deterministically():
+    # Regression for hash-ordered set iteration with mixed X.Y and X.Y+PTX
+    # entries. X.Y and X.Y+PTX must stay distinct and the +PTX variant must
+    # always sort after the bare arch, regardless of input order or hash seed.
+    expected_arch_list = "7.5;8.0;8.0+PTX"
+    expected_args = [
+        "-gencode=arch=compute_75,code=sm_75",
+        "-gencode=arch=compute_80,code=sm_80",
+        "-gencode=arch=compute_80,code=sm_80",
+        "-gencode=arch=compute_80,code=compute_80",
+    ]
+
+    for arch_input in ("8.0;8.0+PTX;7.5", "7.5;8.0+PTX;8.0", "8.0+PTX;7.5;8.0", "8.0;7.5;8.0+PTX"):
+        builder = make_builder(jit_mode=False)
+        with patch.dict(os.environ, {"TORCH_CUDA_ARCH_LIST": arch_input}, clear=False):
+            args = builder.compute_capability_args()
+            assert os.environ["TORCH_CUDA_ARCH_LIST"] == expected_arch_list, arch_input
+        assert args == expected_args, arch_input

--- a/tests/unit/ops/test_op_builder.py
+++ b/tests/unit/ops/test_op_builder.py
@@ -203,10 +203,10 @@ def test_non_jit_branch_canonical_dedupe_mixed_ptx_combinations():
     # behavior cannot regress on either ordering or duplication.
     builder = make_builder(jit_mode=False)
     cases = [
-        ("8.0;8.0+PTX", "8.0+PTX",
-         ["-gencode=arch=compute_80,code=sm_80", "-gencode=arch=compute_80,code=compute_80"]),
-        ("8.0+PTX;8.0", "8.0+PTX",
-         ["-gencode=arch=compute_80,code=sm_80", "-gencode=arch=compute_80,code=compute_80"]),
+        ("8.0;8.0+PTX", "8.0+PTX", ["-gencode=arch=compute_80,code=sm_80",
+                                    "-gencode=arch=compute_80,code=compute_80"]),
+        ("8.0+PTX;8.0", "8.0+PTX", ["-gencode=arch=compute_80,code=sm_80",
+                                    "-gencode=arch=compute_80,code=compute_80"]),
         ("8.0;8.0", "8.0", ["-gencode=arch=compute_80,code=sm_80"]),
         ("8.0+PTX;8.0+PTX", "8.0+PTX",
          ["-gencode=arch=compute_80,code=sm_80", "-gencode=arch=compute_80,code=compute_80"]),


### PR DESCRIPTION
## Summary
- Sort and dedupe `ccs` in `CUDAOpBuilder.compute_capability_args` so the emitted `-gencode` flags are deterministic regardless of the order in which architectures appear in `TORCH_CUDA_ARCH_LIST` or `cross_compile_archs`.
- Matches PyTorch's own canonicalisation, which already sorts the gencode sequence (noted in #7871 while investigating #7863).
- Also dedupes so repeated arches do not produce duplicate `-gencode` entries.

## Why
Issue #7871 observed that PyTorch sorts `-gencode` flags but DeepSpeed emits them in the order entries appear in `TORCH_CUDA_ARCH_LIST`. That order dependence contributed to the regression discussed in #7863. The non-JIT branch in `op_builder/builder.py` did not sort or dedupe before iterating over `self.ccs()`, so calls like `TORCH_CUDA_ARCH_LIST="8.0;7.5;8.0;7.0"` produced an out-of-order, duplicated flag sequence. The JIT branch already sorts (line 669), so this brings the non-JIT branch in line.

## Changes
- `op_builder/builder.py`: after `filter_ccs`, sort and dedupe `ccs` by numeric `(major, minor)` (stripping any `+PTX` suffix for comparison). The downstream `+PTX` handling at the emission site is preserved.
- `tests/unit/ops/test_op_builder.py`: new `test_non_jit_branch_sorts_and_dedupes_gencode_flags` covering the unsorted + duplicated input case. The existing `test_non_jit_branch_unchanged` continues to pass.

## Test plan
- [x] `pytest tests/unit/ops/test_op_builder.py -x -v` (7 passed, including the new test and the prior non-JIT regression test)
- [x] `yapf` (no diff)
- [x] `codespell` (clean)

Fixes #7871