### PR TITLE
fix(zero): enable vmap on LinearFunctionForZeroStage3

### DIFF
--- a/deepspeed/runtime/zero/linear.py
+++ b/deepspeed/runtime/zero/linear.py
@@ -78,6 +78,8 @@ def _get_autocast_dtype(device_type):
 
 class LinearFunctionForZeroStage3(torch.autograd.Function):
 
+    generate_vmap_rule = True
+
     @staticmethod
     # bias is an optional argument
     def forward(input, weight, bias=None):

--- a/tests/unit/v1/zero/test_zero_functorch_linear.py
+++ b/tests/unit/v1/zero/test_zero_functorch_linear.py
@@ -201,3 +201,19 @@ class TestZeroLinearAutocast(DistributedTest):
         assert hasattr(grad_fn, "_dtype")
         out.sum().backward()
         assert torch.isfinite(weight.grad).all()
+
+
+class TestLinearFunctionVmap(DistributedTest):
+    """``LinearFunctionForZeroStage3`` must accept ``torch.func.vmap`` directly."""
+
+    world_size = 1
+
+    def test_vmap_over_linear_function(self):
+        from deepspeed.runtime.zero.linear import LinearFunctionForZeroStage3
+        device = get_accelerator().device_name()
+        weight = torch.randn(4, 8, device=device, requires_grad=True)
+        bias = torch.randn(4, device=device, requires_grad=True)
+        xs = torch.randn(3, 8, device=device)
+        y = torch.func.vmap(lambda xi: LinearFunctionForZeroStage3.apply(xi, weight, bias).sum())(xs)
+        ref = torch.func.vmap(lambda xi: (xi @ weight.t() + bias).sum())(xs)
+        assert torch.allclose(y, ref, atol=1e-5)


### PR DESCRIPTION
Follow-up to #7916.

Adds `generate_vmap_rule = True` to `LinearFunctionForZeroStage3` so `torch.func.vmap` works on the Function directly. The previous PR covered `grad` / `jacrev` via `setup_context` but not `vmap`.

Test:
`pytest tests/unit/v1/zero/test_zero_functorch_linear.py::TestLinearFunctionVmap`
