### PR TITLE
zero3: invalidate coordinator trace on hook re-registration

### DIFF
--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -305,6 +305,13 @@ class DeepSpeedZeRoOffload(object):
         return persistent_params
 
     def _register_deepspeed_module(self, module, count=[0]):
+        # re-registering hooks on the root module (e.g. after an out-of-band generate that
+        # ran with hooks removed) leaves the coordinator trace stale; invalidate so it
+        # re-records on the next forward.
+        if module is self.module:
+            coordinator = self.get_param_coordinator()
+            if coordinator is not None and not coordinator.is_invalid_trace():
+                coordinator._invalidate_trace()
         my_count = count[0]
         module.ds_id = my_count
 

--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -305,9 +305,8 @@ class DeepSpeedZeRoOffload(object):
         return persistent_params
 
     def _register_deepspeed_module(self, module, count=[0]):
-        # re-registering hooks on the root module (e.g. after an out-of-band generate that
-        # ran with hooks removed) leaves the coordinator trace stale; invalidate so it
-        # re-records on the next forward.
+        # re-registering hooks on the root module leaves the coordinator trace stale;
+        # invalidate so it re-records on the next forward.
         if module is self.module:
             coordinator = self.get_param_coordinator()
             if coordinator is not None and not coordinator.is_invalid_trace():

--- a/deepspeed/runtime/zero/partitioned_param_coordinator.py
+++ b/deepspeed/runtime/zero/partitioned_param_coordinator.py
@@ -160,6 +160,9 @@ class PartitionedParameterCoordinator:
         self.__submodule_order = []
         self.__param_order = []
         self.__most_recent_step_id_param_fetched_for = collections.defaultdict(lambda: int(-1e10))
+        # clear the fetch-step deque too; a stale entry here causes record_parameters() to
+        # pop an empty deque (IndexError) after trace invalidation.
+        self.__step_id_module_fetched_for = collections.defaultdict(lambda: collections.deque())
         self.__param_queue = None
 
     def is_complete_trace(self) -> bool:

--- a/tests/unit/runtime/zero/test_unwrap_model.py
+++ b/tests/unit/runtime/zero/test_unwrap_model.py
@@ -70,9 +70,8 @@ class TestUnwrapModel(DistributedTest):
 
 
 class TestUnwrapModelTraceInvalidate(DistributedTest):
-    # re-registering hooks on the root module (e.g. via unwrap_model_for_generation around
-    # an on-policy generate) must leave the coordinator's recorded trace invalidated so
-    # the next training forward re-records cleanly instead of popping a stale deque.
+    # unwrap_model_for_generation removes and re-registers the ZeRO-3 hooks; the
+    # coordinator's recorded trace must be invalidated so the next forward re-records.
     world_size = 2
 
     def test(self):

--- a/tests/unit/runtime/zero/test_unwrap_model.py
+++ b/tests/unit/runtime/zero/test_unwrap_model.py
@@ -3,11 +3,13 @@
 
 # DeepSpeed Team
 
+import torch
+
 import deepspeed
 from deepspeed.runtime.zero import unwrap_model_for_generation
 from deepspeed.accelerator import get_accelerator
 
-from unit.common import DistributedTest
+from unit.common import DistributedTest, preferred_dtype
 from unit.simple_model import SimpleModel
 
 config = {
@@ -65,3 +67,26 @@ class TestUnwrapModel(DistributedTest):
 
         # assert hooks
         assert hooks_exist(engine)
+
+
+class TestUnwrapModelTraceInvalidate(DistributedTest):
+    # re-registering hooks on the root module (e.g. via unwrap_model_for_generation around
+    # an on-policy generate) must leave the coordinator's recorded trace invalidated so
+    # the next training forward re-records cleanly instead of popping a stale deque.
+    world_size = 2
+
+    def test(self):
+        model = SimpleModel(hidden_dim=100)
+        engine, _, _, _ = deepspeed.initialize(args=None, model=model, config=config)
+        coordinator = engine.optimizer.parameter_offload.get_param_coordinator()
+
+        # run one step so the coordinator records a trace (RECORD -> COMPLETE)
+        x = torch.randn(2, 100, device=engine.device, dtype=preferred_dtype())
+        y = torch.empty(2, dtype=torch.long, device=engine.device).random_(100)
+        engine(x, y)
+        assert not coordinator.is_invalid_trace()
+
+        # the wrap cycle around an out-of-band forward must invalidate the recorded trace
+        with unwrap_model_for_generation(engine):
+            pass
+        assert coordinator.is_invalid_trace()

--- a/tests/unit/runtime/zero/test_unwrap_model.py
+++ b/tests/unit/runtime/zero/test_unwrap_model.py
@@ -70,22 +70,24 @@ class TestUnwrapModel(DistributedTest):
 
 
 class TestUnwrapModelTraceInvalidate(DistributedTest):
-    # unwrap_model_for_generation removes and re-registers the ZeRO-3 hooks; the
-    # coordinator's recorded trace must be invalidated so the next forward re-records.
+    # unwrap_model_for_generation re-registers the ZeRO-3 hooks; without trace
+    # invalidation the next training step pops an empty fetch deque.
     world_size = 2
 
     def test(self):
         model = SimpleModel(hidden_dim=100)
         engine, _, _, _ = deepspeed.initialize(args=None, model=model, config=config)
-        coordinator = engine.optimizer.parameter_offload.get_param_coordinator()
 
-        # run one step so the coordinator records a trace (RECORD -> COMPLETE)
         x = torch.randn(2, 100, device=engine.device, dtype=preferred_dtype())
         y = torch.empty(2, dtype=torch.long, device=engine.device).random_(100)
-        engine(x, y)
-        assert not coordinator.is_invalid_trace()
 
-        # the wrap cycle around an out-of-band forward must invalidate the recorded trace
+        loss = engine(x, y)
+        engine.backward(loss)
+        engine.step()
+
         with unwrap_model_for_generation(engine):
             pass
-        assert coordinator.is_invalid_trace()
+
+        loss = engine(x, y)
+        engine.backward(loss)
+        engine.step()


### PR DESCRIPTION
## Summary

Re-registering ZeRO-3 module hooks after they were removed (e.g. via `unwrap_model_for_generation`) leaves the param coordinator's recorded trace stale. The next training forward raises `IndexError: pop from an empty deque` from `_start_of_forward_hook -> reset_step -> record_parameters -> popleft`.

## Repro

DeepSpeed master, torch 2.8.0+cu128, transformers, peft. Single GPU.

```python
import torch, deepspeed
from deepspeed.runtime.zero import unwrap_model_for_generation
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import LoraConfig, get_peft_model, TaskType

m = "hf-internal-testing/tiny-random-gpt2"
tok = AutoTokenizer.from_pretrained(m); tok.pad_token = tok.eos_token
model = get_peft_model(AutoModelForCausalLM.from_pretrained(m, dtype=torch.bfloat16),
                       LoraConfig(task_type=TaskType.CAUSAL_LM, r=4, target_modules=["c_attn"]))
model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})

cfg = {"train_micro_batch_size_per_gpu": 1, "bf16": {"enabled": True},
       "zero_optimization": {"stage": 3, "stage3_param_persistence_threshold": 0},
       "optimizer": {"type": "Adam", "params": {"lr": 1e-3}}}
engine, *_ = deepspeed.initialize(model=model, config=cfg,
                                  model_parameters=[p for p in model.parameters() if p.requires_grad])

ids = tok("hello", return_tensors="pt").input_ids.to(engine.device)
for _ in range(2):
    with unwrap_model_for_generation(engine) as unwrapped:
        with torch.no_grad():
            unwrapped.generate(ids, max_new_tokens=4, do_sample=False, pad_token_id=tok.pad_token_id)
    out = engine(input_ids=ids, labels=ids)
    engine.backward(out.loss); engine.step()
```

Run with ``torchrun --nproc-per-node=1 repro.py``. Second iteration raises the IndexError.

## Fix

Two small edits in ``deepspeed/runtime/zero/``:

- ``parameter_offload.py::_register_deepspeed_module``: when the root module is re-registered, invalidate the coordinator trace so the next forward re-records cleanly.
- ``partitioned_param_coordinator.py::_clear_trace_structures``: also clear ``__step_id_module_fetched_for``, which was being left populated and caused the empty-deque pop.

Both guards are no-ops on initial registration (trace is already INVALID) and on non-root submodule walks.

## Test

``tests/unit/runtime/zero/test_unwrap_model.py::TestUnwrapModelTraceInvalidate`` covers the path: run one training step, wrap with ``unwrap_model_for_generation``, assert the coordinator returns to INVALID. World size 2.