### PR TITLE
Remove AutoSP assertion against Transformers version

### DIFF
--- a/deepspeed/compile/custom_ops/sp_compat.py
+++ b/deepspeed/compile/custom_ops/sp_compat.py
@@ -14,11 +14,3 @@ def _check_autosp_compatibility():
     if torch_version < Version("2.9"):
         raise RuntimeError("AutoSP requires PyTorch >= 2.9, found "
                            f"{torch.__version__}.")
-
-    try:
-        import transformers
-        if Version(transformers.__version__) > Version("4.50.3"):
-            raise RuntimeError("AutoSP requires transformers <= 4.50.3, found "
-                               f"{transformers.__version__}.")
-    except ImportError:
-        pass  # transformers not installed; skip the check


### PR DESCRIPTION
The current [nightly CI fails](https://github.com/deepspeedai/DeepSpeed/actions/runs/26810858020/job/79040150594) because AutoSP rejects Transformers versions newer than 4.50.3. That upper-bound guard was conservative, and we verified that AutoSP still passes with current Transformers main (`5.10.0.dev0`).

This PR removes the Transformers upper-bound guard. If a future Transformers version introduces an AutoSP breakage, we can address that specific incompatibility or add a targeted guard back.