### PR TITLE
Fix minor comment/docstring typos in runtime and inference modules

### DIFF
--- a/deepspeed/inference/v2/model_implementations/inference_model_base.py
+++ b/deepspeed/inference/v2/model_implementations/inference_model_base.py
@@ -233,7 +233,7 @@ class DSInferenceModelBase(torch.nn.Module, ABC):
 
     def maybe_free_kv(self, sequence: DSSequenceDescriptor) -> None:
         """
-        After completing a forward pass, determine whether or not the there are any KV blocks
+        After completing a forward pass, determine whether or not there are any KV blocks
         that maybe freed since they are no longer in use.
 
         Consider the following example:

--- a/deepspeed/runtime/activation_checkpointing/checkpointing.py
+++ b/deepspeed/runtime/activation_checkpointing/checkpointing.py
@@ -704,14 +704,14 @@ class CheckpointFunction(torch.autograd.Function):
 def non_reentrant_checkpoint(function, *args):
     """This function is union of `torch.utils.checkpoint._checkpoint_without_reentrant` and `CheckpointFunction` in this module
 
-    This function is aim to solve the back probagation error raised from all input requires no grad.
+    This function is aim to solve the back propagation error raised from all input requires no grad.
     * has already been implemented in pytorch for a while, the solution is stable at most time except for jit module mode.
     * can help to solve the issue which is hacked by `deepspeed.runtime.pipe.module.PipelineModule._is_checkpointable`
 
     Main modifications compared to the implementation of torch:
     1. adapt to the signature of `checkpoint` function in this module
     2. solve the non-deterministic by random state management consistent with deepspeed `CheckpointFunction`
-    3. when there is partition or cpu checkpointing, gather them in the unpack_hook during back probagation
+    3. when there is partition or cpu checkpointing, gather them in the unpack_hook during back propagation
     4. make all after backward blocks in the hook which will executed after all leaf nodes backward execution.
     5. above 4. is inspired by `torch.autograd.graph.register_multi_grad_hook`, which is only implemented after 2.0.0
     """
@@ -801,7 +801,7 @@ def non_reentrant_checkpoint(function, *args):
         """retrieve the activations from recompute"""
         nonlocal deepspeed_saved_tensors, non_tensor_args, tensor_flags
 
-        # if this is the first step of backward probagation, recompute the graph and save
+        # if this is the first step of backward propagation, recompute the graph and save
         # all the activations with the same order as `checkpoint_pack` does
         if len(storage) == 0:
             unpack_counter = 0

--- a/deepspeed/runtime/data_pipeline/data_sampling/variable_batch_size_and_lr.py
+++ b/deepspeed/runtime/data_pipeline/data_sampling/variable_batch_size_and_lr.py
@@ -291,7 +291,7 @@ class VariableBatchSizeLR(LRScheduler):
 
         self.base_lr_scheduler.step(epoch)  # set unscaled lr, _step_count, last_epoch, _last_lr for new epoch
 
-        # scale the learning rate for the the next iteration for each parameter group.
+        # scale the learning rate for the next iteration for each parameter group.
         self.last_epoch = self.last_epoch + 1 if epoch is None else epoch
         # batch sizes are precomputed and stored in batch_sizes se we loop around to get the next one
         batch_size = self.batch_sizes[self.last_epoch % len(self.batch_sizes)]


### PR DESCRIPTION
### PR Title
Fix minor comment/docstring typos in runtime and inference modules

### PR Description
While reviewing the codebase, I noticed a few small wording issues in comments and docstrings.  
This PR applies focused typo cleanups only, with no functional changes.

### Changes included
1. Replaced `probagation` with `propagation` in three places within activation checkpointing documentation/comments.
2. Fixed duplicated words:
   - `the there` -> `there`
   - `the the` -> `the`

### Why this change
- Improves readability and professionalism of inline documentation.
- Reduces confusion when searching or referencing these comments.
- Keeps the change narrowly scoped, easy to review, and low risk.

### Impact
- No runtime behavior changes
- No API changes
- No compatibility impact

### Testing
- No additional tests required (comment/docstring-only updates)