### PR TITLE
fix: log block eigenvalue summary events

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -2892,6 +2892,19 @@ class DeepSpeedEngine(Module):
         for param_name, param in self.module.named_parameters():
             param.grad = None
 
+    def _eigenvalue_summary_events(self):
+        if not (self.eigenvalue_enabled() and not self.gas_boundary_ctr % self.eigenvalue_gas_boundary_resolution()):
+            return []
+
+        events = []
+        for i, ev_value in enumerate(self.block_eigenvalue.values()):
+            events.append((
+                f"Train/Eigenvalues/ModelBlockParam_{i}",
+                ev_value[0],
+                self.global_samples,
+            ))
+        return events
+
     def clip_fp32_gradients(self):
         clip_grad_norm_(parameters=self.module.parameters(), max_norm=self.gradient_clipping(), mpu=self.mpu)
 
@@ -3041,15 +3054,7 @@ class DeepSpeedEngine(Module):
                             self.global_samples,
                         ))
 
-                    if (self.eigenvalue_enabled()
-                            and not self.gas_boundary_ctr % self.eigenvalue_gas_boundary_resolution()):
-                        ev_values = self.block_eigenvalue.values()
-                        for i in range(len(ev_values)):
-                            self.summary_events.append((
-                                f"Train/Eigenvalues/ModelBlockParam_{i}",
-                                self.ev_values[i][0],
-                                self.global_samples,
-                            ))
+                    self.summary_events.extend(self._eigenvalue_summary_events())
                     self.monitor.write_events(self.summary_events)
 
         # Check flops profiling

--- a/tests/unit/runtime/test_engine.py
+++ b/tests/unit/runtime/test_engine.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+from deepspeed.runtime.engine import DeepSpeedEngine
+
+
+def test_eigenvalue_summary_events_use_block_eigenvalue_values():
+    engine = object.__new__(DeepSpeedEngine)
+    engine.block_eigenvalue = {
+        "block_a": (0.25, 0),
+        "block_b": (0.5, 1),
+    }
+    engine.gas_boundary_ctr = 4
+    engine.global_samples = 128
+    engine.eigenvalue_enabled = lambda: True
+    engine.eigenvalue_gas_boundary_resolution = lambda: 2
+
+    assert engine._eigenvalue_summary_events() == [
+        ("Train/Eigenvalues/ModelBlockParam_0", 0.25, 128),
+        ("Train/Eigenvalues/ModelBlockParam_1", 0.5, 128),
+    ]
+
+
+def test_eigenvalue_summary_events_skip_non_boundary_steps():
+    engine = object.__new__(DeepSpeedEngine)
+    engine.block_eigenvalue = {"block_a": (0.25, 0)}
+    engine.gas_boundary_ctr = 3
+    engine.eigenvalue_enabled = lambda: True
+    engine.eigenvalue_gas_boundary_resolution = lambda: 2
+
+    assert engine._eigenvalue_summary_events() == []


### PR DESCRIPTION
## Summary
- use the eigenvalues from `self.block_eigenvalue.values()` when building monitor summary events
- avoid indexing the Python 3 `dict_values` view
- add focused coverage for the eigenvalue summary-event path without constructing a full engine

Fixes #7983.

## To verify
- `python -m py_compile deepspeed\runtime\engine.py tests\unit\runtime\test_engine.py` (passed)
- `git diff --check` (passed)
- `python -m pytest tests\unit\runtime\test_engine.py -q` was attempted on Windows, but collection failed before the test ran because this clone has `core.symlinks=false` and `deepspeed/accelerator` was checked out as a plain text symlink file, so `deepspeed.accelerator` cannot be imported locally. The new test should run in the normal Linux checkout used by CI.
