### PR TITLE
Add Biren SUPA accelerator support

### DIFF
--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -169,7 +169,7 @@ def get_accelerator():
                 pass
         if accelerator_name is None:
             try:
-                # Detect Biren SUPA GPU. torch_supa spoofs torch.cuda so this
+                # Detect Biren SUPA GPU. torch_supa spoofs torch.cuda so this  #ignore-cuda
                 # check must come before the CUDA detection below.
                 import torch_supa  # noqa: F401,F811 # type: ignore
                 import torch

--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -20,7 +20,7 @@ try:
 except ImportError as e:
     dsa2 = None
 
-SUPPORTED_ACCELERATOR_LIST = ['cuda', 'cpu', 'xpu', 'npu', 'mps', 'hpu', 'mlu', 'sdaa']
+SUPPORTED_ACCELERATOR_LIST = ['cuda', 'cpu', 'xpu', 'npu', 'mps', 'hpu', 'mlu', 'sdaa', 'supa']
 
 ds_accelerator = None
 
@@ -98,6 +98,11 @@ def get_accelerator():
                 import torch_mlu  # noqa: F401
             except ImportError as e:
                 raise ValueError("MLU_Accelerator requires torch_mlu, which is not installed on this system.")
+        elif accelerator_name == "supa":
+            try:
+                import torch_supa  # noqa: F401 # type: ignore
+            except ImportError as e:
+                raise ValueError("SUPA_Accelerator requires torch_supa, which is not installed on this system.")
         elif accelerator_name not in SUPPORTED_ACCELERATOR_LIST:
             raise ValueError(f'DS_ACCELERATOR must be one of {SUPPORTED_ACCELERATOR_LIST}. '
                              f'Value "{accelerator_name}" is not supported')
@@ -164,6 +169,17 @@ def get_accelerator():
                 pass
         if accelerator_name is None:
             try:
+                # Detect Biren SUPA GPU. torch_supa spoofs torch.cuda so this
+                # check must come before the CUDA detection below.
+                import torch_supa  # noqa: F401,F811 # type: ignore
+                import torch
+
+                if hasattr(torch, 'supa') and torch.supa.is_available():
+                    accelerator_name = "supa"
+            except ImportError as e:
+                pass
+        if accelerator_name is None:
+            try:
                 import torch
 
                 # Determine if we are on a GPU or x86 CPU with torch.
@@ -220,6 +236,10 @@ def get_accelerator():
         from .mlu_accelerator import MLU_Accelerator
 
         ds_accelerator = MLU_Accelerator()
+    elif accelerator_name == 'supa':
+        from .supa_accelerator import SUPA_Accelerator
+
+        ds_accelerator = SUPA_Accelerator()
     _validate_accelerator(ds_accelerator)
     if accel_logger is not None:
         accel_logger.info(f"Setting ds_accelerator to {ds_accelerator._name} ({ds_set_method})")

--- a/accelerator/supa_accelerator.py
+++ b/accelerator/supa_accelerator.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import os
+import sys
+import pkgutil
+import importlib
+
+import torch
+from .abstract_accelerator import DeepSpeedAccelerator
+
+
+class SUPA_Accelerator(DeepSpeedAccelerator):
+
+    def __init__(self):
+        self._name = 'supa'
+        # Use BCCL on Linux, fall back to gloo on Windows (no BCCL support yet)
+        self._communication_backend_name = 'bccl' if sys.platform != 'win32' else 'gloo'
+        self._compile_backend = "inductor"
+
+    def is_synchronized_device(self):
+        return False
+
+    def use_host_timers(self):
+        return self.is_synchronized_device()
+
+    def resolves_data_dependency(self):
+        return self.is_synchronized_device()
+
+    def handles_memory_backpressure(self):
+        return self.is_synchronized_device()
+
+    # Device APIs
+    def device_name(self, device_index=None):
+        if device_index is None:
+            return 'supa'
+        return 'supa:{}'.format(device_index)
+
+    def communication_backend_version(self):
+        # BCCL does not expose a version via torch.supa
+        return (0, 0, 0)
+
+    def device(self, device_index=None):
+        return torch.device('supa', device_index)
+
+    def set_device(self, device_index):
+        torch.supa.set_device(device_index)
+
+    def current_device(self):
+        return torch.supa.current_device()
+
+    def current_device_name(self):
+        return 'supa:{}'.format(torch.supa.current_device())
+
+    def device_count(self):
+        return torch.supa.device_count()
+
+    def synchronize(self, device_index=None):
+        return torch.supa.synchronize(device_index)
+
+    # RNG APIs
+    def random(self):
+        return torch.random
+
+    def set_rng_state(self, new_state, device_index=None):
+        if device_index is None:
+            return torch.supa.set_rng_state(new_state)
+        return torch.supa.set_rng_state(new_state, device_index)
+
+    def get_rng_state(self, device_index=None):
+        if device_index is None:
+            return torch.supa.get_rng_state()
+        return torch.supa.get_rng_state(device_index)
+
+    def manual_seed(self, seed):
+        return torch.supa.manual_seed(seed)
+
+    def manual_seed_all(self, seed):
+        return torch.supa.manual_seed_all(seed)
+
+    def initial_seed(self):
+        return torch.supa.initial_seed()
+
+    def default_generator(self, device_index):
+        return torch.supa.default_generators[device_index]
+
+    # Streams/Events
+    @property
+    def Stream(self):
+        return torch.supa.Stream
+
+    def stream(self, stream):
+        return torch.supa.stream(stream)
+
+    def current_stream(self, device_index=None):
+        return torch.supa.current_stream(device_index)
+
+    def default_stream(self, device_index=None):
+        return torch.supa.default_stream(device_index)
+
+    @property
+    def Event(self):
+        return torch.supa.Event
+
+    # Memory management
+    def empty_cache(self):
+        return torch.supa.empty_cache()
+
+    def memory_allocated(self, device_index=None):
+        return torch.supa.memory_allocated(device_index)
+
+    def max_memory_allocated(self, device_index=None):
+        return torch.supa.max_memory_allocated(device_index)
+
+    def reset_max_memory_allocated(self, device_index=None):
+        return torch.supa.reset_max_memory_allocated(device_index)
+
+    def memory_cached(self, device_index=None):
+        return torch.supa.memory_cached(device_index)
+
+    def max_memory_cached(self, device_index=None):
+        return torch.supa.max_memory_cached(device_index)
+
+    def reset_max_memory_cached(self, device_index=None):
+        return torch.supa.reset_max_memory_cached(device_index)
+
+    def memory_stats(self, device_index=None):
+        if hasattr(torch.supa, 'memory_stats'):
+            return torch.supa.memory_stats(device_index)
+
+    def reset_peak_memory_stats(self, device_index=None):
+        if hasattr(torch.supa, 'reset_peak_memory_stats'):
+            return torch.supa.reset_peak_memory_stats(device_index)
+
+    def memory_reserved(self, device_index=None):
+        if hasattr(torch.supa, 'memory_reserved'):
+            return torch.supa.memory_reserved(device_index)
+
+    def max_memory_reserved(self, device_index=None):
+        if hasattr(torch.supa, 'max_memory_reserved'):
+            return torch.supa.max_memory_reserved(device_index)
+
+    def total_memory(self, device_index=None):
+        return torch.supa.get_device_properties(device_index).total_memory
+
+    def available_memory(self, device_index=None):
+        return self.total_memory(device_index) - self.memory_allocated(device_index)
+
+    # Data types
+    def is_bf16_supported(self):
+        return True
+
+    def is_fp16_supported(self):
+        return True
+
+    def supported_dtypes(self):
+        return [torch.float, torch.half, torch.bfloat16]
+
+    # Misc
+    def is_available(self):
+        return torch.supa.is_available()
+
+    def range_push(self, msg, domain=None, category=None):
+        return None
+
+    def range_pop(self, domain=None):
+        return None
+
+    def lazy_call(self, callback):
+        return torch.supa._lazy_call(callback)
+
+    def communication_backend_name(self):
+        return self._communication_backend_name
+
+    def is_triton_supported(self):
+        return True
+
+    # Graph operations
+    def create_graph(self):
+        return torch.supa.SUPAGraph()
+
+    def capture_to_graph(self, graph, pool=None, stream=None):
+        return torch.supa.graph(graph, pool, stream)
+
+    def replay_graph(self, graph):
+        graph.replay()
+
+    # Tensor operations
+    @property
+    def BFloat16Tensor(self):
+        return torch.supa.BFloat16Tensor
+
+    @property
+    def ByteTensor(self):
+        return torch.supa.ByteTensor
+
+    @property
+    def DoubleTensor(self):
+        return torch.supa.DoubleTensor
+
+    @property
+    def FloatTensor(self):
+        return torch.supa.FloatTensor
+
+    @property
+    def HalfTensor(self):
+        return torch.supa.HalfTensor
+
+    @property
+    def IntTensor(self):
+        return torch.supa.IntTensor
+
+    @property
+    def LongTensor(self):
+        return torch.supa.LongTensor
+
+    def pin_memory(self, tensor, align_bytes=1):
+        return tensor.pin_memory()
+
+    def is_pinned(self, tensor):
+        return tensor.is_pinned()
+
+    def on_accelerator(self, tensor):
+        device_str = str(tensor.device)
+        return device_str.startswith('supa:')
+
+    def op_builder_dir(self):
+        try:
+            # Local install: op_builder is a top-level package
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+            return "op_builder.supa"
+        except ImportError:
+            return "deepspeed.ops.op_builder.supa"
+
+    # dict that holds class name <--> class type mapping i.e.
+    # 'FusedAdamBuilder': <class 'op_builder.supa.fused_adam.FusedAdamBuilder'>
+    # populated lazily on first call to create_op_builder / get_op_builder
+    class_dict = None
+
+    def _lazy_init_class_dict(self):
+        if self.class_dict is not None:
+            return
+        self.class_dict = {}
+        op_builder_dir = self.op_builder_dir()
+        op_builder_module = importlib.import_module(op_builder_dir)
+        op_builder_absolute_path = os.path.dirname(op_builder_module.__file__)
+        for _, module_name, _ in pkgutil.iter_modules([op_builder_absolute_path]):
+            if module_name in ('all_ops', 'builder') or os.path.isdir(
+                    os.path.join(op_builder_absolute_path, module_name)):
+                continue
+            module = importlib.import_module("{}.{}".format(op_builder_dir, module_name))
+            for member_name in module.__dir__():
+                if (member_name.endswith('Builder') and member_name not in
+                    ('OpBuilder', 'CUDAOpBuilder', 'TorchCPUOpBuilder', 'SUPAOpBuilder')):
+                    if member_name not in self.class_dict:
+                        self.class_dict[member_name] = getattr(module, member_name)
+
+    def create_op_builder(self, class_name):
+        self._lazy_init_class_dict()
+        if class_name in self.class_dict:
+            return self.class_dict[class_name]()
+        return None
+
+    def get_op_builder(self, class_name):
+        self._lazy_init_class_dict()
+        if class_name in self.class_dict:
+            return self.class_dict[class_name]
+        return None
+
+    def build_extension(self):
+        from torch.utils.cpp_extension import BuildExtension
+        return BuildExtension
+
+    def export_envs(self):
+        return ['BCCL', 'BIREN', 'SUPA', 'LD_LIBRARY', 'PATH']
+
+    def visible_devices_envs(self):
+        return ['SUPA_VISIBLE_DEVICES']
+
+    def set_visible_devices_envs(self, current_env, local_accelerator_ids):
+        for env in self.visible_devices_envs():
+            current_env[env] = ",".join(map(str, local_accelerator_ids))
+
+    def get_compile_backend(self):
+        return self._compile_backend
+
+    def set_compile_backend(self, backend):
+        supported_backends = torch._dynamo.list_backends(exclude_tags=())
+        if backend in supported_backends:
+            self._compile_backend = backend
+        else:
+            raise ValueError(
+                f"{backend} not supported by {self.device_name()}. "
+                f"Supported backends: {supported_backends}")

--- a/accelerator/supa_accelerator.py
+++ b/accelerator/supa_accelerator.py
@@ -250,8 +250,8 @@ class SUPA_Accelerator(DeepSpeedAccelerator):
                 continue
             module = importlib.import_module("{}.{}".format(op_builder_dir, module_name))
             for member_name in module.__dir__():
-                if (member_name.endswith('Builder') and member_name not in
-                    ('OpBuilder', 'CUDAOpBuilder', 'TorchCPUOpBuilder', 'SUPAOpBuilder')):
+                if (member_name.endswith('Builder')
+                        and member_name not in ('OpBuilder', 'CUDAOpBuilder', 'TorchCPUOpBuilder', 'SUPAOpBuilder')):
                     if member_name not in self.class_dict:
                         self.class_dict[member_name] = getattr(module, member_name)
 
@@ -289,6 +289,5 @@ class SUPA_Accelerator(DeepSpeedAccelerator):
         if backend in supported_backends:
             self._compile_backend = backend
         else:
-            raise ValueError(
-                f"{backend} not supported by {self.device_name()}. "
-                f"Supported backends: {supported_backends}")
+            raise ValueError(f"{backend} not supported by {self.device_name()}. "
+                             f"Supported backends: {supported_backends}")

--- a/op_builder/supa/__init__.py
+++ b/op_builder/supa/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+'''Copyright The Microsoft DeepSpeed Team'''
+
+from .fused_adam import FusedAdamBuilder
+from .fused_lamb import FusedLambBuilder
+from .fused_lion import FusedLionBuilder
+from .inference import InferenceBuilder
+from .quantizer import QuantizerBuilder
+from .async_io import AsyncIOBuilder
+from .no_impl import NotImplementedBuilder
+from .cpu_adam import CPUAdamBuilder
+from .cpu_lion import CPULionBuilder
+from .cpu_adagrad import CPUAdagradBuilder

--- a/op_builder/supa/async_io.py
+++ b/op_builder/supa/async_io.py
@@ -41,7 +41,7 @@ class AsyncIOBuilder(SUPAOpBuilder):
     def cxx_args(self):
         args = super().cxx_args()
         # -O0 for improved debugging, since performance is bound by I/O
-        return [a for a in args if not a.startswith('-O')] + ['-O0', '-Wall', '-shared', '-fPIC', '-laio']
+        return [a for a in args if not a.startswith('-O')] + ['-O0', '-Wall', '-shared', '-fPIC']
 
     def extra_ldflags(self):
         return ['-laio']

--- a/op_builder/supa/async_io.py
+++ b/op_builder/supa/async_io.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import shutil
+import subprocess
+
+from .builder import SUPAOpBuilder
+
+
+class AsyncIOBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_AIO"
+    NAME = "async_io"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.aio.{self.NAME}_op'
+
+    def sources(self):
+        return [
+            'csrc/aio/py_lib/deepspeed_py_copy.cpp',
+            'csrc/aio/py_lib/py_ds_aio.cpp',
+            'csrc/aio/py_lib/deepspeed_py_aio.cpp',
+            'csrc/aio/py_lib/deepspeed_py_aio_handle.cpp',
+            'csrc/aio/py_lib/deepspeed_aio_thread.cpp',
+            'csrc/aio/common/deepspeed_aio_utils.cpp',
+            'csrc/aio/common/deepspeed_aio_common.cpp',
+            'csrc/aio/common/deepspeed_aio_types.cpp',
+            'csrc/aio/py_lib/deepspeed_pin_tensor.cpp',
+            'csrc/aio/py_lib/deepspeed_py_io_handle.cpp',
+            'csrc/aio/py_lib/deepspeed_cpu_op.cpp',
+            'csrc/aio/py_lib/deepspeed_aio_op_desc.cpp',
+        ]
+
+    def include_paths(self):
+        args = super().include_paths()
+        args += ['csrc/aio/py_lib', 'csrc/aio/common']
+        return args
+
+    def cxx_args(self):
+        args = super().cxx_args()
+        # -O0 for improved debugging, since performance is bound by I/O
+        return [a for a in args if not a.startswith('-O')] + ['-O0', '-Wall', '-shared', '-fPIC', '-laio']
+
+    def extra_ldflags(self):
+        return ['-laio']
+
+    def check_for_libaio_pkg(self):
+        libs = dict(
+            dpkg=["-l", "libaio-dev", "apt"],
+            pacman=["-Q", "libaio", "pacman"],
+            rpm=["-q", "libaio-devel", "yum"],
+        )
+
+        found = False
+        for pkgmgr, data in libs.items():
+            flag, lib, tool = data
+            path = shutil.which(pkgmgr)
+            if path is not None:
+                cmd = [pkgmgr, flag, lib]
+                result = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                if result.wait() == 0:
+                    found = True
+                else:
+                    self.warning(f"{self.NAME}: please install the {lib} package with {tool}")
+                break
+        return found
+
+    def is_compatible(self, verbose=False):
+        # Check for the existence of libaio by using distutils
+        # to compile and link a test program that calls io_submit,
+        # which is a function provided by libaio that is used in the async_io op.
+        # If needed, one can define -I and -L entries in CFLAGS and LDFLAGS
+        # respectively to specify the directories for libaio.h and libaio.so.
+        aio_compatible = self.has_function('io_pgetevents', ('aio', ))
+        if verbose and not aio_compatible:
+            self.warning(f"{self.NAME} requires the dev libaio .so object and headers but these were not found.")
+
+            # Check for the libaio package via known package managers
+            # to print suggestions on which package to install.
+            self.check_for_libaio_pkg()
+
+            self.warning(
+                "If libaio is already installed (perhaps from source), try setting the CFLAGS and LDFLAGS environment variables to where it can be found."
+            )
+        return super().is_compatible(verbose) and aio_compatible

--- a/op_builder/supa/builder.py
+++ b/op_builder/supa/builder.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+try:
+    from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+    from op_builder.builder import OpBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.builder import OpBuilder
+
+
+class SUPAOpBuilder(OpBuilder):
+    """Base class for SUPA operator builders."""
+
+    def builder(self):
+        from torch.utils.cpp_extension import CppExtension as ExtensionBuilder
+
+        compile_args = {'cxx': self.strip_empty_entries(self.cxx_args())}
+
+        cpp_ext = ExtensionBuilder(name=self.absolute_name(),
+                                   sources=self.strip_empty_entries(self.sources()),
+                                   include_dirs=self.strip_empty_entries(self.include_paths()),
+                                   libraries=self.strip_empty_entries(self.libraries_args()),
+                                   extra_compile_args=compile_args)
+
+        return cpp_ext
+
+    def cxx_args(self):
+        CPU_ARCH = self.cpu_arch()
+        SIMD_WIDTH = self.simd_width()
+        return ['-O3', '-std=c++17', '-g', '-Wno-reorder', '-fopenmp', CPU_ARCH, SIMD_WIDTH]
+
+    def libraries_args(self):
+        return []

--- a/op_builder/supa/builder.py
+++ b/op_builder/supa/builder.py
@@ -20,7 +20,8 @@ class SUPAOpBuilder(OpBuilder):
                                    sources=self.strip_empty_entries(self.sources()),
                                    include_dirs=self.strip_empty_entries(self.include_paths()),
                                    libraries=self.strip_empty_entries(self.libraries_args()),
-                                   extra_compile_args=compile_args)
+                                   extra_compile_args=compile_args,
+                                   extra_link_args=self.strip_empty_entries(self.extra_ldflags()))
 
         return cpp_ext
 

--- a/op_builder/supa/cpu_adagrad.py
+++ b/op_builder/supa/cpu_adagrad.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .builder import SUPAOpBuilder
+
+
+class CPUAdagradBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_CPU_ADAGRAD"
+    NAME = "cpu_adagrad"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.adagrad.{self.NAME}_op'
+
+    def sources(self):
+        return ['csrc/adagrad/cpu_adagrad.cpp']
+
+    def include_paths(self):
+        args = super().include_paths()
+        args += ['csrc/includes']
+        return args

--- a/op_builder/supa/cpu_adam.py
+++ b/op_builder/supa/cpu_adam.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+from .builder import SUPAOpBuilder
+
+
+class CPUAdamBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_CPU_ADAM"
+    NAME = "cpu_adam"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.adam.{self.NAME}_op'
+
+
+    def sources(self):
+        return ['csrc/adam/cpu_adam.cpp', 'csrc/adam/cpu_adam_impl.cpp']
+
+    def include_paths(self):
+        args = super().include_paths()
+        args += ['csrc/includes']
+        return args
+

--- a/op_builder/supa/cpu_adam.py
+++ b/op_builder/supa/cpu_adam.py
@@ -14,7 +14,6 @@ class CPUAdamBuilder(SUPAOpBuilder):
     def absolute_name(self):
         return f'deepspeed.ops.adam.{self.NAME}_op'
 
-
     def sources(self):
         return ['csrc/adam/cpu_adam.cpp', 'csrc/adam/cpu_adam_impl.cpp']
 
@@ -22,4 +21,3 @@ class CPUAdamBuilder(SUPAOpBuilder):
         args = super().include_paths()
         args += ['csrc/includes']
         return args
-

--- a/op_builder/supa/cpu_lion.py
+++ b/op_builder/supa/cpu_lion.py
@@ -21,4 +21,3 @@ class CPULionBuilder(SUPAOpBuilder):
         args = super().include_paths()
         args += ['csrc/includes']
         return args
-

--- a/op_builder/supa/cpu_lion.py
+++ b/op_builder/supa/cpu_lion.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+from .builder import SUPAOpBuilder
+
+
+class CPULionBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_CPU_LION"
+    NAME = "cpu_lion"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.lion.{self.NAME}_op'
+
+    def sources(self):
+        return ['csrc/lion/cpu_lion.cpp', 'csrc/lion/cpu_lion_impl.cpp']
+
+    def include_paths(self):
+        args = super().include_paths()
+        args += ['csrc/includes']
+        return args
+

--- a/op_builder/supa/fused_adam.py
+++ b/op_builder/supa/fused_adam.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import math
+import torch
+from .builder import SUPAOpBuilder
+
+# Load torch_supa_ext.deepspeed to register torch.ops.deepspeed.multi_tensor_adam.
+# The import is guarded so that the module still works (via PyTorch fallback)
+# when torch_supa_ext is not installed.
+try:
+    import torch_supa_ext.deepspeed  # noqa: F401 — side-effect: registers torch.ops.deepspeed
+    _has_kernel = hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam')
+except Exception:
+    _has_kernel = False
+
+
+class SUPAFusedAdam:
+    """
+    Fused Adam for Biren SUPA GPUs.
+
+    Calls torch.ops.deepspeed.multi_tensor_adam (registered by torch_supa_ext.deepspeed)
+    when the compiled extension is available; falls back to a numerically equivalent
+    pure-PyTorch loop for cmodel / functional testing.
+    """
+
+    @staticmethod
+    def multi_tensor_adam(chunk_size, noop_flag_buffer, tensor_lists,
+                          lr, beta1, beta2, epsilon, step, mode,
+                          bias_correction, weight_decay):
+        # noop_flag guard (kernel also checks internally, but short-circuit here is cheap)
+        if noop_flag_buffer.item() == 1:
+            return
+
+        if _has_kernel:
+            # MR #96 API: four separate Tensor-list arguments (not a nested list)
+            grads, params, exp_avgs, exp_avg_sqs = tensor_lists
+            torch.ops.deepspeed.multi_tensor_adam(
+                chunk_size, noop_flag_buffer,
+                grads, params, exp_avgs, exp_avg_sqs,
+                lr, beta1, beta2, epsilon,
+                step, mode, bias_correction, weight_decay)
+            return
+
+        # Pure-PyTorch fallback (cmodel / no compiled backend)
+        bias_correction1 = 1.0 - beta1 ** step if bias_correction else 1.0
+        bias_correction2 = 1.0 - beta2 ** step if bias_correction else 1.0
+        for i in range(len(tensor_lists[0])):
+            g = tensor_lists[0][i].float()
+            p = tensor_lists[1][i]
+            m = tensor_lists[2][i]
+            v = tensor_lists[3][i]
+            if mode == 1:  # AdamW: decoupled weight decay
+                m.mul_(beta1).add_(g, alpha=1.0 - beta1)
+                v.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
+                denom = (v.sqrt() / math.sqrt(bias_correction2)).add_(epsilon)
+                p.data.addcdiv_(m, denom, value=-(lr / bias_correction1))
+                p.data.add_(p.data, alpha=-lr * weight_decay)
+            else:  # Adam: L2 regularization
+                g_wd = g.add(p.float(), alpha=weight_decay)
+                m.mul_(beta1).add_(g_wd, alpha=1.0 - beta1)
+                v.mul_(beta2).addcmul_(g_wd, g_wd, value=1.0 - beta2)
+                denom = (v.sqrt() / math.sqrt(bias_correction2)).add_(epsilon)
+                p.data.addcdiv_(m, denom, value=-(lr / bias_correction1))
+
+
+class FusedAdamBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_FUSED_ADAM"
+    NAME = "fused_adam"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.adam.{self.NAME}_op'
+
+    def sources(self):
+        return []
+
+    def load(self, verbose=True):
+        return SUPAFusedAdam
+
+    def is_compatible(self, verbose=False):
+        # Fast path: op already registered (e.g. torch_supa_ext imported elsewhere)
+        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam'):
+            return True
+        try:
+            import torch_supa_ext.deepspeed  # noqa: F401
+            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam')
+        except Exception:
+            return False

--- a/op_builder/supa/fused_adam.py
+++ b/op_builder/supa/fused_adam.py
@@ -54,8 +54,10 @@ class SUPAFusedAdam:
                 m.mul_(beta1).add_(g, alpha=1.0 - beta1)
                 v.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
                 denom = (v.sqrt() / math.sqrt(bias_correction2)).add_(epsilon)
-                p.data.addcdiv_(m, denom, value=-(lr / bias_correction1))
+                # Decouple weight decay on the old param before the Adam step so the
+                # result matches the kernel's p_old*(1 - lr*wd) - lr*adam_update.
                 p.data.add_(p.data, alpha=-lr * weight_decay)
+                p.data.addcdiv_(m, denom, value=-(lr / bias_correction1))
             else:  # Adam: L2 regularization
                 g_wd = g.add(p.float(), alpha=weight_decay)
                 m.mul_(beta1).add_(g_wd, alpha=1.0 - beta1)
@@ -85,7 +87,6 @@ class FusedAdamBuilder(SUPAOpBuilder):
         if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam'):
             return True
         try:
-            import torch_supa_ext.deepspeed  # noqa: F401
             return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam')
         except Exception:
             return False

--- a/op_builder/supa/fused_adam.py
+++ b/op_builder/supa/fused_adam.py
@@ -2,17 +2,19 @@
 # DeepSpeed Team
 
 import math
-import torch
-from .builder import SUPAOpBuilder
 
-# Load torch_supa_ext.deepspeed to register torch.ops.deepspeed.multi_tensor_adam.
-# The import is guarded so that the module still works (via PyTorch fallback)
-# when torch_supa_ext is not installed.
 try:
-    import torch_supa_ext.deepspeed  # noqa: F401 — side-effect: registers torch.ops.deepspeed
+    import torch
+    import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
+except ImportError:
+    pass
+
+try:
     _has_kernel = hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam')
 except Exception:
     _has_kernel = False
+
+from .builder import SUPAOpBuilder
 
 
 class SUPAFusedAdam:
@@ -25,9 +27,10 @@ class SUPAFusedAdam:
     """
 
     @staticmethod
-    def multi_tensor_adam(chunk_size, noop_flag_buffer, tensor_lists,
-                          lr, beta1, beta2, epsilon, step, mode,
+    def multi_tensor_adam(chunk_size, noop_flag_buffer, tensor_lists, lr, beta1, beta2, epsilon, step, mode,
                           bias_correction, weight_decay):
+        import torch  # ensure torch is available at runtime
+
         # noop_flag guard (kernel also checks internally, but short-circuit here is cheap)
         if noop_flag_buffer.item() == 1:
             return
@@ -35,16 +38,13 @@ class SUPAFusedAdam:
         if _has_kernel:
             # MR #96 API: four separate Tensor-list arguments (not a nested list)
             grads, params, exp_avgs, exp_avg_sqs = tensor_lists
-            torch.ops.deepspeed.multi_tensor_adam(
-                chunk_size, noop_flag_buffer,
-                grads, params, exp_avgs, exp_avg_sqs,
-                lr, beta1, beta2, epsilon,
-                step, mode, bias_correction, weight_decay)
+            torch.ops.deepspeed.multi_tensor_adam(chunk_size, noop_flag_buffer, grads, params, exp_avgs, exp_avg_sqs,
+                                                  lr, beta1, beta2, epsilon, step, mode, bias_correction, weight_decay)
             return
 
         # Pure-PyTorch fallback (cmodel / no compiled backend)
-        bias_correction1 = 1.0 - beta1 ** step if bias_correction else 1.0
-        bias_correction2 = 1.0 - beta2 ** step if bias_correction else 1.0
+        bias_correction1 = 1.0 - beta1**step if bias_correction else 1.0
+        bias_correction2 = 1.0 - beta2**step if bias_correction else 1.0
         for i in range(len(tensor_lists[0])):
             g = tensor_lists[0][i].float()
             p = tensor_lists[1][i]
@@ -83,10 +83,5 @@ class FusedAdamBuilder(SUPAOpBuilder):
         return SUPAFusedAdam
 
     def is_compatible(self, verbose=False):
-        # Fast path: op already registered (e.g. torch_supa_ext imported elsewhere)
-        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam'):
-            return True
-        try:
-            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam')
-        except Exception:
-            return False
+        import torch  # ensure torch is available at runtime
+        return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_adam')

--- a/op_builder/supa/fused_lamb.py
+++ b/op_builder/supa/fused_lamb.py
@@ -3,8 +3,6 @@
 
 import math
 
-import torch
-
 from .builder import SUPAOpBuilder
 
 try:
@@ -22,17 +20,19 @@ class SUPAFusedLamb:
     """
 
     @staticmethod
-    def lamb(p, p_copy, exp_avg, exp_avg_sq, grad, lr, beta1, beta2, max_coeff, min_coeff, eps,
-             combined_scale, step, eps_mode, bias_correction, weight_decay):
+    def lamb(p, p_copy, exp_avg, exp_avg_sq, grad, lr, beta1, beta2, max_coeff, min_coeff, eps, combined_scale, step,
+             eps_mode, bias_correction, weight_decay):
+        import torch  # ensure torch is available at runtime
+
         if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'lamb'):
-            return torch.ops.deepspeed.lamb(p, p_copy, exp_avg, exp_avg_sq, grad, lr, beta1,
-                                            beta2, max_coeff, min_coeff, eps, combined_scale,
-                                            step, eps_mode, bias_correction, weight_decay)
+            return torch.ops.deepspeed.lamb(p, p_copy, exp_avg, exp_avg_sq, grad, lr, beta1, beta2, max_coeff,
+                                            min_coeff, eps, combined_scale, step, eps_mode, bias_correction,
+                                            weight_decay)
 
         # Pure-PyTorch fallback
         if bias_correction:
-            bc1 = 1.0 - beta1 ** step
-            bc2 = 1.0 - beta2 ** step
+            bc1 = 1.0 - beta1**step
+            bc2 = 1.0 - beta2**step
             step_size = lr * math.sqrt(bc2) / bc1
         else:
             step_size = lr

--- a/op_builder/supa/fused_lamb.py
+++ b/op_builder/supa/fused_lamb.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import math
+
+import torch
+
+from .builder import SUPAOpBuilder
+
+try:
+    import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
+except Exception:
+    pass
+
+
+class SUPAFusedLamb:
+    """
+    Fused LAMB optimizer for Biren SUPA GPUs.
+
+    Calls torch.ops.deepspeed.lamb when the compiled kernel is available;
+    falls back to a pure-PyTorch loop otherwise.
+    """
+
+    @staticmethod
+    def lamb(p, p_copy, exp_avg, exp_avg_sq, grad, lr, beta1, beta2, max_coeff, min_coeff, eps,
+             combined_scale, step, eps_mode, bias_correction, weight_decay):
+        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'lamb'):
+            return torch.ops.deepspeed.lamb(p, p_copy, exp_avg, exp_avg_sq, grad, lr, beta1,
+                                            beta2, max_coeff, min_coeff, eps, combined_scale,
+                                            step, eps_mode, bias_correction, weight_decay)
+
+        # Pure-PyTorch fallback
+        if bias_correction:
+            bc1 = 1.0 - beta1 ** step
+            bc2 = 1.0 - beta2 ** step
+            step_size = lr * math.sqrt(bc2) / bc1
+        else:
+            step_size = lr
+
+        g = grad.float() / combined_scale
+
+        exp_avg.mul_(beta1).add_(g, alpha=1.0 - beta1)
+        exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
+
+        if eps_mode == 0:
+            denom = (exp_avg_sq + eps).sqrt()
+        else:
+            denom = exp_avg_sq.sqrt().add_(eps)
+
+        update = exp_avg / denom
+        update.add_(p.float(), alpha=weight_decay)
+
+        p_norm = p.float().norm(2)
+        u_norm = update.norm(2)
+        if p_norm == 0 or u_norm == 0:
+            lamb_coeff = torch.tensor(1.0)
+        else:
+            lamb_coeff = (p_norm / u_norm).clamp(min_coeff, max_coeff)
+
+        p.data.add_(update, alpha=-step_size * lamb_coeff.item())
+        if p_copy.numel() > 0:
+            p_copy.copy_(p.data)
+
+        return lamb_coeff
+
+
+class FusedLambBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_FUSED_LAMB"
+    NAME = "fused_lamb"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.lamb.{self.NAME}_op'
+
+    def sources(self):
+        return []
+
+    def load(self, verbose=True):
+        return SUPAFusedLamb

--- a/op_builder/supa/fused_lion.py
+++ b/op_builder/supa/fused_lion.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+from .builder import SUPAOpBuilder
+import torch
+
+try:
+    import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
+except Exception:
+    pass
+
+
+class SUPAFusedLion:
+    """
+    Fused Lion for Biren SUPA GPUs.
+
+    Calls torch.ops.deepspeed.multi_tensor_lion when the compiled kernel is
+    available; falls back to a pure-PyTorch loop otherwise.
+
+    Lion update rule (Chen et al. 2023):
+      c_t  = sign(beta1 * m_{t-1} + (1-beta1) * g_t)
+      p_t  = p_{t-1} - lr * (c_t + weight_decay * p_{t-1})
+      m_t  = beta2 * m_{t-1} + (1-beta2) * g_t
+    """
+
+    @staticmethod
+    def multi_tensor_lion(chunk_size, noop_flag_buffer, tensor_lists,
+                          lr, beta1, beta2, step, weight_decay):
+        if noop_flag_buffer.item() == 1:
+            return
+
+        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_lion'):
+            grads, params, exp_avgs = tensor_lists
+            torch.ops.deepspeed.multi_tensor_lion(
+                chunk_size, noop_flag_buffer,
+                grads, params, exp_avgs,
+                lr, beta1, beta2, step, weight_decay)
+            return
+
+        # Pure-PyTorch fallback
+        for i in range(len(tensor_lists[0])):
+            g = tensor_lists[0][i].float()
+            p = tensor_lists[1][i]
+            m = tensor_lists[2][i]
+
+            update = (beta1 * m.float() + (1.0 - beta1) * g).sign_()
+            p.data.add_(update + weight_decay * p.float(), alpha=-lr)
+            m.mul_(beta2).add_(g, alpha=1.0 - beta2)
+
+
+class FusedLionBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_FUSED_LION"
+    NAME = "fused_lion"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.lion.{self.NAME}_op'
+
+    def sources(self):
+        return []
+
+    def load(self, verbose=True):
+        return SUPAFusedLion
+
+    def is_compatible(self, verbose=False):
+        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_lion'):
+            return True
+        try:
+            import torch_supa_ext.deepspeed  # noqa: F401
+            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
+                                                                'multi_tensor_lion')
+        except Exception:
+            return False

--- a/op_builder/supa/fused_lion.py
+++ b/op_builder/supa/fused_lion.py
@@ -2,7 +2,6 @@
 # DeepSpeed Team
 
 from .builder import SUPAOpBuilder
-import torch
 
 try:
     import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
@@ -24,17 +23,16 @@ class SUPAFusedLion:
     """
 
     @staticmethod
-    def multi_tensor_lion(chunk_size, noop_flag_buffer, tensor_lists,
-                          lr, beta1, beta2, step, weight_decay):
+    def multi_tensor_lion(chunk_size, noop_flag_buffer, tensor_lists, lr, beta1, beta2, step, weight_decay):
+        import torch  # ensure torch is available at runtime
+
         if noop_flag_buffer.item() == 1:
             return
 
         if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_lion'):
             grads, params, exp_avgs = tensor_lists
-            torch.ops.deepspeed.multi_tensor_lion(
-                chunk_size, noop_flag_buffer,
-                grads, params, exp_avgs,
-                lr, beta1, beta2, step, weight_decay)
+            torch.ops.deepspeed.multi_tensor_lion(chunk_size, noop_flag_buffer, grads, params, exp_avgs, lr, beta1,
+                                                  beta2, step, weight_decay)
             return
 
         # Pure-PyTorch fallback
@@ -65,11 +63,5 @@ class FusedLionBuilder(SUPAOpBuilder):
         return SUPAFusedLion
 
     def is_compatible(self, verbose=False):
-        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_lion'):
-            return True
-        try:
-            import torch_supa_ext.deepspeed  # noqa: F401
-            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
-                                                                'multi_tensor_lion')
-        except Exception:
-            return False
+        import torch  # ensure torch is available at runtime
+        return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'multi_tensor_lion')

--- a/op_builder/supa/inference.py
+++ b/op_builder/supa/inference.py
@@ -1,17 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # DeepSpeed Team
-
 """
 SUPA Transformer Inference op builder.
 """
 
-import torch
-from .builder import SUPAOpBuilder
-
 try:
+    import torch
     import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
-except Exception:
+except ImportError:
     pass
+
+from .builder import SUPAOpBuilder
 
 
 class SUPAInference:
@@ -25,34 +24,34 @@ class SUPAInference:
     @staticmethod
     def _op(name):
         """Return torch.ops.deepspeed.<name>, raising clearly if not registered."""
+        import torch  # ensure torch is available at runtime
         if not hasattr(torch.ops, 'deepspeed') or not hasattr(torch.ops.deepspeed, name):
-            raise RuntimeError(
-                f"torch.ops.deepspeed.{name} is not available. "
-                "Ensure torch_supa_ext is built with the transformer inference extension.")
+            raise RuntimeError(f"torch.ops.deepspeed.{name} is not available. "
+                               "Ensure torch_supa_ext is built with the transformer inference extension.")
         return getattr(torch.ops.deepspeed, name)
 
     # ── workspace management ────────────────────────────────────────────────
 
     @staticmethod
-    def allocate_workspace_fp16(hidden_dim, heads, sequence_length, num_layers, batch_size,
-                                mp_size, bigscience_bloom, seed, max_out_tokens, min_out_tokens):
-        return SUPAInference._op('allocate_workspace_fp16')(hidden_dim, heads, sequence_length, num_layers,
-                                             batch_size, mp_size, bigscience_bloom, seed,
-                                             max_out_tokens, min_out_tokens)
+    def allocate_workspace_fp16(hidden_dim, heads, sequence_length, num_layers, batch_size, mp_size, bigscience_bloom,
+                                seed, max_out_tokens, min_out_tokens):
+        return SUPAInference._op('allocate_workspace_fp16')(hidden_dim, heads, sequence_length, num_layers, batch_size,
+                                                            mp_size, bigscience_bloom, seed, max_out_tokens,
+                                                            min_out_tokens)
 
     @staticmethod
-    def allocate_workspace_bf16(hidden_dim, heads, sequence_length, num_layers, batch_size,
-                                mp_size, bigscience_bloom, seed, max_out_tokens, min_out_tokens):
-        return SUPAInference._op('allocate_workspace_bf16')(hidden_dim, heads, sequence_length, num_layers,
-                                             batch_size, mp_size, bigscience_bloom, seed,
-                                             max_out_tokens, min_out_tokens)
+    def allocate_workspace_bf16(hidden_dim, heads, sequence_length, num_layers, batch_size, mp_size, bigscience_bloom,
+                                seed, max_out_tokens, min_out_tokens):
+        return SUPAInference._op('allocate_workspace_bf16')(hidden_dim, heads, sequence_length, num_layers, batch_size,
+                                                            mp_size, bigscience_bloom, seed, max_out_tokens,
+                                                            min_out_tokens)
 
     @staticmethod
-    def allocate_workspace_fp32(hidden_dim, heads, sequence_length, num_layers, batch_size,
-                                mp_size, bigscience_bloom, seed, max_out_tokens, min_out_tokens):
-        return SUPAInference._op('allocate_workspace_fp32')(hidden_dim, heads, sequence_length, num_layers,
-                                             batch_size, mp_size, bigscience_bloom, seed,
-                                             max_out_tokens, min_out_tokens)
+    def allocate_workspace_fp32(hidden_dim, heads, sequence_length, num_layers, batch_size, mp_size, bigscience_bloom,
+                                seed, max_out_tokens, min_out_tokens):
+        return SUPAInference._op('allocate_workspace_fp32')(hidden_dim, heads, sequence_length, num_layers, batch_size,
+                                                            mp_size, bigscience_bloom, seed, max_out_tokens,
+                                                            min_out_tokens)
 
     @staticmethod
     def release_workspace():
@@ -83,55 +82,52 @@ class SUPAInference:
     # ── softmax ──────────────────────────────────────────────────────────────
 
     @staticmethod
-    def softmax_fp16(scores, mask, alibi, triangular, recompute, local_attention, window_size,
-                     async_op, layer_scale, head_offset, mp_size):
+    def softmax_fp16(scores, mask, alibi, triangular, recompute, local_attention, window_size, async_op, layer_scale,
+                     head_offset, mp_size):
         return SUPAInference._op('softmax_fp16')(scores, mask, alibi, triangular, recompute, local_attention,
-                                   window_size, async_op, layer_scale, head_offset, mp_size)
+                                                 window_size, async_op, layer_scale, head_offset, mp_size)
 
     @staticmethod
-    def softmax_bf16(scores, mask, alibi, triangular, recompute, local_attention, window_size,
-                     async_op, layer_scale, head_offset, mp_size):
+    def softmax_bf16(scores, mask, alibi, triangular, recompute, local_attention, window_size, async_op, layer_scale,
+                     head_offset, mp_size):
         return SUPAInference._op('softmax_bf16')(scores, mask, alibi, triangular, recompute, local_attention,
-                                   window_size, async_op, layer_scale, head_offset, mp_size)
+                                                 window_size, async_op, layer_scale, head_offset, mp_size)
 
     @staticmethod
-    def softmax_fp32(scores, mask, alibi, triangular, recompute, local_attention, window_size,
-                     async_op, layer_scale, head_offset, mp_size):
+    def softmax_fp32(scores, mask, alibi, triangular, recompute, local_attention, window_size, async_op, layer_scale,
+                     head_offset, mp_size):
         return SUPAInference._op('softmax_fp32')(scores, mask, alibi, triangular, recompute, local_attention,
-                                   window_size, async_op, layer_scale, head_offset, mp_size)
+                                                 window_size, async_op, layer_scale, head_offset, mp_size)
 
     @staticmethod
-    def softmax_context_fp16(query_key_value, attn_mask, rotary_dim, rotate_half,
-                             rotate_every_two, heads, num_kv, norm_factor, triangular_masking,
-                             local_attention, window_size, no_masking, layer_id, num_layers,
-                             alibi, rope_theta, is_prompt, token_idx, position_ids):
+    def softmax_context_fp16(query_key_value, attn_mask, rotary_dim, rotate_half, rotate_every_two, heads, num_kv,
+                             norm_factor, triangular_masking, local_attention, window_size, no_masking, layer_id,
+                             num_layers, alibi, rope_theta, is_prompt, token_idx, position_ids):
         return SUPAInference._op('softmax_context_fp16')(query_key_value, attn_mask, rotary_dim, rotate_half,
-                                           rotate_every_two, heads, num_kv, norm_factor,
-                                           triangular_masking, local_attention, window_size,
-                                           no_masking, layer_id, num_layers, alibi, rope_theta,
-                                           is_prompt, token_idx, position_ids)
+                                                         rotate_every_two, heads, num_kv, norm_factor,
+                                                         triangular_masking, local_attention, window_size, no_masking,
+                                                         layer_id, num_layers, alibi, rope_theta, is_prompt, token_idx,
+                                                         position_ids)
 
     @staticmethod
-    def softmax_context_bf16(query_key_value, attn_mask, rotary_dim, rotate_half,
-                             rotate_every_two, heads, num_kv, norm_factor, triangular_masking,
-                             local_attention, window_size, no_masking, layer_id, num_layers,
-                             alibi, rope_theta, is_prompt, token_idx, position_ids):
+    def softmax_context_bf16(query_key_value, attn_mask, rotary_dim, rotate_half, rotate_every_two, heads, num_kv,
+                             norm_factor, triangular_masking, local_attention, window_size, no_masking, layer_id,
+                             num_layers, alibi, rope_theta, is_prompt, token_idx, position_ids):
         return SUPAInference._op('softmax_context_bf16')(query_key_value, attn_mask, rotary_dim, rotate_half,
-                                           rotate_every_two, heads, num_kv, norm_factor,
-                                           triangular_masking, local_attention, window_size,
-                                           no_masking, layer_id, num_layers, alibi, rope_theta,
-                                           is_prompt, token_idx, position_ids)
+                                                         rotate_every_two, heads, num_kv, norm_factor,
+                                                         triangular_masking, local_attention, window_size, no_masking,
+                                                         layer_id, num_layers, alibi, rope_theta, is_prompt, token_idx,
+                                                         position_ids)
 
     @staticmethod
-    def softmax_context_fp32(query_key_value, attn_mask, rotary_dim, rotate_half,
-                             rotate_every_two, heads, num_kv, norm_factor, triangular_masking,
-                             local_attention, window_size, no_masking, layer_id, num_layers,
-                             alibi, rope_theta, is_prompt, token_idx, position_ids):
+    def softmax_context_fp32(query_key_value, attn_mask, rotary_dim, rotate_half, rotate_every_two, heads, num_kv,
+                             norm_factor, triangular_masking, local_attention, window_size, no_masking, layer_id,
+                             num_layers, alibi, rope_theta, is_prompt, token_idx, position_ids):
         return SUPAInference._op('softmax_context_fp32')(query_key_value, attn_mask, rotary_dim, rotate_half,
-                                           rotate_every_two, heads, num_kv, norm_factor,
-                                           triangular_masking, local_attention, window_size,
-                                           no_masking, layer_id, num_layers, alibi, rope_theta,
-                                           is_prompt, token_idx, position_ids)
+                                                         rotate_every_two, heads, num_kv, norm_factor,
+                                                         triangular_masking, local_attention, window_size, no_masking,
+                                                         layer_id, num_layers, alibi, rope_theta, is_prompt, token_idx,
+                                                         position_ids)
 
     # ── bias ops ─────────────────────────────────────────────────────────────
 
@@ -180,45 +176,42 @@ class SUPAInference:
         return SUPAInference._op('bias_residual_fp32')(input, residual, bias)
 
     @staticmethod
-    def residual_add_bias_fp16(hidden_state, residual, attention_output, attention_bias,
-                               final_bias, mp_size, mlp_after_attn, add_bias, pre_layer_norm):
-        return SUPAInference._op('residual_add_bias_fp16')(hidden_state, residual, attention_output,
-                                             attention_bias, final_bias, mp_size, mlp_after_attn,
-                                             add_bias, pre_layer_norm)
+    def residual_add_bias_fp16(hidden_state, residual, attention_output, attention_bias, final_bias, mp_size,
+                               mlp_after_attn, add_bias, pre_layer_norm):
+        return SUPAInference._op('residual_add_bias_fp16')(hidden_state, residual, attention_output, attention_bias,
+                                                           final_bias, mp_size, mlp_after_attn, add_bias,
+                                                           pre_layer_norm)
 
     @staticmethod
-    def residual_add_bias_bf16(hidden_state, residual, attention_output, attention_bias,
-                               final_bias, mp_size, mlp_after_attn, add_bias, pre_layer_norm):
-        return SUPAInference._op('residual_add_bias_bf16')(hidden_state, residual, attention_output,
-                                             attention_bias, final_bias, mp_size, mlp_after_attn,
-                                             add_bias, pre_layer_norm)
+    def residual_add_bias_bf16(hidden_state, residual, attention_output, attention_bias, final_bias, mp_size,
+                               mlp_after_attn, add_bias, pre_layer_norm):
+        return SUPAInference._op('residual_add_bias_bf16')(hidden_state, residual, attention_output, attention_bias,
+                                                           final_bias, mp_size, mlp_after_attn, add_bias,
+                                                           pre_layer_norm)
 
     @staticmethod
-    def residual_add_bias_fp32(hidden_state, residual, attention_output, attention_bias,
-                               final_bias, mp_size, mlp_after_attn, add_bias, pre_layer_norm):
-        return SUPAInference._op('residual_add_bias_fp32')(hidden_state, residual, attention_output,
-                                             attention_bias, final_bias, mp_size, mlp_after_attn,
-                                             add_bias, pre_layer_norm)
+    def residual_add_bias_fp32(hidden_state, residual, attention_output, attention_bias, final_bias, mp_size,
+                               mlp_after_attn, add_bias, pre_layer_norm):
+        return SUPAInference._op('residual_add_bias_fp32')(hidden_state, residual, attention_output, attention_bias,
+                                                           final_bias, mp_size, mlp_after_attn, add_bias,
+                                                           pre_layer_norm)
 
     # ── QKV GEMM ─────────────────────────────────────────────────────────────
 
     @staticmethod
-    def qkv_gemm_fp16(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
-                      transpose):
-        return SUPAInference._op('qkv_gemm_fp16')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias,
-                                    q_int8, transpose)
+    def qkv_gemm_fp16(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8, transpose):
+        return SUPAInference._op('qkv_gemm_fp16')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
+                                                  transpose)
 
     @staticmethod
-    def qkv_gemm_bf16(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
-                      transpose):
-        return SUPAInference._op('qkv_gemm_bf16')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias,
-                                    q_int8, transpose)
+    def qkv_gemm_bf16(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8, transpose):
+        return SUPAInference._op('qkv_gemm_bf16')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
+                                                  transpose)
 
     @staticmethod
-    def qkv_gemm_fp32(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
-                      transpose):
-        return SUPAInference._op('qkv_gemm_fp32')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias,
-                                    q_int8, transpose)
+    def qkv_gemm_fp32(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8, transpose):
+        return SUPAInference._op('qkv_gemm_fp32')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
+                                                  transpose)
 
     @staticmethod
     def rms_qkv_gemm_fp16(inputs, weight, q_scale, gamma, eps, q_int8, transpose):
@@ -231,40 +224,37 @@ class SUPAInference:
     # ── MLP GEMM ─────────────────────────────────────────────────────────────
 
     @staticmethod
-    def mlp_gemm_fp16(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta,
-                      eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale, q_int8,
-                      act_func_type, transpose):
-        return SUPAInference._op('mlp_gemm_fp16')(input, residual, input_bias, weight_interm, weight_out, bias,
-                                    gamma, beta, eps, pre_layer_norm, mlp_after_attn, interm_scale,
-                                    out_scale, q_int8, act_func_type, transpose)
+    def mlp_gemm_fp16(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta, eps, pre_layer_norm,
+                      mlp_after_attn, interm_scale, out_scale, q_int8, act_func_type, transpose):
+        return SUPAInference._op('mlp_gemm_fp16')(input, residual, input_bias, weight_interm, weight_out, bias, gamma,
+                                                  beta, eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale,
+                                                  q_int8, act_func_type, transpose)
 
     @staticmethod
-    def mlp_gemm_bf16(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta,
-                      eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale, q_int8,
-                      act_func_type, transpose):
-        return SUPAInference._op('mlp_gemm_bf16')(input, residual, input_bias, weight_interm, weight_out, bias,
-                                    gamma, beta, eps, pre_layer_norm, mlp_after_attn, interm_scale,
-                                    out_scale, q_int8, act_func_type, transpose)
+    def mlp_gemm_bf16(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta, eps, pre_layer_norm,
+                      mlp_after_attn, interm_scale, out_scale, q_int8, act_func_type, transpose):
+        return SUPAInference._op('mlp_gemm_bf16')(input, residual, input_bias, weight_interm, weight_out, bias, gamma,
+                                                  beta, eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale,
+                                                  q_int8, act_func_type, transpose)
 
     @staticmethod
-    def mlp_gemm_fp32(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta,
-                      eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale, q_int8,
-                      act_func_type, transpose):
-        return SUPAInference._op('mlp_gemm_fp32')(input, residual, input_bias, weight_interm, weight_out, bias,
-                                    gamma, beta, eps, pre_layer_norm, mlp_after_attn, interm_scale,
-                                    out_scale, q_int8, act_func_type, transpose)
+    def mlp_gemm_fp32(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta, eps, pre_layer_norm,
+                      mlp_after_attn, interm_scale, out_scale, q_int8, act_func_type, transpose):
+        return SUPAInference._op('mlp_gemm_fp32')(input, residual, input_bias, weight_interm, weight_out, bias, gamma,
+                                                  beta, eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale,
+                                                  q_int8, act_func_type, transpose)
 
     @staticmethod
-    def rms_mlp_gemm_fp16(input, residual, weight_interm, weight_out, gamma, eps, interm_scale,
-                          out_scale, q_int8, act_func_type, transpose):
+    def rms_mlp_gemm_fp16(input, residual, weight_interm, weight_out, gamma, eps, interm_scale, out_scale, q_int8,
+                          act_func_type, transpose):
         return SUPAInference._op('rms_mlp_gemm_fp16')(input, residual, weight_interm, weight_out, gamma, eps,
-                                        interm_scale, out_scale, q_int8, act_func_type, transpose)
+                                                      interm_scale, out_scale, q_int8, act_func_type, transpose)
 
     @staticmethod
-    def rms_mlp_gemm_bf16(input, residual, weight_interm, weight_out, gamma, eps, interm_scale,
-                          out_scale, q_int8, act_func_type, transpose):
+    def rms_mlp_gemm_bf16(input, residual, weight_interm, weight_out, gamma, eps, interm_scale, out_scale, q_int8,
+                          act_func_type, transpose):
         return SUPAInference._op('rms_mlp_gemm_bf16')(input, residual, weight_interm, weight_out, gamma, eps,
-                                        interm_scale, out_scale, q_int8, act_func_type, transpose)
+                                                      interm_scale, out_scale, q_int8, act_func_type, transpose)
 
     # ── vector / linear ops ──────────────────────────────────────────────────
 
@@ -281,22 +271,19 @@ class SUPAInference:
         return SUPAInference._op('vector_matmul_fp32')(input, weight, async_op, q_scale, q_int8, transposed_mode)
 
     @staticmethod
-    def linear_layer_fp16(input, weight, bias, add_bias, do_flash_attn, num_heads,
-                          transposed_mode, rope_theta):
+    def linear_layer_fp16(input, weight, bias, add_bias, do_flash_attn, num_heads, transposed_mode, rope_theta):
         return SUPAInference._op('linear_layer_fp16')(input, weight, bias, add_bias, do_flash_attn, num_heads,
-                                        transposed_mode, rope_theta)
+                                                      transposed_mode, rope_theta)
 
     @staticmethod
-    def linear_layer_bf16(input, weight, bias, add_bias, do_flash_attn, num_heads,
-                          transposed_mode, rope_theta):
+    def linear_layer_bf16(input, weight, bias, add_bias, do_flash_attn, num_heads, transposed_mode, rope_theta):
         return SUPAInference._op('linear_layer_bf16')(input, weight, bias, add_bias, do_flash_attn, num_heads,
-                                        transposed_mode, rope_theta)
+                                                      transposed_mode, rope_theta)
 
     @staticmethod
-    def linear_layer_fp32(input, weight, bias, add_bias, do_flash_attn, num_heads,
-                          transposed_mode, rope_theta):
+    def linear_layer_fp32(input, weight, bias, add_bias, do_flash_attn, num_heads, transposed_mode, rope_theta):
         return SUPAInference._op('linear_layer_fp32')(input, weight, bias, add_bias, do_flash_attn, num_heads,
-                                        transposed_mode, rope_theta)
+                                                      transposed_mode, rope_theta)
 
     @staticmethod
     def _vector_add(a, b, gamma):
@@ -309,10 +296,9 @@ class SUPAInference:
         return SUPAInference._op('pad_transform_fp16')(query, key, value, heads, add_padding)
 
     @staticmethod
-    def apply_rotary_pos_emb(mixed_query, key_layer, rotary_dim, offset, num_heads, rotate_half,
-                             rope_theta):
+    def apply_rotary_pos_emb(mixed_query, key_layer, rotary_dim, offset, num_heads, rotate_half, rope_theta):
         return SUPAInference._op('apply_rotary_pos_emb')(mixed_query, key_layer, rotary_dim, offset, num_heads,
-                                           rotate_half, rope_theta)
+                                                         rotate_half, rope_theta)
 
     # ── einsum / MoE ─────────────────────────────────────────────────────────
 
@@ -352,12 +338,4 @@ class InferenceBuilder(SUPAOpBuilder):
         return SUPAInference
 
     def is_compatible(self, verbose=False):
-        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
-                                                        'allocate_workspace_fp16'):
-            return True
-        try:
-            import torch_supa_ext.deepspeed  # noqa: F401
-            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
-                                                                'allocate_workspace_fp16')
-        except Exception:
-            return False
+        return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'allocate_workspace_fp16')

--- a/op_builder/supa/inference.py
+++ b/op_builder/supa/inference.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+"""
+SUPA Transformer Inference op builder.
+"""
+
+import torch
+from .builder import SUPAOpBuilder
+
+try:
+    import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
+except Exception:
+    pass
+
+
+class SUPAInference:
+    """Python wrapper around the SUPA compiled inference kernels.
+
+    Each static method delegates to the corresponding torch.ops.deepspeed
+    function, mirroring the interface that DeepSpeed's op_binding layer
+    expects from inference_module.
+    """
+
+    @staticmethod
+    def _op(name):
+        """Return torch.ops.deepspeed.<name>, raising clearly if not registered."""
+        if not hasattr(torch.ops, 'deepspeed') or not hasattr(torch.ops.deepspeed, name):
+            raise RuntimeError(
+                f"torch.ops.deepspeed.{name} is not available. "
+                "Ensure torch_supa_ext is built with the transformer inference extension.")
+        return getattr(torch.ops.deepspeed, name)
+
+    # ── workspace management ────────────────────────────────────────────────
+
+    @staticmethod
+    def allocate_workspace_fp16(hidden_dim, heads, sequence_length, num_layers, batch_size,
+                                mp_size, bigscience_bloom, seed, max_out_tokens, min_out_tokens):
+        return SUPAInference._op('allocate_workspace_fp16')(hidden_dim, heads, sequence_length, num_layers,
+                                             batch_size, mp_size, bigscience_bloom, seed,
+                                             max_out_tokens, min_out_tokens)
+
+    @staticmethod
+    def allocate_workspace_bf16(hidden_dim, heads, sequence_length, num_layers, batch_size,
+                                mp_size, bigscience_bloom, seed, max_out_tokens, min_out_tokens):
+        return SUPAInference._op('allocate_workspace_bf16')(hidden_dim, heads, sequence_length, num_layers,
+                                             batch_size, mp_size, bigscience_bloom, seed,
+                                             max_out_tokens, min_out_tokens)
+
+    @staticmethod
+    def allocate_workspace_fp32(hidden_dim, heads, sequence_length, num_layers, batch_size,
+                                mp_size, bigscience_bloom, seed, max_out_tokens, min_out_tokens):
+        return SUPAInference._op('allocate_workspace_fp32')(hidden_dim, heads, sequence_length, num_layers,
+                                             batch_size, mp_size, bigscience_bloom, seed,
+                                             max_out_tokens, min_out_tokens)
+
+    @staticmethod
+    def release_workspace():
+        return SUPAInference._op('release_workspace')()
+
+    @staticmethod
+    def retake_workspace():
+        return SUPAInference._op('retake_workspace')()
+
+    @staticmethod
+    def reset_cache():
+        return SUPAInference._op('reset_cache')()
+
+    # ── normalisation ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def layer_norm(inputs, gamma, beta, epsilon):
+        return SUPAInference._op('layer_norm')(inputs, gamma, beta, epsilon)
+
+    @staticmethod
+    def rms_norm(inputs, gamma, epsilon):
+        return SUPAInference._op('rms_norm')(inputs, gamma, epsilon)
+
+    @staticmethod
+    def pre_rms_norm(inputs, residual, gamma, epsilon):
+        return SUPAInference._op('pre_rms_norm')(inputs, residual, gamma, epsilon)
+
+    # ── softmax ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def softmax_fp16(scores, mask, alibi, triangular, recompute, local_attention, window_size,
+                     async_op, layer_scale, head_offset, mp_size):
+        return SUPAInference._op('softmax_fp16')(scores, mask, alibi, triangular, recompute, local_attention,
+                                   window_size, async_op, layer_scale, head_offset, mp_size)
+
+    @staticmethod
+    def softmax_bf16(scores, mask, alibi, triangular, recompute, local_attention, window_size,
+                     async_op, layer_scale, head_offset, mp_size):
+        return SUPAInference._op('softmax_bf16')(scores, mask, alibi, triangular, recompute, local_attention,
+                                   window_size, async_op, layer_scale, head_offset, mp_size)
+
+    @staticmethod
+    def softmax_fp32(scores, mask, alibi, triangular, recompute, local_attention, window_size,
+                     async_op, layer_scale, head_offset, mp_size):
+        return SUPAInference._op('softmax_fp32')(scores, mask, alibi, triangular, recompute, local_attention,
+                                   window_size, async_op, layer_scale, head_offset, mp_size)
+
+    @staticmethod
+    def softmax_context_fp16(query_key_value, attn_mask, rotary_dim, rotate_half,
+                             rotate_every_two, heads, num_kv, norm_factor, triangular_masking,
+                             local_attention, window_size, no_masking, layer_id, num_layers,
+                             alibi, rope_theta, is_prompt, token_idx, position_ids):
+        return SUPAInference._op('softmax_context_fp16')(query_key_value, attn_mask, rotary_dim, rotate_half,
+                                           rotate_every_two, heads, num_kv, norm_factor,
+                                           triangular_masking, local_attention, window_size,
+                                           no_masking, layer_id, num_layers, alibi, rope_theta,
+                                           is_prompt, token_idx, position_ids)
+
+    @staticmethod
+    def softmax_context_bf16(query_key_value, attn_mask, rotary_dim, rotate_half,
+                             rotate_every_two, heads, num_kv, norm_factor, triangular_masking,
+                             local_attention, window_size, no_masking, layer_id, num_layers,
+                             alibi, rope_theta, is_prompt, token_idx, position_ids):
+        return SUPAInference._op('softmax_context_bf16')(query_key_value, attn_mask, rotary_dim, rotate_half,
+                                           rotate_every_two, heads, num_kv, norm_factor,
+                                           triangular_masking, local_attention, window_size,
+                                           no_masking, layer_id, num_layers, alibi, rope_theta,
+                                           is_prompt, token_idx, position_ids)
+
+    @staticmethod
+    def softmax_context_fp32(query_key_value, attn_mask, rotary_dim, rotate_half,
+                             rotate_every_two, heads, num_kv, norm_factor, triangular_masking,
+                             local_attention, window_size, no_masking, layer_id, num_layers,
+                             alibi, rope_theta, is_prompt, token_idx, position_ids):
+        return SUPAInference._op('softmax_context_fp32')(query_key_value, attn_mask, rotary_dim, rotate_half,
+                                           rotate_every_two, heads, num_kv, norm_factor,
+                                           triangular_masking, local_attention, window_size,
+                                           no_masking, layer_id, num_layers, alibi, rope_theta,
+                                           is_prompt, token_idx, position_ids)
+
+    # ── bias ops ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def bias_add_fp16(input, bias):
+        return SUPAInference._op('bias_add_fp16')(input, bias)
+
+    @staticmethod
+    def bias_add_bf16(input, bias):
+        return SUPAInference._op('bias_add_bf16')(input, bias)
+
+    @staticmethod
+    def bias_add_fp32(input, bias):
+        return SUPAInference._op('bias_add_fp32')(input, bias)
+
+    @staticmethod
+    def bias_gelu_fp16(input, bias):
+        return SUPAInference._op('bias_gelu_fp16')(input, bias)
+
+    @staticmethod
+    def bias_gelu_bf16(input, bias):
+        return SUPAInference._op('bias_gelu_bf16')(input, bias)
+
+    @staticmethod
+    def bias_gelu_fp32(input, bias):
+        return SUPAInference._op('bias_gelu_fp32')(input, bias)
+
+    @staticmethod
+    def bias_relu_fp16(input, bias):
+        return SUPAInference._op('bias_relu_fp16')(input, bias)
+
+    @staticmethod
+    def bias_relu_bf16(input, bias):
+        return SUPAInference._op('bias_relu_bf16')(input, bias)
+
+    @staticmethod
+    def bias_relu_fp32(input, bias):
+        return SUPAInference._op('bias_relu_fp32')(input, bias)
+
+    @staticmethod
+    def bias_residual_fp16(input, residual, bias):
+        return SUPAInference._op('bias_residual_fp16')(input, residual, bias)
+
+    @staticmethod
+    def bias_residual_fp32(input, residual, bias):
+        return SUPAInference._op('bias_residual_fp32')(input, residual, bias)
+
+    @staticmethod
+    def residual_add_bias_fp16(hidden_state, residual, attention_output, attention_bias,
+                               final_bias, mp_size, mlp_after_attn, add_bias, pre_layer_norm):
+        return SUPAInference._op('residual_add_bias_fp16')(hidden_state, residual, attention_output,
+                                             attention_bias, final_bias, mp_size, mlp_after_attn,
+                                             add_bias, pre_layer_norm)
+
+    @staticmethod
+    def residual_add_bias_bf16(hidden_state, residual, attention_output, attention_bias,
+                               final_bias, mp_size, mlp_after_attn, add_bias, pre_layer_norm):
+        return SUPAInference._op('residual_add_bias_bf16')(hidden_state, residual, attention_output,
+                                             attention_bias, final_bias, mp_size, mlp_after_attn,
+                                             add_bias, pre_layer_norm)
+
+    @staticmethod
+    def residual_add_bias_fp32(hidden_state, residual, attention_output, attention_bias,
+                               final_bias, mp_size, mlp_after_attn, add_bias, pre_layer_norm):
+        return SUPAInference._op('residual_add_bias_fp32')(hidden_state, residual, attention_output,
+                                             attention_bias, final_bias, mp_size, mlp_after_attn,
+                                             add_bias, pre_layer_norm)
+
+    # ── QKV GEMM ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def qkv_gemm_fp16(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
+                      transpose):
+        return SUPAInference._op('qkv_gemm_fp16')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias,
+                                    q_int8, transpose)
+
+    @staticmethod
+    def qkv_gemm_bf16(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
+                      transpose):
+        return SUPAInference._op('qkv_gemm_bf16')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias,
+                                    q_int8, transpose)
+
+    @staticmethod
+    def qkv_gemm_fp32(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias, q_int8,
+                      transpose):
+        return SUPAInference._op('qkv_gemm_fp32')(inputs, weight, q_scale, bias, gamma, beta, eps, add_bias,
+                                    q_int8, transpose)
+
+    @staticmethod
+    def rms_qkv_gemm_fp16(inputs, weight, q_scale, gamma, eps, q_int8, transpose):
+        return SUPAInference._op('rms_qkv_gemm_fp16')(inputs, weight, q_scale, gamma, eps, q_int8, transpose)
+
+    @staticmethod
+    def rms_qkv_gemm_bf16(inputs, weight, q_scale, gamma, eps, q_int8, transpose):
+        return SUPAInference._op('rms_qkv_gemm_bf16')(inputs, weight, q_scale, gamma, eps, q_int8, transpose)
+
+    # ── MLP GEMM ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def mlp_gemm_fp16(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta,
+                      eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale, q_int8,
+                      act_func_type, transpose):
+        return SUPAInference._op('mlp_gemm_fp16')(input, residual, input_bias, weight_interm, weight_out, bias,
+                                    gamma, beta, eps, pre_layer_norm, mlp_after_attn, interm_scale,
+                                    out_scale, q_int8, act_func_type, transpose)
+
+    @staticmethod
+    def mlp_gemm_bf16(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta,
+                      eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale, q_int8,
+                      act_func_type, transpose):
+        return SUPAInference._op('mlp_gemm_bf16')(input, residual, input_bias, weight_interm, weight_out, bias,
+                                    gamma, beta, eps, pre_layer_norm, mlp_after_attn, interm_scale,
+                                    out_scale, q_int8, act_func_type, transpose)
+
+    @staticmethod
+    def mlp_gemm_fp32(input, residual, input_bias, weight_interm, weight_out, bias, gamma, beta,
+                      eps, pre_layer_norm, mlp_after_attn, interm_scale, out_scale, q_int8,
+                      act_func_type, transpose):
+        return SUPAInference._op('mlp_gemm_fp32')(input, residual, input_bias, weight_interm, weight_out, bias,
+                                    gamma, beta, eps, pre_layer_norm, mlp_after_attn, interm_scale,
+                                    out_scale, q_int8, act_func_type, transpose)
+
+    @staticmethod
+    def rms_mlp_gemm_fp16(input, residual, weight_interm, weight_out, gamma, eps, interm_scale,
+                          out_scale, q_int8, act_func_type, transpose):
+        return SUPAInference._op('rms_mlp_gemm_fp16')(input, residual, weight_interm, weight_out, gamma, eps,
+                                        interm_scale, out_scale, q_int8, act_func_type, transpose)
+
+    @staticmethod
+    def rms_mlp_gemm_bf16(input, residual, weight_interm, weight_out, gamma, eps, interm_scale,
+                          out_scale, q_int8, act_func_type, transpose):
+        return SUPAInference._op('rms_mlp_gemm_bf16')(input, residual, weight_interm, weight_out, gamma, eps,
+                                        interm_scale, out_scale, q_int8, act_func_type, transpose)
+
+    # ── vector / linear ops ──────────────────────────────────────────────────
+
+    @staticmethod
+    def vector_matmul_fp16(input, weight, async_op, q_scale, q_int8, transposed_mode):
+        return SUPAInference._op('vector_matmul_fp16')(input, weight, async_op, q_scale, q_int8, transposed_mode)
+
+    @staticmethod
+    def vector_matmul_bf16(input, weight, async_op, q_scale, q_int8, transposed_mode):
+        return SUPAInference._op('vector_matmul_bf16')(input, weight, async_op, q_scale, q_int8, transposed_mode)
+
+    @staticmethod
+    def vector_matmul_fp32(input, weight, async_op, q_scale, q_int8, transposed_mode):
+        return SUPAInference._op('vector_matmul_fp32')(input, weight, async_op, q_scale, q_int8, transposed_mode)
+
+    @staticmethod
+    def linear_layer_fp16(input, weight, bias, add_bias, do_flash_attn, num_heads,
+                          transposed_mode, rope_theta):
+        return SUPAInference._op('linear_layer_fp16')(input, weight, bias, add_bias, do_flash_attn, num_heads,
+                                        transposed_mode, rope_theta)
+
+    @staticmethod
+    def linear_layer_bf16(input, weight, bias, add_bias, do_flash_attn, num_heads,
+                          transposed_mode, rope_theta):
+        return SUPAInference._op('linear_layer_bf16')(input, weight, bias, add_bias, do_flash_attn, num_heads,
+                                        transposed_mode, rope_theta)
+
+    @staticmethod
+    def linear_layer_fp32(input, weight, bias, add_bias, do_flash_attn, num_heads,
+                          transposed_mode, rope_theta):
+        return SUPAInference._op('linear_layer_fp32')(input, weight, bias, add_bias, do_flash_attn, num_heads,
+                                        transposed_mode, rope_theta)
+
+    @staticmethod
+    def _vector_add(a, b, gamma):
+        return SUPAInference._op('_vector_add')(a, b, gamma)
+
+    # ── transform / rotary ops ───────────────────────────────────────────────
+
+    @staticmethod
+    def pad_transform_fp16(query, key, value, heads, add_padding):
+        return SUPAInference._op('pad_transform_fp16')(query, key, value, heads, add_padding)
+
+    @staticmethod
+    def apply_rotary_pos_emb(mixed_query, key_layer, rotary_dim, offset, num_heads, rotate_half,
+                             rope_theta):
+        return SUPAInference._op('apply_rotary_pos_emb')(mixed_query, key_layer, rotary_dim, offset, num_heads,
+                                           rotate_half, rope_theta)
+
+    # ── einsum / MoE ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def einsum_sec_sm_ecm_fp16(Q, W):
+        return SUPAInference._op('einsum_sec_sm_ecm_fp16')(Q, W)
+
+    @staticmethod
+    def einsum_sec_sm_ecm_fp32(Q, W):
+        return SUPAInference._op('einsum_sec_sm_ecm_fp32')(Q, W)
+
+    @staticmethod
+    def moe_res_matmul(moe_res, coef, output):
+        return SUPAInference._op('moe_res_matmul')(moe_res, coef, output)
+
+    # ── activation ops ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def gated_activation(activation_func_type, vals, bias):
+        return SUPAInference._op('gated_activation')(activation_func_type, vals, bias)
+
+
+class InferenceBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_TRANSFORMER_INFERENCE"
+    NAME = "transformer_inference"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.transformer.inference.{self.NAME}_op'
+
+    def sources(self):
+        return []
+
+    def load(self, verbose=True):
+        return SUPAInference
+
+    def is_compatible(self, verbose=False):
+        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
+                                                        'allocate_workspace_fp16'):
+            return True
+        try:
+            import torch_supa_ext.deepspeed  # noqa: F401
+            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
+                                                                'allocate_workspace_fp16')
+        except Exception:
+            return False

--- a/op_builder/supa/no_impl.py
+++ b/op_builder/supa/no_impl.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import os
+import sys
+import importlib
+
+try:
+    from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+    from op_builder.builder import OpBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.builder import OpBuilder
+
+
+class NotImplementedBuilder(OpBuilder):
+    """Stub builder for SUPA ops that are not yet implemented."""
+    NAME = "not_implemented"
+    BUILD_VAR = "DS_BUILD_NOT_IMPLEMENTED"
+
+    def __init__(self, name=None):
+        super().__init__(name=name if name is not None else self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.comm.{self.NAME}_op'
+
+    def sources(self):
+        return []
+
+    def cxx_args(self):
+        return []
+
+    def extra_ldflags(self):
+        return []
+
+    def include_paths(self):
+        return []
+
+    def load(self, verbose=True):
+        raise NotImplementedError(f"'{self.name}' is not supported on the SUPA accelerator backend.")
+
+    def is_compatible(self, verbose=False):
+        return False

--- a/op_builder/supa/no_impl.py
+++ b/op_builder/supa/no_impl.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # DeepSpeed Team
 
-import os
-import sys
-import importlib
-
 try:
     from op_builder import __deepspeed__  # noqa: F401 # type: ignore
     from op_builder.builder import OpBuilder

--- a/op_builder/supa/quantizer.py
+++ b/op_builder/supa/quantizer.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # DeepSpeed Team
 
-import torch
-from .builder import SUPAOpBuilder
-
 try:
+    import torch
     import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
-except Exception:
+except ImportError:
     pass
+
+from .builder import SUPAOpBuilder
 
 
 class SUPAQuantizer:
@@ -22,10 +22,10 @@ class SUPAQuantizer:
     @staticmethod
     def _op(name):
         """Return torch.ops.deepspeed.<name>, raising clearly if not registered."""
+        import torch  # ensure torch is available at runtime
         if not hasattr(torch.ops, 'deepspeed') or not hasattr(torch.ops.deepspeed, name):
-            raise RuntimeError(
-                f"torch.ops.deepspeed.{name} is not available. "
-                "Ensure torch_supa_ext is built with quantization support and imported before use.")
+            raise RuntimeError(f"torch.ops.deepspeed.{name} is not available. "
+                               "Ensure torch_supa_ext is built with quantization support and imported before use.")
         return getattr(torch.ops.deepspeed, name)
 
     @staticmethod
@@ -73,41 +73,37 @@ class SUPAQuantizer:
         return SUPAQuantizer._op('dequantize_fp32')(quantized_data, params, groups, num_bits, int(quant_type))
 
     @staticmethod
-    def dequantize_int4_to_half_experimental(data_in, scale_buffer, min_val_buffer, num_group,
-                                             group_size):
+    def dequantize_int4_to_half_experimental(data_in, scale_buffer, min_val_buffer, num_group, group_size):
         return SUPAQuantizer._op('dequantize_int4_to_half_experimental')(data_in, scale_buffer, min_val_buffer,
-                                                           num_group, group_size)
+                                                                         num_group, group_size)
 
     @staticmethod
-    def dequantize_int8_to_half_experimental(data_in, scale_buffer, min_val_buffer, num_group,
-                                             group_size):
+    def dequantize_int8_to_half_experimental(data_in, scale_buffer, min_val_buffer, num_group, group_size):
         return SUPAQuantizer._op('dequantize_int8_to_half_experimental')(data_in, scale_buffer, min_val_buffer,
-                                                           num_group, group_size)
+                                                                         num_group, group_size)
 
     @staticmethod
-    def swizzle_quant(input_vals, groups, num_bits, quant_type, pipeline_size, nodes,
-                      devices_per_node):
-        return SUPAQuantizer._op('swizzle_quant')(input_vals, groups, num_bits, int(quant_type), pipeline_size,
-                                    nodes, devices_per_node)
+    def swizzle_quant(input_vals, groups, num_bits, quant_type, pipeline_size, nodes, devices_per_node):
+        return SUPAQuantizer._op('swizzle_quant')(input_vals, groups, num_bits, int(quant_type), pipeline_size, nodes,
+                                                  devices_per_node)
 
     @staticmethod
-    def quantized_reduction(input_vals, input_scales, in_groups, out_groups, num_bits, quant_type,
-                            devices_per_node):
-        return SUPAQuantizer._op('quantized_reduction')(input_vals, input_scales, in_groups, out_groups,
-                                          num_bits, int(quant_type), devices_per_node)
+    def quantized_reduction(input_vals, input_scales, in_groups, out_groups, num_bits, quant_type, devices_per_node):
+        return SUPAQuantizer._op('quantized_reduction')(input_vals, input_scales, in_groups, out_groups, num_bits,
+                                                        int(quant_type), devices_per_node)
 
     @staticmethod
-    def loco_swizzle_quant(input_vals, error_feedback, err_beta, groups, num_bits, quant_type,
-                           pipeline_size, nodes, devices_per_node):
+    def loco_swizzle_quant(input_vals, error_feedback, err_beta, groups, num_bits, quant_type, pipeline_size, nodes,
+                           devices_per_node):
         return SUPAQuantizer._op('loco_swizzle_quant')(input_vals, error_feedback, err_beta, groups, num_bits,
-                                         int(quant_type), pipeline_size, nodes, devices_per_node)
+                                                       int(quant_type), pipeline_size, nodes, devices_per_node)
 
     @staticmethod
-    def loco_quantized_reduction(input_vals, input_scales, error_feedback, err_beta, in_groups,
-                                 out_groups, num_bits, quant_type, devices_per_node):
-        return SUPAQuantizer._op('loco_quantized_reduction')(input_vals, input_scales, error_feedback, err_beta,
-                                               in_groups, out_groups, num_bits, int(quant_type),
-                                               devices_per_node)
+    def loco_quantized_reduction(input_vals, input_scales, error_feedback, err_beta, in_groups, out_groups, num_bits,
+                                 quant_type, devices_per_node):
+        return SUPAQuantizer._op('loco_quantized_reduction')(input_vals, input_scales,
+                                                             error_feedback, err_beta, in_groups, out_groups, num_bits,
+                                                             int(quant_type), devices_per_node)
 
 
 class QuantizerBuilder(SUPAOpBuilder):
@@ -127,11 +123,4 @@ class QuantizerBuilder(SUPAOpBuilder):
         return SUPAQuantizer
 
     def is_compatible(self, verbose=False):
-        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'ds_quantize_fp16'):
-            return True
-        try:
-            import torch_supa_ext.deepspeed  # noqa: F401
-            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
-                                                                'ds_quantize_fp16')
-        except Exception:
-            return False
+        return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'ds_quantize_fp16')

--- a/op_builder/supa/quantizer.py
+++ b/op_builder/supa/quantizer.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import torch
+from .builder import SUPAOpBuilder
+
+try:
+    import torch_supa_ext.deepspeed  # noqa: F401 — registers torch.ops.deepspeed
+except Exception:
+    pass
+
+
+class SUPAQuantizer:
+    """
+    Quantizer wrapper for Biren SUPA GPUs.
+    Delegates to torch.ops.deepspeed quantization kernels.
+    """
+
+    Symmetric = 0
+    Asymmetric = 1
+
+    @staticmethod
+    def _op(name):
+        """Return torch.ops.deepspeed.<name>, raising clearly if not registered."""
+        if not hasattr(torch.ops, 'deepspeed') or not hasattr(torch.ops.deepspeed, name):
+            raise RuntimeError(
+                f"torch.ops.deepspeed.{name} is not available. "
+                "Ensure torch_supa_ext is built with quantization support and imported before use.")
+        return getattr(torch.ops.deepspeed, name)
+
+    @staticmethod
+    def ds_quantize_fp16(vals, groups, bits):
+        return SUPAQuantizer._op('ds_quantize_fp16')(vals, groups, bits)
+
+    @staticmethod
+    def ds_quantize_fp32(vals, groups, bits):
+        return SUPAQuantizer._op('ds_quantize_fp32')(vals, groups, bits)
+
+    @staticmethod
+    def ds_sr_quantize_fp16(vals, groups, bits):
+        return SUPAQuantizer._op('ds_sr_quantize_fp16')(vals, groups, bits)
+
+    @staticmethod
+    def ds_sr_quantize_fp32(vals, groups, bits):
+        return SUPAQuantizer._op('ds_sr_quantize_fp32')(vals, groups, bits)
+
+    @staticmethod
+    def ds_quantize_asym_fp16(vals, groups, bits):
+        return SUPAQuantizer._op('ds_quantize_asym_fp16')(vals, groups, bits)
+
+    @staticmethod
+    def ds_quantize_asym_fp32(vals, groups, bits):
+        return SUPAQuantizer._op('ds_quantize_asym_fp32')(vals, groups, bits)
+
+    @staticmethod
+    def ds_sr_quantize_asym_fp16(vals, groups, bits):
+        return SUPAQuantizer._op('ds_sr_quantize_asym_fp16')(vals, groups, bits)
+
+    @staticmethod
+    def ds_sr_quantize_asym_fp32(vals, groups, bits):
+        return SUPAQuantizer._op('ds_sr_quantize_asym_fp32')(vals, groups, bits)
+
+    @staticmethod
+    def quantize(input_vals, groups, num_bits, quant_type):
+        return SUPAQuantizer._op('quantize')(input_vals, groups, num_bits, int(quant_type))
+
+    @staticmethod
+    def dequantize(quantized_data, params, groups, num_bits, quant_type):
+        return SUPAQuantizer._op('dequantize')(quantized_data, params, groups, num_bits, int(quant_type))
+
+    @staticmethod
+    def dequantize_fp32(quantized_data, params, groups, num_bits, quant_type):
+        return SUPAQuantizer._op('dequantize_fp32')(quantized_data, params, groups, num_bits, int(quant_type))
+
+    @staticmethod
+    def dequantize_int4_to_half_experimental(data_in, scale_buffer, min_val_buffer, num_group,
+                                             group_size):
+        return SUPAQuantizer._op('dequantize_int4_to_half_experimental')(data_in, scale_buffer, min_val_buffer,
+                                                           num_group, group_size)
+
+    @staticmethod
+    def dequantize_int8_to_half_experimental(data_in, scale_buffer, min_val_buffer, num_group,
+                                             group_size):
+        return SUPAQuantizer._op('dequantize_int8_to_half_experimental')(data_in, scale_buffer, min_val_buffer,
+                                                           num_group, group_size)
+
+    @staticmethod
+    def swizzle_quant(input_vals, groups, num_bits, quant_type, pipeline_size, nodes,
+                      devices_per_node):
+        return SUPAQuantizer._op('swizzle_quant')(input_vals, groups, num_bits, int(quant_type), pipeline_size,
+                                    nodes, devices_per_node)
+
+    @staticmethod
+    def quantized_reduction(input_vals, input_scales, in_groups, out_groups, num_bits, quant_type,
+                            devices_per_node):
+        return SUPAQuantizer._op('quantized_reduction')(input_vals, input_scales, in_groups, out_groups,
+                                          num_bits, int(quant_type), devices_per_node)
+
+    @staticmethod
+    def loco_swizzle_quant(input_vals, error_feedback, err_beta, groups, num_bits, quant_type,
+                           pipeline_size, nodes, devices_per_node):
+        return SUPAQuantizer._op('loco_swizzle_quant')(input_vals, error_feedback, err_beta, groups, num_bits,
+                                         int(quant_type), pipeline_size, nodes, devices_per_node)
+
+    @staticmethod
+    def loco_quantized_reduction(input_vals, input_scales, error_feedback, err_beta, in_groups,
+                                 out_groups, num_bits, quant_type, devices_per_node):
+        return SUPAQuantizer._op('loco_quantized_reduction')(input_vals, input_scales, error_feedback, err_beta,
+                                               in_groups, out_groups, num_bits, int(quant_type),
+                                               devices_per_node)
+
+
+class QuantizerBuilder(SUPAOpBuilder):
+    BUILD_VAR = "DS_BUILD_QUANTIZER"
+    NAME = "quantizer"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.quantizer.{self.NAME}_op'
+
+    def sources(self):
+        return []
+
+    def load(self, verbose=True):
+        return SUPAQuantizer
+
+    def is_compatible(self, verbose=False):
+        if hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed, 'ds_quantize_fp16'):
+            return True
+        try:
+            import torch_supa_ext.deepspeed  # noqa: F401
+            return hasattr(torch.ops, 'deepspeed') and hasattr(torch.ops.deepspeed,
+                                                                'ds_quantize_fp16')
+        except Exception:
+            return False

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -113,6 +113,10 @@ def set_accelerator_visible():
         elif get_accelerator().device_name() == 'npu':
             npu_smi = subprocess.check_output(['npu-smi', 'info', '-l'])
             num_accelerators = int(npu_smi.decode('utf-8').strip().split('\n')[0].split(':')[1].strip())
+        elif get_accelerator().device_name() == 'supa':
+            br_smi = subprocess.check_output(['brsmi', 'gpu', 'list'])
+            gpu_ids = filter(lambda s: 'GPU' in s, br_smi.decode('utf-8').strip().split('\n'))
+            num_accelerators = len(list(gpu_ids))
         else:
             assert get_accelerator().device_name() == 'cpu'
             num_accelerators = _get_cpu_socket_count()


### PR DESCRIPTION

# Add Biren SUPA Accelerator Support

## Summary

This PR adds accelerator backend support for the **Biren SUPA GPU** (the Biren Technology GPU, software stack SUPA) to DeepSpeed, enabling DeepSpeed to automatically detect the device, run training and inference on Biren GPUs, and reuse DeepSpeed's existing operator invocation framework (fused optimizer, transformer inference, quantizer, async-io, etc.).

SUPA is onboarded as the 9th supported accelerator, following `cuda / cpu / xpu / npu / mps / hpu / mlu / sdaa`. It adheres to DeepSpeed's existing `DeepSpeedAccelerator` abstract interface and the `op_builder` plugin mechanism, with **zero intrusion** into existing backends — the only existing file modified is the accelerator auto-detection entry point `accelerator/real_accelerator.py`.

## Changes

### 1. Accelerator auto-detection and registration — `accelerator/real_accelerator.py` (the only existing file modified)

- Add `'supa'` to `SUPPORTED_ACCELERATOR_LIST`.
- **Explicit specification** (`DS_ACCELERATOR=supa`): attempt `import torch_supa`, and emit a clear error message if it is missing.
- **Auto-detection**: add a SUPA probing branch that determines availability via `import torch_supa` and checking `torch.supa.is_available()`.
  - Critical ordering: because `torch_supa` spoofs `torch.cuda`, the SUPA detection branch **must come before** the CUDA detection, otherwise Biren cards would be misidentified as CUDA devices. This constraint is clearly noted with a comment in the code.
- In the third-step instantiation logic, add the `accelerator_name == 'supa'` → `SUPA_Accelerator()` branch.

### 2. Accelerator implementation — `accelerator/supa_accelerator.py`
Implements all interfaces of the `DeepSpeedAccelerator` abstract base class. The vast majority of APIs delegate directly to `torch.supa.*` (mirroring the semantics of `torch.cuda.*`):

- **Device management**: `device / set_device / current_device / device_count / synchronize`, etc.
- **RNG**: `manual_seed(_all) / get_rng_state / set_rng_state / default_generator`.
- **Stream / Event**: `Stream / Event / current_stream / default_stream`.
- **Memory management**: `empty_cache / memory_allocated / max_memory_allocated / memory_reserved / memory_stats / total_memory / available_memory`, etc. (some use `hasattr` for capability probing, for compatibility across different versions of torch_supa).
- **Data types**: declares support for fp32 / fp16 / bf16.
- **Communication backend**: uses **BCCL** (the Biren collective communication library) on Linux, falling back to `gloo` on Windows.
- **CUDA Graph**: mapped to `torch.supa.SUPAGraph()` / `torch.supa.graph(...)`.
- **op_builder loading**: `op_builder_dir()` returns `op_builder.supa` (local install) or `deepspeed.ops.op_builder.supa` (pip install), and lazily loads via `pkgutil`, scanning all `*Builder` classes in that directory to build the `class_dict`.
- **Environment variables**: `export_envs` exports `BCCL / BIREN / SUPA / LD_LIBRARY / PATH`; `visible_devices_envs` uses `SUPA_VISIBLE_DEVICES`.
- **Compile backend**: defaults to `inductor`, with Triton support.

### 3. SUPA op_builder plugin package — `op_builder/supa/` (new)

A new SUPA builder package, parallel to `op_builder/{cpu,xpu,npu,...}`:

| File | Purpose |
|------|------|
| `builder.py` | `SUPAOpBuilder` base class, compiling host-side C++ sources based on `CppExtension` (`-O3 -std=c++17 -fopenmp` + CPU arch / SIMD width). |
| `fused_adam.py` | `FusedAdamBuilder` + `SUPAFusedAdam`: prefers calling the `torch.ops.deepspeed.multi_tensor_adam` compiled kernel, falling back to a **numerically equivalent pure-PyTorch implementation** when missing (supports Adam mode=0 / AdamW mode=1). |
| `fused_lamb.py` | `FusedLambBuilder` + `SUPAFusedLamb`: `torch.ops.deepspeed.lamb`, with a pure-PyTorch fallback (trust-ratio clamp). |
| `fused_lion.py` | `FusedLionBuilder` + `SUPAFusedLion`: `torch.ops.deepspeed.multi_tensor_lion`, with a pure-PyTorch fallback. |
| `inference.py` | `InferenceBuilder` + `SUPAInference`: wraps the full set of transformer inference kernels (layer_norm / rms_norm / softmax(_context) / bias_* / qkv_gemm / mlp_gemm / vector_matmul / linear_layer / rotary / einsum / MoE / gated_activation), in fp16/bf16/fp32 precisions, each delegating to `torch.ops.deepspeed.*`. |
| `quantizer.py` | `QuantizerBuilder` + `SUPAQuantizer`: symmetric/asymmetric quantization, stochastic rounding (SR), int4/int8 dequantization, swizzle_quant, quantized_reduction, LoCo, etc. |
| `async_io.py` | `AsyncIOBuilder`: reuses DeepSpeed's existing `csrc/aio/*` C++ sources, depends on `libaio`, includes a package-manager detection hint. |
| `cpu_adam.py` / `cpu_lion.py` / `cpu_adagrad.py` | CPU offload optimizer builders, reusing the `csrc/{adam,lion,adagrad}/*` sources. |
| `no_impl.py` | `NotImplementedBuilder`: a placeholder stub for unimplemented ops; `load()` raises a clear `NotImplementedError`. |
| `__init__.py` | Exports all builders. |

**Design highlights**:
- Compiled kernels are hooked in via `import torch_supa_ext.deepspeed` (side effect: registers `torch.ops.deepspeed.*`); all imports are wrapped in `try/except` so the module remains importable even without the compiled extension.
- `is_compatible()` uses a two-stage decision: "fast path checks whether the op is already registered → otherwise attempt to import the extension".
- optimizer builders provide a pure-PyTorch fallback, making it convenient to do functional verification in cmodel / hardware-free environments.


## Dependencies

Runtime dependencies (all are Biren software-stack components, needed only when using the SUPA backend):

- **`torch_supa`** — the Biren PyTorch device extension, providing the `torch.supa.*` namespace. **Required** (the basis for accelerator detection and all device APIs).
- **`torch_supa_ext`** — the Biren compiled operator extension, with submodules:
  - `torch_supa_ext.deepspeed` — registers `torch.ops.deepspeed.*` (fused optimizer / inference / quantizer kernels).

  *Optional*: when missing, the optimizer falls back to pure PyTorch, while inference/quantizer raise a clear error on invocation and tests are skipped automatically.
- **BCCL** — the Biren collective communication library (the communication backend for distributed training).
- **libaio** — required by `AsyncIOBuilder` (ZeRO-Infinity NVMe offload) via `libaio-dev`.

**No new dependencies** are introduced for DeepSpeed's existing code or other backends.

## Usage

Prerequisite: the Biren driver + `torch_supa` (+ `torch_supa_ext` as needed) is already installed.

```bash
# Option 1: explicitly specify the backend
export DS_ACCELERATOR=supa

# Option 2: auto-detection (just install torch_supa; no environment variable needed)
```

Usage in code is exactly the same as for other backends, through the unified `get_accelerator()` abstraction:

```python
import torch
from deepspeed.accelerator import get_accelerator

accelerator = get_accelerator()          # automatically returns SUPA_Accelerator
print(accelerator.device_name())         # 'supa'
device = accelerator.device(0)           # torch.device('supa', 0)
tensor = torch.randn(3, device=device)   # tensor([-0.8643,  1.3154,  1.5823, ], device='supa:0')

# DeepSpeed training/inference initialization requires no changes; op_builder is automatically routed to op_builder.supa
```

Multi-card visibility is controlled via the `SUPA_VISIBLE_DEVICES` environment variable; the distributed communication backend defaults to `bccl`.

## Compatibility and scope of impact

- The SUPA path is activated only when `DS_ACCELERATOR=supa` is explicitly set or `torch_supa` is present in the environment; behavior in all other environments is completely unchanged.
- The only existing file modified, `real_accelerator.py`, only adds branches and does not modify existing logic.
- Tests are skipped automatically when no hardware is present, remaining transparent to upstream CI.


