### PR TITLE
[DeepCompile] fix gather params in dynamo skipped frames for ZeRO3

### DIFF
--- a/deepspeed/compile/init_z3.py
+++ b/deepspeed/compile/init_z3.py
@@ -13,7 +13,8 @@ from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload
 from .passes import zero3_compile, prefetch, selective_gather, offload_parameters
 from .backend import make_backend, launch_compile_passes, init_schedule
 from .patch_fake_tensor import patch_fake_tensor
-from .util import get_deepcompile_handle, add_pre_backward_hook
+from .util import get_deepcompile_handle, add_pre_backward_hook, add_post_backward_hook
+from .z3_eager_fallback import DeepCompileZ3EagerFallback
 
 WARMUP = 5
 
@@ -44,9 +45,8 @@ def init_z3(engine, backend, compile_config, compile_kwargs, schedule=None):
     dc = get_deepcompile_handle()
     dc.init(engine.data_parallel_group, compile_config, engine.zero_reduce_bucket_size())
 
-    # Unset hooks
-    for m in engine.module.modules():
-        m._parameters = m._original_parameters
+    engine._deepcompile_z3_eager_fallback = DeepCompileZ3EagerFallback(engine)
+    add_post_backward_hook(engine._deepcompile_z3_eager_fallback.release_gathered_params)
 
     if use_opt:
         optimizer.parameter_offload._remove_module_hooks()

--- a/deepspeed/compile/util.py
+++ b/deepspeed/compile/util.py
@@ -60,10 +60,15 @@ def is_backend_inductor(backend):
 
 backward_started = False
 pre_backward_hooks = []
+post_backward_hooks = []
 
 
 def add_pre_backward_hook(hook):
     pre_backward_hooks.append(hook)
+
+
+def add_post_backward_hook(hook):
+    post_backward_hooks.append(hook)
 
 
 def deepcompile_backward_prologue(is_gradient_accumulation_boundary):
@@ -73,6 +78,11 @@ def deepcompile_backward_prologue(is_gradient_accumulation_boundary):
 
     dc = get_deepcompile_handle()
     dc.start_backward(is_gradient_accumulation_boundary)
+
+
+def deepcompile_backward_epilogue():
+    for hook in post_backward_hooks:
+        hook()
 
 
 def log_rank0(msg: str, enable: bool = False):

--- a/deepspeed/compile/z3_eager_fallback.py
+++ b/deepspeed/compile/z3_eager_fallback.py
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from contextlib import contextmanager
+
+import torch
+
+from deepspeed.runtime.zero.parameter_offload import ZeROOrderedDict, ensure_zero_ordered_dict
+from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+
+_ACTIVE_FALLBACK = None
+
+
+def get_active_z3_eager_fallback():
+    return _ACTIVE_FALLBACK
+
+
+def record_z3_eager_fallback_param(param):
+    fallback = get_active_z3_eager_fallback()
+    if fallback is None:
+        return False
+    fallback.record_gathered_param(param)
+    return True
+
+
+@contextmanager
+def deepcompile_z3_forward_context(engine):
+    fallback = getattr(engine, "_deepcompile_z3_eager_fallback", None)
+    if fallback is None or not engine.is_deepcompile_active() or not engine.zero_optimization_partition_weights():
+        yield
+        return
+
+    with fallback.forward_context():
+        yield
+
+
+class DeepCompileZ3EagerFallback:
+
+    def __init__(self, engine):
+        self.engine = engine
+        self._depth = 0
+        self._tracked_params = {}
+        self._last_gathered_param_ids = []
+        self._last_released_param_ids = []
+        self.total_gathered_params = 0
+
+    @contextmanager
+    def forward_context(self):
+        global _ACTIVE_FALLBACK
+        previous = _ACTIVE_FALLBACK
+        self._depth += 1
+        if self._depth == 1:
+            self._last_gathered_param_ids = []
+            self._enable_forward_fallback()
+        _ACTIVE_FALLBACK = self
+        try:
+            yield
+        finally:
+            _ACTIVE_FALLBACK = previous
+            self._depth -= 1
+            if self._depth == 0:
+                self._disable_forward_fallback()
+
+    def _enable_forward_fallback(self):
+        for module in self.engine.module.modules():
+            ensure_zero_ordered_dict(module)
+            module._parameters._in_forward = True
+
+    def _disable_forward_fallback(self):
+        for module in self.engine.module.modules():
+            if isinstance(module._parameters, ZeROOrderedDict):
+                module._parameters._in_forward = False
+
+    def record_gathered_param(self, param):
+        ds_id = int(param.ds_id)
+        self._tracked_params[ds_id] = param
+        self._last_gathered_param_ids.append(ds_id)
+        self.total_gathered_params += 1
+
+    @torch.no_grad()
+    def release_gathered_params(self):
+        released = []
+        for ds_id, param in list(self._tracked_params.items()):
+            if (hasattr(param, "ds_status") and param.ds_status == ZeroParamStatus.AVAILABLE
+                    and not getattr(param, "ds_persist", False)):
+                param.partition()
+                released.append(ds_id)
+        self._tracked_params.clear()
+        self._last_released_param_ids = released
+
+    def stats(self):
+        return {
+            "tracked_param_ids": sorted(self._tracked_params),
+            "last_gathered_param_ids": list(self._last_gathered_param_ids),
+            "last_released_param_ids": list(self._last_released_param_ids),
+            "total_gathered_params": self.total_gathered_params,
+        }

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -137,11 +137,13 @@ from deepspeed.accelerator import get_accelerator
 
 from deepspeed.runtime.config import DtypeEnum
 
-from deepspeed.compile.util import is_deepcompile_supported, get_deepcompile_handle, deepcompile_backward_prologue
+from deepspeed.compile.util import (is_deepcompile_supported, get_deepcompile_handle, deepcompile_backward_prologue,
+                                    deepcompile_backward_epilogue)
 from deepspeed.compile.backend import register_compile_pass, opt_passes
 from deepspeed.compile.passes import zero3_compile, prefetch, selective_gather, offload_adam_states
 from deepspeed.compile.init_z1 import init_z1
 from deepspeed.compile.init_z3 import init_z3
+from deepspeed.compile.z3_eager_fallback import deepcompile_z3_forward_context
 from deepspeed.compile.init_sp import init_autosp
 
 MEMORY_OPT_ALLREDUCE_SIZE = 500000000
@@ -2619,7 +2621,7 @@ class DeepSpeedEngine(Module):
             # We can't have this in forward prologue as the compiler compiles hooks including the forward prologue.
             self.launch_compile_passes(self.global_steps)
 
-        with autocast_if_enabled(self):
+        with deepcompile_z3_forward_context(self), autocast_if_enabled(self):
             loss = self.module(*inputs, **kwargs)
 
         # Register output backward hooks
@@ -2752,6 +2754,9 @@ class DeepSpeedEngine(Module):
             if not bf16_optimizer:
                 self.optimizer.backward_epilogue()
             self.optimizer.exit_backward()
+
+        if self.is_deepcompile_active():
+            deepcompile_backward_epilogue()
 
         see_memory_usage("Engine after backward", force=self.memory_breakdown())
         self._stop_timers(self.engine_timers.backward_reduce_timers)

--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -61,11 +61,16 @@ class ZeROOrderedDict(OrderedDict):
         if param is None:
             return param
 
-        # TODO: only weaken this check during compilation
         if hasattr(param, "ds_status") and param.ds_status == ZeroParamStatus.NOT_AVAILABLE:
-            if self._parent_module._parameters._in_forward:
-                register_external_parameter(FWD_MODULE_STACK[-1], param)
-                param.all_gather()
+            if self._parent_module._parameters._in_forward and not torch.compiler.is_compiling():
+                from deepspeed.compile.z3_eager_fallback import get_active_z3_eager_fallback
+                fallback = get_active_z3_eager_fallback()
+                if fallback is None:
+                    register_external_parameter(FWD_MODULE_STACK[-1], param)
+                    param.all_gather()
+                else:
+                    param.all_gather()
+                    fallback.record_gathered_param(param)
                 print_rank_0(f'Registering external parameter from getter {key} ds_id = {param.ds_id}', force=False)
 
         return param

--- a/tests/torch_compile/ds_config_z3_deepcompile_no_persist.json
+++ b/tests/torch_compile/ds_config_z3_deepcompile_no_persist.json
@@ -1,0 +1,41 @@
+{
+  "train_batch_size": 8,
+  "steps_per_print": 2000,
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 0.001,
+      "betas": [
+        0.8,
+        0.999
+      ],
+      "eps": 1e-8,
+      "weight_decay": 3e-7
+    }
+  },
+  "scheduler": {
+    "type": "WarmupLR",
+    "params": {
+      "warmup_min_lr": 0,
+      "warmup_max_lr": 0.001,
+      "warmup_num_steps": 1000
+    }
+  },
+  "gradient_clipping": 1.0,
+  "prescale_gradients": false,
+  "bf16": {
+    "enabled": true
+  },
+  "wall_clock_breakdown": false,
+  "compile": {
+    "deepcompile": true
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "reduce_scatter": true,
+    "overlap_comm": false,
+    "contiguous_gradients": false,
+    "stage3_param_persistence_threshold": 0,
+    "stage3_model_persistence_threshold": 0
+  }
+}

--- a/tests/torch_compile/test_deepcompile_skipped_frame.py
+++ b/tests/torch_compile/test_deepcompile_skipped_frame.py
@@ -1,0 +1,94 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Regression test for skipped eager frames under DeepCompile ZeRO-3."""
+
+import argparse
+import logging
+
+import torch
+
+import deepspeed
+from deepspeed import comm
+from deepspeed.accelerator import get_accelerator
+
+torch._dynamo.config.cache_size_limit = 100
+
+
+def configure_dynamo_logging():
+    try:
+        import torch._logging
+
+        torch._logging.set_logs(dynamo=logging.INFO, graph_breaks=True)
+        torch._dynamo.config.verbose = True
+    except Exception:
+        pass
+
+
+def dynamo_counter_text():
+    counters = torch._dynamo.utils.counters
+    return repr({str(key): dict(value) for key, value in counters.items()})
+
+
+class SkippedFrameModel(torch.nn.Module):
+
+    def __init__(self, vocab_size=384, hidden=384, n_layers=3):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.embed_tokens = torch.nn.Embedding(vocab_size, hidden)
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(hidden, hidden, bias=False) for _ in range(n_layers)])
+        self.head = torch.nn.Linear(hidden, vocab_size, bias=False)
+
+    @torch.compiler.disable
+    def _compiler_disabled_forward(self, input_ids):
+        h = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            h = layer(h)
+            h = torch.relu(h)
+        return self.head(h)
+
+    def forward(self, input_ids):
+        return self._compiler_disabled_forward(input_ids)
+
+
+def main():
+    configure_dynamo_logging()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_rank", type=int, default=-1)
+    parser.add_argument("--deepspeed_config", type=str, default="ds_config_z3_deepcompile_no_persist.json")
+    args = parser.parse_args()
+
+    model = SkippedFrameModel()
+    assert all(p.numel() > 100000 for p in model.parameters())
+
+    engine, _, _, _ = deepspeed.initialize(args=args, model=model, model_parameters=model.parameters())
+    torch._dynamo.reset()
+    torch._dynamo.utils.counters.clear()
+    engine.compile()
+
+    device = get_accelerator().current_device_name()
+    input_ids = torch.randint(0, model.vocab_size, (1, 16), device=device)
+
+    for step in range(3):
+        loss = engine(input_ids).sum()
+        engine.backward(loss)
+        engine.step()
+        if comm.get_rank() == 0:
+            print(f"step={step} loss={loss.item():.4f}")
+
+    counters = dynamo_counter_text()
+    fallback = getattr(engine, "_deepcompile_z3_eager_fallback", None)
+    fallback_stats = fallback.stats() if fallback is not None else {}
+    if comm.get_rank() == 0:
+        print(f"dynamo_counters={counters}")
+        print(f"fallback_stats={fallback_stats}")
+    assert "compiler.disable" in counters or "Skip inlining" in counters
+    assert fallback_stats.get("total_gathered_params", 0) > 0
+
+    if comm.get_rank() == 0:
+        print("PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #7942 

**Root cause:** When `init_z3()` initializes DeepCompile it removes all three parameter-gathering mechanisms (ZeROOrderedDict, module hooks, engine forward hooks) and relies entirely on compiled FX graph ops for allgather/release. but `torch._dynamo` may skip entire frames when it detects graph breaks in for/while loops. Skipped frames execute eagerly with no gathering mechanism, so parameters stay partitioned at shape `[0]`.

## Testing

Validated on 2× H200 with ZeRO3 + DeepCompile:

| Test | Result |
|------|--------|
| **Qwen2 MoE** (actual failing model from #7942) | PASS — 5 training steps, no crash |
| **LLaMA** (regression — already worked) | PASS |
| **Tied embeddings** (shared param across frame types) | PASS |
| **Gradient correctness** (loss decreases on fixed input) | PASS — 12.09 → 10.28 |
| **Guard stability** (no recompilation loops) | PASS — 22 compilations with fix = 22 without |
| **Existing test_compile.py** (100 steps) | PASS |

## Test plan

- [x] `pre-commit run` passes on all changed files
- [x] Existing `tests/torch_compile/test_compile.py` passes (2 GPU, ZeRO-3)
- [x] New regression test `test_deepcompile_skipped_frame.py` passes
- [x] Real Qwen2 MoE model trains without crash
- [x] Real LLaMA model trains without regression
- [x] Tied embedding model trains without crash
- [x] Compilation count unchanged vs upstream (no guard instability)

cc @tohtana @eternalNight 
