### PR TITLE
Pass expected grad dtype to register_z3_param in ZeRO-3 release test

### DIFF
--- a/tests/torch_compile/test_deepcompile_z3_release.py
+++ b/tests/torch_compile/test_deepcompile_z3_release.py
@@ -38,7 +38,7 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
         rank = dist.get_rank()
         values = torch.arange(rank * shard_numel, (rank + 1) * shard_numel, device=device, dtype=torch.float32)
         grad_buffer = torch.zeros_like(values)
-        dc.register_z3_param(ds_id, list(shape), values, grad_buffer, persistent)
+        dc.register_z3_param(ds_id, list(shape), values, grad_buffer, persistent, values.dtype)
         dc.register_graph_z3(graph_id, [ds_id])
         return values
 


### PR DESCRIPTION
#8038 added an argument to `register_z3_param`, but `test_deepcompile_z3_release.py` wasn't updated.
This PR updates the test accordingly.