### PR TITLE
Mixed-precision: per-policy param/buffer dtype cast (preserve fp32 buffers)

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -860,6 +860,10 @@ class DeepSpeedConfig(object):
 
         data_types_params = get_data_types_params(param_dict)
         self.grad_accum_dtype = data_types_params.get(GRAD_ACCUM_DTYPE, GRAD_ACCUM_DTYPE_DEFAULT)
+        # Raw strings ("bf16"/"fp16"/"fp32") or None; resolved via DtypeEnum at
+        # use-time. buffer_dtype=None keeps buffers at their loaded dtype.
+        self.param_dtype = data_types_params.get(PARAM_DTYPE, PARAM_DTYPE_DEFAULT)
+        self.buffer_dtype = data_types_params.get(BUFFER_DTYPE, BUFFER_DTYPE_DEFAULT)
 
         par_write_pipe = get_checkpoint_parallel_write_pipeline(checkpoint_params)
         self.checkpoint_parallel_write_pipeline = par_write_pipe

--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -861,8 +861,9 @@ class DeepSpeedConfig(object):
         data_types_params = get_data_types_params(param_dict)
         self.grad_accum_dtype = data_types_params.get(GRAD_ACCUM_DTYPE, GRAD_ACCUM_DTYPE_DEFAULT)
         # Raw strings ("bf16"/"fp16"/"fp32") or None; resolved via DtypeEnum at
-        # use-time. buffer_dtype=None keeps buffers at their loaded dtype.
+        # use-time.
         self.param_dtype = data_types_params.get(PARAM_DTYPE, PARAM_DTYPE_DEFAULT)
+        # buffer_dtype=None keeps buffers at their loaded dtype.
         self.buffer_dtype = data_types_params.get(BUFFER_DTYPE, BUFFER_DTYPE_DEFAULT)
 
         par_write_pipe = get_checkpoint_parallel_write_pipeline(checkpoint_params)

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -470,11 +470,9 @@ CHECKPOINT_PARALLEL_WRITE_PIPELINE_STAGE_DEFAULT = False
 #   buffer_dtype=["bf16"|"fp16"|"fp32"]
 #   }
 # }
-# param_dtype / buffer_dtype mirror FSDP MixedPrecisionPolicy. When unset (None):
-#   - param_dtype follows the enabled bf16/fp16 mode; if set it must match that
-#     mode (it is validated, not an independent override).
-#   - buffer_dtype keeps each buffer's loaded dtype (e.g. fp32 rotary inv_freq).
-#     Set it to a concrete dtype to force-cast buffers (legacy blanket cast).
+# param_dtype and buffer_dtype mirror FSDP's MixedPrecisionPolicy.
+#   - param_dtype: if None uses the specified mixed precision dtype, otherwise casts the params into the provided dtype
+#   - buffer_dtype: if None uses the buffers' dtype found when the model was loaded (e.g. fp32 rotary inv_freq), otherwise casts the buffers into the provided dtype (which is likely to lead to unintended consequences)
 
 DATA_TYPES = "data_types"
 GRAD_ACCUM_DTYPE = "grad_accum_dtype"

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -471,7 +471,8 @@ CHECKPOINT_PARALLEL_WRITE_PIPELINE_STAGE_DEFAULT = False
 #   }
 # }
 # param_dtype / buffer_dtype mirror FSDP MixedPrecisionPolicy. When unset (None):
-#   - param_dtype falls back to the bf16/fp16 enabled flag (legacy behavior).
+#   - param_dtype follows the enabled bf16/fp16 mode; if set it must match that
+#     mode (it is validated, not an independent override).
 #   - buffer_dtype keeps each buffer's loaded dtype (e.g. fp32 rotary inv_freq).
 #     Set it to a concrete dtype to force-cast buffers (legacy blanket cast).
 

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -466,12 +466,22 @@ CHECKPOINT_PARALLEL_WRITE_PIPELINE_STAGE_DEFAULT = False
 #########################################
 # "data_types": {
 #   grad_accum_dtype=["bf16"|"fp16"|"fp32"]
+#   param_dtype=["bf16"|"fp16"|"fp32"]
+#   buffer_dtype=["bf16"|"fp16"|"fp32"]
 #   }
 # }
+# param_dtype / buffer_dtype mirror FSDP MixedPrecisionPolicy. When unset (None):
+#   - param_dtype falls back to the bf16/fp16 enabled flag (legacy behavior).
+#   - buffer_dtype keeps each buffer's loaded dtype (e.g. fp32 rotary inv_freq).
+#     Set it to a concrete dtype to force-cast buffers (legacy blanket cast).
 
 DATA_TYPES = "data_types"
 GRAD_ACCUM_DTYPE = "grad_accum_dtype"
 GRAD_ACCUM_DTYPE_DEFAULT = None
+PARAM_DTYPE = "param_dtype"
+PARAM_DTYPE_DEFAULT = None
+BUFFER_DTYPE = "buffer_dtype"
+BUFFER_DTYPE_DEFAULT = None
 
 #########################################
 # Drop the last incomplete Batch

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1322,15 +1322,33 @@ class DeepSpeedEngine(Module):
             grad_accum_dtype = DtypeEnum(self._config.grad_accum_dtype).value
         return (model_dtype, grad_accum_dtype)
 
+    def _assert_valid_mixed_precision_config(self):
+        """param_dtype, if set, must match the enabled fp16/bf16 mode.
+
+        The optimizer/master-weight/reduction paths derive the model dtype from
+        the fp16/bf16 flags, so a divergent param_dtype is unsafe.
+        """
+        if self._config.param_dtype is None:
+            return
+        if self.fp16_enabled():
+            model_dtype = torch.half
+        elif self.bfloat16_enabled():
+            model_dtype = torch.bfloat16
+        else:
+            model_dtype = torch.float32
+        requested = DtypeEnum(self._config.param_dtype).value
+        assert requested == model_dtype, (f"data_types.param_dtype='{self._config.param_dtype}' conflicts with the "
+                                          f"enabled precision mode (model dtype {model_dtype}). Set the matching "
+                                          f"fp16/bf16 'enabled' flag or omit data_types.param_dtype.")
+
     def _mixed_precision_dtypes(self):
         """Resolve (param_dtype, buffer_dtype) for the module cast.
 
-        param_dtype: config override, else the fp16/bf16 enabled flag, else None.
-        buffer_dtype: config override, else None (buffers keep their loaded dtype).
+        param_dtype follows the enabled fp16/bf16 mode (None if neither).
+        buffer_dtype: config override, else None (buffers keep loaded dtype).
+        Mismatched param_dtype is rejected in _assert_valid_mixed_precision_config.
         """
-        if self._config.param_dtype is not None:
-            param_dtype = DtypeEnum(self._config.param_dtype).value
-        elif self.fp16_enabled():
+        if self.fp16_enabled():
             param_dtype = torch.half
         elif self.bfloat16_enabled():
             param_dtype = torch.bfloat16
@@ -1489,6 +1507,8 @@ class DeepSpeedEngine(Module):
 
         if self.bfloat16_enabled() and not get_accelerator().is_bf16_supported():
             raise ValueError("Type bf16 is not supported on your device.")
+
+        self._assert_valid_mixed_precision_config()
 
         expected_optim_types = self._supported_optims()
         expected_optim_types += [type(None), Callable]

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -1322,6 +1322,42 @@ class DeepSpeedEngine(Module):
             grad_accum_dtype = DtypeEnum(self._config.grad_accum_dtype).value
         return (model_dtype, grad_accum_dtype)
 
+    def _mixed_precision_dtypes(self):
+        """Resolve (param_dtype, buffer_dtype) for the module cast.
+
+        param_dtype: config override, else the fp16/bf16 enabled flag, else None.
+        buffer_dtype: config override, else None (buffers keep their loaded dtype).
+        """
+        if self._config.param_dtype is not None:
+            param_dtype = DtypeEnum(self._config.param_dtype).value
+        elif self.fp16_enabled():
+            param_dtype = torch.half
+        elif self.bfloat16_enabled():
+            param_dtype = torch.bfloat16
+        else:
+            param_dtype = None
+
+        buffer_dtype = None
+        if self._config.buffer_dtype is not None:
+            buffer_dtype = DtypeEnum(self._config.buffer_dtype).value
+
+        return param_dtype, buffer_dtype
+
+    def _cast_module_mixed_precision(self, param_dtype, buffer_dtype, is_zero_init_model):
+        """Cast params to param_dtype; cast buffers only when buffer_dtype is set."""
+        # ZeRO-Init params are already at the configured dtype and partitioned, so
+        # the per-parameter cast applies only in the non-zero-init path.
+        if param_dtype is not None and not is_zero_init_model:
+            for p in self.module.parameters(recurse=True):
+                if p.is_floating_point() and p.dtype != param_dtype:
+                    p.data = p.data.to(param_dtype)
+
+        # Buffers are never ZeRO-partitioned.
+        if buffer_dtype is not None:
+            for b in self.module.buffers(recurse=True):
+                if b.is_floating_point() and b.dtype != buffer_dtype:
+                    b.data = b.data.to(buffer_dtype)
+
     def _optimizer_has_ckpt_event_prologue(self):
         return self.optimizer is not None and hasattr(self.optimizer, 'checkpoint_event_prologue')
 
@@ -1513,14 +1549,14 @@ class DeepSpeedEngine(Module):
         is_zero_init_model = self.zero_optimization_partition_weights() and any(
             [hasattr(param, "ds_id") for param in self.module.parameters()])
 
-        if self.fp16_enabled():
+        if self.fp16_enabled() or self.bfloat16_enabled():
+            check_dtype = torch.half if self.fp16_enabled() else torch.bfloat16
             if is_zero_init_model:
-                self.__check_params(self.module, torch.half)
-            self.module.half()
-        elif self.bfloat16_enabled():
-            if is_zero_init_model:
-                self.__check_params(self.module, torch.bfloat16)
-            self.module.bfloat16()
+                self.__check_params(self.module, check_dtype)
+            # Cast params only; preserve fp32 buffers (e.g. rotary inv_freq)
+            # unless buffer_dtype is set. Replaces blanket module.half()/bfloat16().
+            param_dtype, buffer_dtype = self._mixed_precision_dtypes()
+            self._cast_module_mixed_precision(param_dtype, buffer_dtype, is_zero_init_model)
         else:
             self.__check_params(self.module, torch.float)
 

--- a/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
+++ b/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
@@ -45,15 +45,31 @@ class TestMixedPrecisionDtypeResolution:
         param_dtype, buffer_dtype = DeepSpeedEngine._mixed_precision_dtypes(self._engine())
         assert param_dtype is None and buffer_dtype is None
 
-    def test_explicit_param_dtype_overrides_flag(self):
-        param_dtype, _ = DeepSpeedEngine._mixed_precision_dtypes(self._engine(param_dtype="fp32", bf16=True))
-        assert param_dtype == torch.float32
-
     @pytest.mark.parametrize("cfg_str,expected", [("bf16", torch.bfloat16), ("fp16", torch.half),
                                                   ("fp32", torch.float32)])
     def test_buffer_dtype_string_resolution(self, cfg_str, expected):
         _, buffer_dtype = DeepSpeedEngine._mixed_precision_dtypes(self._engine(buffer_dtype=cfg_str, bf16=True))
         assert buffer_dtype == expected
+
+
+class TestMixedPrecisionConfigValidation:
+
+    def _engine(self, param_dtype=None, fp16=False, bf16=False):
+        cfg = types.SimpleNamespace(param_dtype=param_dtype, buffer_dtype=None)
+        return types.SimpleNamespace(_config=cfg, fp16_enabled=lambda: fp16, bfloat16_enabled=lambda: bf16)
+
+    def test_unset_param_dtype_ok(self):
+        DeepSpeedEngine._assert_valid_mixed_precision_config(self._engine(bf16=True))  # no raise
+
+    def test_matching_param_dtype_ok(self):
+        DeepSpeedEngine._assert_valid_mixed_precision_config(self._engine(param_dtype="bf16", bf16=True))  # no raise
+
+    @pytest.mark.parametrize("param_dtype,fp16,bf16", [("fp16", False, True), ("fp32", False, True),
+                                                       ("bf16", True, False), ("bf16", False, False)])
+    def test_conflicting_param_dtype_rejected(self, param_dtype, fp16, bf16):
+        with pytest.raises(AssertionError):
+            DeepSpeedEngine._assert_valid_mixed_precision_config(
+                self._engine(param_dtype=param_dtype, fp16=fp16, bf16=bf16))
 
 
 class TestCastModuleMixedPrecision:

--- a/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
+++ b/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
@@ -20,12 +20,6 @@ def _module_with_fp32_buffer(hidden_dim=8):
     module.register_buffer("inv_freq", torch.ones(hidden_dim, dtype=torch.float32))
     return module
 
-
-# ---------------------------------------------------------------------------
-# CPU tests: the new engine methods only read self._config, self.module, and
-# the fp16|bf16 flags, so they can be exercised on lightweight stand-ins
-# without an accelerator or distributed init.
-# ---------------------------------------------------------------------------
 class TestMixedPrecisionDtypeResolution:
 
     def _engine(self, param_dtype=None, buffer_dtype=None, fp16=False, bf16=False):
@@ -100,16 +94,12 @@ class TestCastModuleMixedPrecision:
         assert module.inv_freq.dtype == torch.bfloat16
 
 
-# ---------------------------------------------------------------------------
-# GPU test: the keys flow through DeepSpeedConfig and the cast happens at
-# engine init. This is the real-world regression check (fp32 inv_freq survives
-# a bf16 initialize), so it runs on the accelerator.
-# ---------------------------------------------------------------------------
 @pytest.mark.skipif(torch.bfloat16 not in get_accelerator().supported_dtypes(), reason="bf16 not supported")
+@pytest.mark.parametrize("zero_stage", [0, 3])
 class TestMixedPrecisionDtypeEndToEnd(DistributedTest):
     world_size = 1
 
-    def _config(self, buffer_dtype=None):
+    def _config(self, zero_stage, buffer_dtype=None):
         data_types = {}
         if buffer_dtype is not None:
             data_types["buffer_dtype"] = buffer_dtype
@@ -126,23 +116,26 @@ class TestMixedPrecisionDtypeEndToEnd(DistributedTest):
                 "enabled": True
             },
             "data_types": data_types,
+            "zero_optimization": {
+                "stage": zero_stage
+            }
         }
 
-    def test_config_defaults(self):
-        model = _module_with_fp32_buffer()
-        engine, _, _, _ = deepspeed.initialize(config=self._config(), model=model, model_parameters=model.parameters())
+    def test_config_defaults(self, zero_stage):
+        model = _module_with_fp32_buffer(1024)
+        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage), model=model, model_parameters=model.parameters())
         assert engine._config.param_dtype is None
         assert engine._config.buffer_dtype is None
 
-    def test_buffer_preserved_by_default(self):
-        model = _module_with_fp32_buffer()
-        engine, _, _, _ = deepspeed.initialize(config=self._config(), model=model, model_parameters=model.parameters())
+    def test_buffer_preserved_by_default(self, zero_stage):
+        model = _module_with_fp32_buffer(1024)
+        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage), model=model, model_parameters=model.parameters())
         assert all(p.dtype == torch.bfloat16 for p in engine.module.parameters())
         assert engine.module.inv_freq.dtype == torch.float32
 
-    def test_buffer_dtype_opt_in(self):
-        model = _module_with_fp32_buffer()
-        engine, _, _, _ = deepspeed.initialize(config=self._config(buffer_dtype="bf16"),
+    def test_buffer_dtype_opt_in(self, zero_stage):
+        model = _module_with_fp32_buffer(1024)
+        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage, buffer_dtype="bf16"),
                                                model=model,
                                                model_parameters=model.parameters())
         assert engine.module.inv_freq.dtype == torch.bfloat16

--- a/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
+++ b/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
@@ -1,0 +1,132 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import types
+
+import torch
+import pytest
+
+import deepspeed
+from deepspeed.runtime.engine import DeepSpeedEngine
+from deepspeed.accelerator import get_accelerator
+from unit.common import DistributedTest
+
+
+def _module_with_fp32_buffer(hidden_dim=8):
+    """Linear layer plus an fp32 buffer that mimics the rotary inv_freq."""
+    module = torch.nn.Sequential(torch.nn.Linear(hidden_dim, hidden_dim))
+    module.register_buffer("inv_freq", torch.ones(hidden_dim, dtype=torch.float32))
+    return module
+
+
+# ---------------------------------------------------------------------------
+# CPU tests: the new engine methods only read self._config, self.module, and
+# the fp16|bf16 flags, so they can be exercised on lightweight stand-ins
+# without an accelerator or distributed init.
+# ---------------------------------------------------------------------------
+class TestMixedPrecisionDtypeResolution:
+
+    def _engine(self, param_dtype=None, buffer_dtype=None, fp16=False, bf16=False):
+        cfg = types.SimpleNamespace(param_dtype=param_dtype, buffer_dtype=buffer_dtype)
+        return types.SimpleNamespace(_config=cfg, fp16_enabled=lambda: fp16, bfloat16_enabled=lambda: bf16)
+
+    def test_param_dtype_from_bf16_flag(self):
+        param_dtype, buffer_dtype = DeepSpeedEngine._mixed_precision_dtypes(self._engine(bf16=True))
+        assert param_dtype == torch.bfloat16
+        assert buffer_dtype is None  # buffers preserved by default
+
+    def test_param_dtype_from_fp16_flag(self):
+        param_dtype, _ = DeepSpeedEngine._mixed_precision_dtypes(self._engine(fp16=True))
+        assert param_dtype == torch.half
+
+    def test_no_low_precision_when_disabled(self):
+        param_dtype, buffer_dtype = DeepSpeedEngine._mixed_precision_dtypes(self._engine())
+        assert param_dtype is None and buffer_dtype is None
+
+    def test_explicit_param_dtype_overrides_flag(self):
+        param_dtype, _ = DeepSpeedEngine._mixed_precision_dtypes(self._engine(param_dtype="fp32", bf16=True))
+        assert param_dtype == torch.float32
+
+    @pytest.mark.parametrize("cfg_str,expected", [("bf16", torch.bfloat16), ("fp16", torch.half),
+                                                  ("fp32", torch.float32)])
+    def test_buffer_dtype_string_resolution(self, cfg_str, expected):
+        _, buffer_dtype = DeepSpeedEngine._mixed_precision_dtypes(self._engine(buffer_dtype=cfg_str, bf16=True))
+        assert buffer_dtype == expected
+
+
+class TestCastModuleMixedPrecision:
+
+    def _engine(self, module):
+        return types.SimpleNamespace(module=module)
+
+    def test_params_cast_buffers_preserved_by_default(self):
+        module = _module_with_fp32_buffer()
+        DeepSpeedEngine._cast_module_mixed_precision(self._engine(module), torch.bfloat16, None, False)
+        assert all(p.dtype == torch.bfloat16 for p in module.parameters())
+        assert module.inv_freq.dtype == torch.float32  # the regression this PR fixes
+
+    def test_buffer_dtype_forces_cast(self):
+        module = _module_with_fp32_buffer()
+        DeepSpeedEngine._cast_module_mixed_precision(self._engine(module), torch.bfloat16, torch.bfloat16, False)
+        assert module.inv_freq.dtype == torch.bfloat16  # legacy blanket-cast parity
+
+    def test_zero_init_skips_param_cast(self):
+        module = _module_with_fp32_buffer()
+        DeepSpeedEngine._cast_module_mixed_precision(self._engine(module), torch.bfloat16, None, True)
+        assert all(p.dtype == torch.float32 for p in module.parameters())  # zero-init owns the param dtype
+
+    def test_param_dtype_none_leaves_params(self):
+        module = _module_with_fp32_buffer()
+        DeepSpeedEngine._cast_module_mixed_precision(self._engine(module), None, torch.bfloat16, False)
+        assert all(p.dtype == torch.float32 for p in module.parameters())
+        assert module.inv_freq.dtype == torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# GPU test: the keys flow through DeepSpeedConfig and the cast happens at
+# engine init. This is the real-world regression check (fp32 inv_freq survives
+# a bf16 initialize), so it runs on the accelerator.
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(torch.bfloat16 not in get_accelerator().supported_dtypes(), reason="bf16 not supported")
+class TestMixedPrecisionDtypeEndToEnd(DistributedTest):
+    world_size = 1
+
+    def _config(self, buffer_dtype=None):
+        data_types = {}
+        if buffer_dtype is not None:
+            data_types["buffer_dtype"] = buffer_dtype
+        return {
+            "train_batch_size": 1,
+            "optimizer": {
+                "type": "Adam",
+                "params": {
+                    "lr": 1e-3,
+                    "torch_adam": True
+                }
+            },
+            "bf16": {
+                "enabled": True
+            },
+            "data_types": data_types,
+        }
+
+    def test_config_defaults(self):
+        model = _module_with_fp32_buffer()
+        engine, _, _, _ = deepspeed.initialize(config=self._config(), model=model, model_parameters=model.parameters())
+        assert engine._config.param_dtype is None
+        assert engine._config.buffer_dtype is None
+
+    def test_buffer_preserved_by_default(self):
+        model = _module_with_fp32_buffer()
+        engine, _, _, _ = deepspeed.initialize(config=self._config(), model=model, model_parameters=model.parameters())
+        assert all(p.dtype == torch.bfloat16 for p in engine.module.parameters())
+        assert engine.module.inv_freq.dtype == torch.float32
+
+    def test_buffer_dtype_opt_in(self):
+        model = _module_with_fp32_buffer()
+        engine, _, _, _ = deepspeed.initialize(config=self._config(buffer_dtype="bf16"),
+                                               model=model,
+                                               model_parameters=model.parameters())
+        assert engine.module.inv_freq.dtype == torch.bfloat16

--- a/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
+++ b/tests/unit/v1/half_precision/test_mixed_precision_dtype.py
@@ -20,6 +20,7 @@ def _module_with_fp32_buffer(hidden_dim=8):
     module.register_buffer("inv_freq", torch.ones(hidden_dim, dtype=torch.float32))
     return module
 
+
 class TestMixedPrecisionDtypeResolution:
 
     def _engine(self, param_dtype=None, buffer_dtype=None, fp16=False, bf16=False):
@@ -123,13 +124,17 @@ class TestMixedPrecisionDtypeEndToEnd(DistributedTest):
 
     def test_config_defaults(self, zero_stage):
         model = _module_with_fp32_buffer(1024)
-        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage), model=model, model_parameters=model.parameters())
+        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage),
+                                               model=model,
+                                               model_parameters=model.parameters())
         assert engine._config.param_dtype is None
         assert engine._config.buffer_dtype is None
 
     def test_buffer_preserved_by_default(self, zero_stage):
         model = _module_with_fp32_buffer(1024)
-        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage), model=model, model_parameters=model.parameters())
+        engine, _, _, _ = deepspeed.initialize(config=self._config(zero_stage),
+                                               model=model,
+                                               model_parameters=model.parameters())
         assert all(p.dtype == torch.bfloat16 for p in engine.module.parameters())
         assert engine.module.inv_freq.dtype == torch.float32
 


### PR DESCRIPTION
## Summary
- Add `data_types.param_dtype` and `data_types.buffer_dtype` (both default `None`), mirroring FSDP `MixedPrecisionPolicy`.
- Replace the blanket `module.half()` / `module.bfloat16()` in `_configure_distributed_model` with a targeted cast: parameters go to `param_dtype`; floating buffers keep their loaded dtype unless `buffer_dtype` is explicitly set.

## Motivation
The blanket cast downcasts every floating buffer, including the rotary `inv_freq` buffer that HF/FSDP2 keep in fp32. On long contexts the bf16 `inv_freq` loses precision, RoPE angles drift, and logits/grads diverge from the FSDP2 reference. Preserving fp32 buffers by default fixes this; `buffer_dtype` is the escape hatch to reproduce the legacy behavior.

## Behavior
- `param_dtype` unset -> derived from the fp16/bf16 enabled flag (legacy param behavior).
- `buffer_dtype` unset -> buffers keep their loaded dtype (e.g. fp32 `inv_freq`).
- `buffer_dtype` set -> buffers force-cast (legacy blanket-cast parity).

## Test plan
- [ ] `param_dtype=bf16`, `buffer_dtype` unset -> params bf16, `inv_freq` stays fp32.
- [ ] `buffer_dtype=bf16` -> buffers downcast (legacy parity).
- [ ] bf16/fp16 run with neither key set behaves as before except fp32 buffers preserved.
- [ ] 8B / 32B ZeRO-3 long-context run -> grad_norm tracks the FSDP2 reference.

Made with [Cursor](https://cursor.com)