### PR TITLE
Fix AttributeError/TypeError in eigenvalue monitoring (self.ev_values)

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3099,11 +3099,11 @@ class DeepSpeedEngine(Module):
 
                     if (self.eigenvalue_enabled()
                             and not self.gas_boundary_ctr % self.eigenvalue_gas_boundary_resolution()):
-                        ev_values = self.block_eigenvalue.values()
+                        ev_values = list(self.block_eigenvalue.values())
                         for i in range(len(ev_values)):
                             self.summary_events.append((
                                 f"Train/Eigenvalues/ModelBlockParam_{i}",
-                                self.ev_values[i][0],
+                                ev_values[i][0],
                                 self.global_samples,
                             ))
                     self.monitor.write_events(self.summary_events)


### PR DESCRIPTION
## What

Fixes #7983.

The eigenvalue monitoring branch in `DeepSpeedEngine._take_model_step`'s logging path (`deepspeed/runtime/engine.py`) had two bugs:

1. It referenced `self.ev_values`, which is never defined anywhere on the engine. When this branch is reached (monitor enabled, GA boundary, rank 0, eigenvalue enabled) it raises `AttributeError: 'DeepSpeedEngine' object has no attribute 'ev_values'`, which breaks the `monitor.write_events` call.
2. `ev_values = self.block_eigenvalue.values()` returns a `dict_values` view, which is not subscriptable in Python 3. Even after fixing (1), `ev_values[i][0]` would raise `TypeError`.

## Fix

```python
ev_values = list(self.block_eigenvalue.values())
for i in range(len(ev_values)):
    self.summary_events.append((
        f"Train/Eigenvalues/ModelBlockParam_{i}",
        ev_values[i][0],
        self.global_samples,
    ))
```

- Use the local `ev_values` instead of the undefined `self.ev_values`.
- Wrap `.values()` in `list(...)` so index access works.

## Verification

- `grep` confirms no remaining `self.ev_values` references.
- `python -m py_compile deepspeed/runtime/engine.py` passes.

Minimal correctness fix scoped to the reported lines. The code path requires an eigenvalue-enabled training run with monitoring, so no isolated unit test is added; happy to add one if maintainers prefer a targeted regression test.