### PR TITLE
fix: close file descriptor in deepspeed_io_handle_t::wait() to prevent fd leak

### DIFF
--- a/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
+++ b/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
@@ -210,7 +210,7 @@ int deepspeed_io_handle_t::wait()
 
         completed_op->finish();
 
-        if (!completed_op->_filename.empty()) { (completed_op->_fd); }
+        if (!completed_op->_filename.empty()) { close(completed_op->_fd); }
 
         --_num_pending_ops;
         ++num_completed_ops;


### PR DESCRIPTION
## Overview
This PR addresses a file descriptor leak in `deepspeed_io_handle_t::wait()` by ensuring the file descriptor is properly closed after the async I/O operation completes.

## Changes

* Added `close()` call on the file descriptor at the end of `deepspeed_io_handle_t::wait()` to prevent fd accumulation during repeated async I/O operations.
* This prevents potential resource exhaustion in long-running training jobs that perform frequent checkpoint reads/writes via DeepSpeed's async I/O interface with ZeRO3 offload NVMe.