### PR TITLE
[CI] diff driven test selection

### DIFF
--- a/.github/workflows/TEST_SELECTION.md
+++ b/.github/workflows/TEST_SELECTION.md
@@ -1,0 +1,292 @@
+# Diff-based CI test selection
+
+This document explains the diff-driven test-selection system that lets some GPU CI
+workflows run only the tests a PR could affect, instead of the whole suite, while
+still satisfying Required status checks.
+
+It currently drives **`modal-torch-latest`** (which runs `tests/unit/v1/` on
+[modal.com](https://modal.com) GPUs), but is built to drive more workflows from
+one config — see [Adding a workflow](#adding-a-new-workflow).
+
+- [TL;DR](#tldr)
+- [Why](#why)
+- [Moving parts](#moving-parts)
+- [How a decision is made](#how-a-decision-is-made)
+- [Driving it (as a contributor)](#driving-it-as-a-contributor)
+- [Changing it (as a maintainer)](#changing-it-as-a-maintainer)
+- [Security model](#security-model)
+- [Failure modes & guarantees](#failure-modes--guarantees)
+- [FAQ / troubleshooting](#faq--troubleshooting)
+
+
+## TL;DR
+
+- On a PR, `ci/tests_fetcher.py` diffs your branch against the base branch, traces
+  the import graph from your changed files to the impacted tests, and writes the
+  list to `ci/.test_selection/test_list.txt`.
+- The workflow runs pytest on just that list. `push` to `master` and manual runs
+  always run everything.
+- It is **fail-safe**: anything it can't reason about safely → run the *full* suite.
+  It never silently runs *fewer* tests than reality.
+- Preview locally:
+  ```bash
+  python ci/tests_fetcher.py --base origin/master            # what would CI run?
+  python ci/tests_fetcher.py --base origin/master --explain  # ...and why?
+  ```
+- Force a full run: put `[test all]` (or `[no filter]`) in a commit message.
+
+
+## Why
+
+`modal-torch-latest` is a **Required** check, so it must report a status on every
+PR — which means we can't use GitHub's path filters (`on.<event>.paths`) to skip
+it, because a skipped Required job blocks merges. Instead, the job always runs but
+*selects* what to test: a docs-only PR resolves to "no impacted tests" and exits
+fast (still green), while a PR touching a leaf module runs only the tests that
+import it.
+
+The design is a small, self-contained take on HuggingFace `transformers`'
+`utils/tests_fetcher.py`.
+
+
+## Moving parts
+
+| File | Role |
+| --- | --- |
+| `.github/workflows/modal-torch-latest.yml` | The workflow: a `collect-tests` job (runs the fetcher) gating a `deploy` job (runs pytest on modal). |
+| `ci/tests_fetcher.py` | The selector. AST-parses the repo, builds an import graph, decides `all` / `subset` / `none`, writes the test-list file, emits a job summary. |
+| `ci/test_tests_fetcher.py` | Self-tests for the selector (pure stdlib; run in `collect-tests`). |
+| `ci/torch_latest.py` | The modal runner. Reads the test-list file and feeds it to pytest. |
+| `ci/.test_selection/test_list.txt` | The hand-off artifact (one pytest target per line). Git-ignored. |
+
+### Job flow
+
+```
+                pull_request_target / push / workflow_dispatch
+                                  │
+                    ┌─────────────┴─────────────┐
+                    │        collect-tests       │   (no secrets; AST-only)
+                    │  checkout PR head          │
+                    │  self-test the fetcher     │
+                    │  run tests_fetcher.py      │
+                    │   → mode (all|subset|none) │
+                    │   → upload test_list.txt   │
+                    └─────────────┬──────────────┘
+                                  │ needs:
+                                  ▼
+                    ┌────────────────────────────┐
+                    │           deploy            │   (has modal/HF secrets)
+                    │  if mode != none (or manual │
+                    │     / collector failed)     │
+                    │  checkout PR head           │
+                    │  restore ci/ from base      │
+                    │  download test_list.txt     │
+                    │  modal run ci.torch_latest  │
+                    └────────────────────────────┘
+```
+
+`mode` controls `deploy`:
+
+- **`none`** → `deploy` is skipped. The Required status is still satisfied (a
+  skipped dependent job counts as success here).
+- **`subset`** → `deploy` runs pytest on exactly the impacted files.
+- **`all`** → `deploy` runs the whole scope (`tests/unit/v1`).
+
+
+## How a decision is made
+
+`TestSelector.select()` in `ci/tests_fetcher.py` runs these checks in order; the
+first that matches wins:
+
+1. **No base ref** (push / manual) → `all`.
+2. **Base ref unresolvable** → `all`.
+3. **No merge-base** with the base (e.g. shallow clone, unrelated history) → `all`.
+   A diff here would be wrong, so we never narrow on it.
+4. **Commit message tag** `[test all]` / `[no filter]` anywhere on the branch → `all`.
+5. **A changed file matches a run-all glob** (`COMMON_RUN_ALL_GLOBS` +
+   the workflow's `extra_run_all_globs`) → `all`. These are files too central or
+   too dynamic to narrow safely: CI scripts, build system, `csrc/`, `op_builder/`,
+   `accelerator/`, shared fixtures (`tests/unit/common.py`, `tests/conftest.py`,
+   `pytest.ini`), and core runtime hubs (`deepspeed/__init__.py`,
+   `deepspeed/runtime/engine.py`, `deepspeed/comm/**`, `deepspeed/accelerator/**`, …).
+6. **A deleted module is still imported** by a surviving file (a dangling import
+   the graph can't follow) → `all`. A *clean* deletion (importers removed/updated
+   in the same PR) does **not** trigger this.
+7. Otherwise, **narrow via the import graph** (below). If nothing is impacted →
+   `none`; if everything is → `all`; else → `subset`.
+
+### The import graph
+
+- Nodes are Python files under the package roots: `deepspeed/**` and the `unit`
+  test-helper package at `tests/unit/**`.
+- An edge `A → B` means "B imports A". The selector walks **backwards** from each
+  changed file to every test that (transitively) imports it.
+- **Opaque hub modules** (`OPAQUE_MODULES`: `deepspeed`, `deepspeed.comm`,
+  `deepspeed.accelerator`): almost every test imports `unit.common`, which imports
+  these. Their `__init__.py` files eagerly pull in huge subtrees, so if treated as
+  normal nodes *any* `deepspeed/**` change would fan out to the whole suite. We
+  therefore don't expand their `__init__` imports; instead, changes to the hubs
+  themselves are caught by the run-all globs in step 5.
+- **`conftest.py`** changes select every test under that conftest's directory.
+- **New test files** are selected directly (they have no importers yet).
+
+### Dynamic edges (`DYNAMIC_EDGES`)
+
+Some dependencies are wired at runtime (monkey-patching, plugin/registry lookup,
+JIT-loaded ops, `deepspeed.initialize()`-time `replace_module` injection), so a
+test can depend on code it never `import`s. `DYNAMIC_EDGES` is a curated map of
+`changed-file glob → extra test-path globs` that patches these blind spots. It is
+additive on top of the static graph (and is only consulted if step 5 didn't
+already short-circuit to `all`).
+
+
+## Driving it (as a contributor)
+
+### Preview what CI will run
+
+The fetcher is pure stdlib — no DeepSpeed/torch install needed, just `git`:
+
+```bash
+# Selection for your branch vs. the base branch
+python ci/tests_fetcher.py --base origin/master
+cat ci/.test_selection/test_list.txt
+
+# Explain *why* each test was selected (prints import chains)
+python ci/tests_fetcher.py --base origin/master --explain
+```
+
+`--explain` output looks like:
+
+```
+deepspeed/shared.py impacts:
+    tests/unit/v1/test_shared.py <- deepspeed/shared.py
+    tests/unit/v1/moe/test_moe.py <- tests/unit/v1/moe/test_moe.py <- deepspeed/shared.py
+```
+
+### Escape hatches
+
+- **Force the full suite for a push:** include `[test all]` (or `[no filter]`)
+  anywhere in a commit message on the branch.
+- **Touch an infra file:** any change to a run-all glob runs everything.
+- **Found a missed test?** It's likely a runtime/dynamic dependency the static
+  graph can't see — add a `DYNAMIC_EDGES` entry (see below) and/or report it.
+
+
+## Changing it (as a maintainer)
+
+All knobs live in `ci/tests_fetcher.py`. After any change, run the self-tests:
+
+```bash
+python ci/test_tests_fetcher.py          # standalone
+# or: pytest ci/test_tests_fetcher.py
+```
+
+### Add a run-all trigger
+
+Add a glob to `TestSelector.COMMON_RUN_ALL_GLOBS` (shared across workflows) or to
+a specific workflow's `extra_run_all_globs`. Globs match repo-root-relative POSIX
+paths; `dir/**` matches everything under `dir/`.
+
+### Add a dynamic edge
+
+Add to `TestSelector.DYNAMIC_EDGES`:
+
+```python
+DYNAMIC_EDGES = {
+    # changed-file glob : test-path globs to pull in when it changes
+    "deepspeed/module_inject/**": ("tests/unit/v1/moe/**",),
+}
+```
+
+Keep entries conservative: too broad just wastes GPU time; too narrow misses
+coverage. Prefer fixing it here over widening a run-all glob when only a slice of
+tests is truly affected.
+
+### Mark a module opaque
+
+If a new universal hub starts fanning every change out to the whole suite, add it
+to `OPAQUE_MODULES` and (usually) add the hub file itself to the run-all globs so
+real changes to it still run everything.
+
+### Add a new workflow
+
+The engine is config-driven (`WORKFLOWS` registry of `WorkflowConfig`). To drive
+another workflow:
+
+1. Add an entry:
+   ```python
+   WORKFLOWS["my-workflow"] = WorkflowConfig(
+       name="my-workflow",
+       test_scopes=("tests/unit/v2",),               # dirs this workflow runs
+       extra_run_all_globs=(".github/workflows/my-workflow.yml",),
+   )
+   ```
+2. In that workflow's YAML, mirror `modal-torch-latest.yml`'s `collect-tests` job
+   and call the fetcher with `--workflow my-workflow`.
+3. Point the runner at `ci/.test_selection/test_list.txt`.
+4. Add coverage to `ci/test_tests_fetcher.py` if the scope/behavior differs.
+
+### Add a self-test
+
+`ci/test_tests_fetcher.py` builds throwaway git repos (`TmpRepo`) from a synthetic
+`BASELINE` tree and asserts the resulting `mode`/`tests`. Add a `test_*` function
+for any new behavior; it runs both standalone and under pytest, and executes in
+the `collect-tests` CI job, so a broken selector is caught before it mis-picks
+tests.
+
+
+## Security model
+
+The workflow triggers on **`pull_request_target`**, so it runs in the base repo's
+context and the `deploy` job has the modal/HF **secrets** in scope. To keep PRs
+from abusing that:
+
+- `collect-tests` holds **no secrets** and only **AST-parses** (never executes)
+  the PR tree, so reading PR code there is safe.
+- The workflow is gated on `review_requested` / `ready_for_review` — a maintainer
+  vets the PR before CI with secrets runs.
+- `deploy` checks out the **PR's** `deepspeed/` + `tests/` (so selection is
+  meaningful) but **restores `ci/` from the base branch** before running. This
+  means a PR cannot modify the orchestration (which drives `modal run` with the
+  secrets) to exfiltrate them.
+
+> **Consequence:** changes to `ci/*` (including `tests_fetcher.py` itself) take
+> effect under `pull_request_target` only after they're **merged**. Validate
+> `ci/*` changes via a `pull_request`-triggered run or the `modal` CLI locally.
+
+
+## Failure modes & guarantees
+
+The selector is built to **fail safe — to `all`, never to `none`**:
+
+- Missing/unresolvable base, no merge-base, a parse error on a file, or **any
+  unexpected exception** in the selector → it falls back to the full suite (the
+  top-level handler in `main()` logs the traceback and sets `mode=all`).
+- If `collect-tests` fails entirely, `deploy` still runs (and the workflow has an
+  explicit "fail if selection failed" guard) so a broken collector can't let a PR
+  pass without testing.
+- The only way to run *fewer* tests is a clean, well-understood narrow decision;
+  every uncertain case widens to everything.
+
+Every run writes a summary to the GitHub job summary (mode, reason, and the
+selected files) so the decision is auditable from the Actions UI.
+
+
+## FAQ / troubleshooting
+
+**My PR shows `mode=none` but I changed code.**
+Either the change is non-Python / out of the workflow's scope, or your edits
+aren't committed (the fetcher diffs *committed* history, `merge-base..HEAD`).
+
+**A relevant test wasn't selected.**
+Likely a runtime/dynamic dependency. Confirm with `--explain`, then add a
+`DYNAMIC_EDGES` entry. As a stop-gap, push with `[test all]`.
+
+**Everything runs even for a tiny change.**
+You touched a run-all glob (CI/build/shared fixture/core runtime), or a hub module
+fanned out. Check the job summary's `reason`. If a hub over-fans, consider
+`OPAQUE_MODULES`.
+
+**It ran the full suite and the summary says "shallow clone?" / "no merge-base".**
+The runner didn't have enough history to compute the diff. `collect-tests` uses
+`fetch-depth: 0`; if you changed that, restore full history for the base.

--- a/.github/workflows/TEST_SELECTION.md
+++ b/.github/workflows/TEST_SELECTION.md
@@ -67,6 +67,7 @@ The design is a small, self-contained take on HuggingFace `transformers`'
                     ┌─────────────┴─────────────┐
                     │        collect-tests       │   (no secrets; AST-only)
                     │  checkout PR head          │
+                    │  restore ci/ from base     │
                     │  self-test the fetcher     │
                     │  run tests_fetcher.py      │
                     │   → mode (all|subset|none) │
@@ -242,17 +243,27 @@ context and the `deploy` job has the modal/HF **secrets** in scope. To keep PRs
 from abusing that:
 
 - `collect-tests` holds **no secrets** and only **AST-parses** (never executes)
-  the PR tree, so reading PR code there is safe.
+  the PR tree.
+- **Both jobs restore `ci/` from the base branch** before using it:
+  - `collect-tests` runs the **base** selector + self-tests. This job decides
+    whether the Required `deploy` runs, so it must not trust the PR's own
+    `ci/tests_fetcher.py` — otherwise a PR could rewrite it to emit `mode=none`
+    and skip CI while still going green. The diff is computed from git history, so
+    a PR's `ci/` changes still appear in the diff and (via the base selector's
+    `ci/**` run-all glob) force a full run.
+  - `deploy` runs the **base** orchestration (which drives `modal run` with the
+    secrets), so a PR can't repoint it at the secrets to exfiltrate them.
+  In both jobs the PR's `deepspeed/` + `tests/` are what gets parsed/tested.
 - The workflow is gated on `review_requested` / `ready_for_review` — a maintainer
   vets the PR before CI with secrets runs.
-- `deploy` checks out the **PR's** `deepspeed/` + `tests/` (so selection is
-  meaningful) but **restores `ci/` from the base branch** before running. This
-  means a PR cannot modify the orchestration (which drives `modal run` with the
-  secrets) to exfiltrate them.
 
 > **Consequence:** changes to `ci/*` (including `tests_fetcher.py` itself) take
 > effect under `pull_request_target` only after they're **merged**. Validate
 > `ci/*` changes via a `pull_request`-triggered run or the `modal` CLI locally.
+>
+> **Bootstrap:** when the base branch has no selector yet (the PR that introduces
+> it), the restored base `ci/` won't contain `tests_fetcher.py`; `collect-tests`
+> detects this and falls back to running the full suite.
 
 
 ## Failure modes & guarantees

--- a/.github/workflows/TEST_SELECTION.md
+++ b/.github/workflows/TEST_SELECTION.md
@@ -254,8 +254,11 @@ from abusing that:
   - `deploy` runs the **base** orchestration (which drives `modal run` with the
     secrets), so a PR can't repoint it at the secrets to exfiltrate them.
   In both jobs the PR's `deepspeed/` + `tests/` are what gets parsed/tested.
-- The workflow is gated on `review_requested` / `ready_for_review` — a maintainer
-  vets the PR before CI with secrets runs.
+- The `pull_request_target` trigger types are `review_requested`,
+  `ready_for_review`, and `synchronize`. Because `synchronize` re-runs on every
+  push to an open PR (not just on a maintainer action), the maintainer review is a
+  mitigation, **not** an absolute barrier — the base-`ci/` restore above is the
+  primary protection for the secrets.
 
 > **Consequence:** changes to `ci/*` (including `tests_fetcher.py` itself) take
 > effect under `pull_request_target` only after they're **merged**. Validate

--- a/.github/workflows/TEST_SELECTION_STATE.md
+++ b/.github/workflows/TEST_SELECTION_STATE.md
@@ -1,0 +1,108 @@
+# Test-selection — implementation state / handoff
+
+Working notes for the diff-based CI test-selection system, so the work can be
+resumed without re-deriving context. For *how the system works / how to use it*,
+see [`TEST_SELECTION.md`](TEST_SELECTION.md); this file is only about the **state
+of the implementation**.
+
+_Last updated: 2026-06-18._
+
+
+## Status: complete & locally verified (not yet exercised in real CI)
+
+The system is implemented end-to-end and passes local checks. It has **not** yet
+run in a live PR on GitHub Actions / modal, so the first real PR against it should
+be watched.
+
+> Reminder: under `pull_request_target`, `deploy` restores `ci/` from the base
+> branch, so changes under `ci/*` (the fetcher included) only take effect once
+> **merged**. To validate the live behavior before merge, trigger via a
+> `pull_request`-based run or the `modal` CLI.
+
+
+## What was built
+
+A diff-driven selector that, on a PR, runs only the `tests/unit/v1` tests impacted
+by the changed files, with a fail-safe fallback to the full suite. Driven by the
+`modal-torch-latest` workflow.
+
+### Files
+
+| File | State | Notes |
+| --- | --- | --- |
+| `ci/tests_fetcher.py` | new/rewritten | Config-driven `TestSelector` class; import-graph selector. |
+| `ci/test_tests_fetcher.py` | new | 12 stdlib self-tests over synthetic git repos. |
+| `ci/torch_latest.py` | modified | Reads `DS_TEST_LIST_FILE`, runs pytest on the selected targets (falls back to full `tests/unit/v1`). |
+| `.github/workflows/modal-torch-latest.yml` | rewritten | `collect-tests` (fetcher) gates `deploy` (modal). |
+| `.github/workflows/TEST_SELECTION.md` | new | Full design + usage doc. |
+| `.github/workflows/TEST_SELECTION_STATE.md` | new | This file. |
+| `CONTRIBUTING.md` | modified | "Diff-based CI test selection" section + link. |
+| `.gitignore` | modified | Ignores `ci/.test_selection/`. |
+
+
+## Key design decisions (and why)
+
+- **Always-runs Required job, selects instead of skips.** `modal-torch-latest` is a
+  Required check, so path filters can't skip it. `collect-tests` decides
+  `all|subset|none`; `none` skips `deploy` while still satisfying the Required
+  status.
+- **`deploy` tests PR code but restores `ci/` from base.** Selection must reflect
+  PR code, but the orchestration that holds modal/HF secrets must not be
+  PR-controlled. (Security trade-off accepted earlier in the work.)
+- **Opaque hub modules + curated run-all globs.** `deepspeed`, `deepspeed.comm`,
+  `deepspeed.accelerator` are opaque in the graph to stop universal fan-out; core
+  hubs (`deepspeed/__init__.py`, `runtime/engine.py`, `comm/**`, `accelerator/**`,
+  …) instead live in the run-all globs. (Coarseness fix accepted earlier.)
+- **Fail-safe to `all`, never `none`.** Every uncertain case (no base, no
+  merge-base, parse error, unexpected exception) widens to the full suite.
+
+### Improvements implemented in the latest pass (items #3–#11)
+
+- **#3** Degrade to `all` on any selector error (top-level guard in `main()`).
+- **#4** `DYNAMIC_EDGES` map for runtime/dynamic deps the AST can't see
+  (seeded: `deepspeed/module_inject/** → tests/unit/v1/moe/**`).
+- **#5** Deleted `.py` only forces `all` when a *surviving* file still imports it
+  (dangling import); clean deletions no longer over-trigger.
+- **#6** GitHub job summary (`$GITHUB_STEP_SUMMARY`) with mode/reason/file list;
+  `reason` also on `$GITHUB_OUTPUT`.
+- **#7** `--explain` prints import chains from changed files to selected tests.
+- **#8** Escape hatches documented in `CONTRIBUTING.md` + `TEST_SELECTION.md`.
+- **#9** Self-tests in `ci/test_tests_fetcher.py`, also run in `collect-tests`.
+- **#10** Robust merge-base: explicit check, `all` if missing; workflow keeps
+  `fetch-depth: 0` with rationale.
+- **#11** Multi-workflow config: `WORKFLOWS` registry + `WorkflowConfig` +
+  `--workflow` flag.
+
+
+## Verification done locally
+
+- `python ci/tests_fetcher.py` self-tests: **12/12 pass**
+  (narrowing, shared importers, core/comm/fixture run-all, commit tag, docs-only →
+  none, new test file, clean vs. dangling delete, dynamic edge, missing base).
+- Real-repo smoke: `--base`, `--explain`, `--workflow` validation all behave.
+- Confirmed `$GITHUB_OUTPUT` + `$GITHUB_STEP_SUMMARY` emission and the #3
+  error-fallback path directly.
+- No linter errors.
+
+Re-run the core check any time:
+
+```bash
+python ci/test_tests_fetcher.py
+python ci/tests_fetcher.py --base origin/master --explain
+```
+
+
+## Open items / possible follow-ups
+
+- **Live validation:** watch the first real PR; confirm `collect-tests` artifact
+  hand-off and `deploy` gating behave on Actions + modal.
+- **`DYNAMIC_EDGES` is minimal.** Only one seeded edge. Expand as blind spots are
+  found (tests that fail on `master`'s full run but weren't selected on their PR
+  are the signal).
+- **Single workflow wired.** The engine is config-driven (#11) but only
+  `modal-torch-latest` is registered/wired. Other GPU workflows could adopt it by
+  adding a `WorkflowConfig` and mirroring the `collect-tests` job.
+- **Run-all glob tuning.** The core-hub list is a conservative first cut; revisit
+  if it proves too coarse (full runs on minor edits) or too narrow (missed impact).
+- **No telemetry.** Consider logging selection stats over time to tune
+  globs/opaque-modules against real false-positive/negative rates.

--- a/.github/workflows/TEST_SELECTION_STATE.md
+++ b/.github/workflows/TEST_SELECTION_STATE.md
@@ -8,11 +8,24 @@ of the implementation**.
 _Last updated: 2026-06-18._
 
 
-## Status: complete & locally verified (not yet exercised in real CI)
+## Status: complete & locally verified; in review on PR #8077
 
-The system is implemented end-to-end and passes local checks. It has **not** yet
-run in a live PR on GitHub Actions / modal, so the first real PR against it should
-be watched.
+The system is implemented end-to-end and passes local checks. Opened as
+[deepspeedai/DeepSpeed#8077](https://github.com/deepspeedai/DeepSpeed/pull/8077)
+(scoped to `modal-torch-latest` first; replicate to other workflows if accepted).
+It has **not** yet run a live `subset`/`deploy` on modal, so the first real runs
+should be watched.
+
+### Review fixes applied (Codex bot, PR #8077)
+
+- **P1 — run the selector from trusted code.** `collect-tests` now restores `ci/`
+  from the base branch before running the selector + self-tests, so a PR can't
+  rewrite `tests_fetcher.py` to emit `mode=none` and skip the Required check. (A
+  PR's `ci/` changes still show in the diff and force a full run via `ci/**`.)
+  Includes a bootstrap fallback: if base has no `tests_fetcher.py` yet, run all.
+- **P1 — hidden-file artifact.** `actions/upload-artifact@v4` skips dot-prefixed
+  paths by default; `ci/.test_selection/` is one. Added `include-hidden-files:
+  true` so `deploy`'s download doesn't fail.
 
 > Reminder: under `pull_request_target`, `deploy` restores `ci/` from the base
 > branch, so changes under `ci/*` (the fetcher included) only take effect once

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -179,11 +179,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Test the PR's code (not the base) so diff-driven selection is meaningful.
-          # NOTE: under pull_request_target this runs PR-authored code; the modal/HF
-          # secrets live on this runner, which is why the workflow is gated on
-          # review_requested / ready_for_review (a maintainer vets the PR first). The
-          # CI orchestration itself is restored from base in the next step so a PR
-          # can't repoint it at the secrets.
+          # SECURITY NOTE: under pull_request_target this runs PR-authored code while
+          # the modal/HF secrets are on this runner. The trigger types include
+          # `synchronize`, so this re-runs on every push to an open PR (not only on a
+          # maintainer's review_requested / ready_for_review action) -- do not treat
+          # the maintainer gate as an absolute barrier. The primary protection is that
+          # the CI orchestration (which actually receives the secrets) is restored
+          # from the base branch in the next step, so a PR can't repoint it at the
+          # secrets; only the PR's deepspeed/ + tests/ run, inside modal.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
 

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -9,8 +9,17 @@ name: modal-torch-latest
 # Both files are annotated to what's important and how one might change or update things if needed.
 #
 # Note that since this is a Required job we can't use `on.push.path` file filter - we are using
-# collect-tests job to do the filtering for us so that the job can be skipped and satisfy the
+# the collect-tests job to do the filtering for us so that the job can be skipped and satisfy the
 # Required status for PRs to pass.
+#
+# Test selection: collect-tests runs ci/tests_fetcher.py, which traces the import
+# graph from the PR's changed files to the impacted tests/unit/v1 tests. It emits a
+# `mode` (all | subset | none) and a test-list file:
+#   - none   -> deploy is skipped (Required status is still satisfied by the skip)
+#   - subset -> deploy runs pytest on only the impacted test files
+#   - all    -> deploy runs the whole tests/unit/v1 suite
+#
+# Full design / how to drive & change it: .github/workflows/TEST_SELECTION.md
 #
 
 
@@ -63,55 +72,112 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      deepspeed: ${{ steps.filter.outputs.deepspeed == 'true' || steps.filter.outputs.modal_workflow == 'true' || steps.filter.outputs.ci == 'true' || steps.filter.outputs.unit_tests == 'true' || steps.filter.outputs.csrc == 'true' }}
+      mode: ${{ steps.fetch.outputs.mode }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # For PRs, check out the PR head so the fetcher sees the proposed code.
+          # This job holds NO secrets and the fetcher only AST-parses (never executes)
+          # the tree, so reading PR code here is safe. Falls back to the pushed/manual
+          # commit for non-PR events.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Full history so the merge-base with the base branch is always present.
+          # This is the robust (if slower) choice: a shallow clone that can't reach
+          # the fork point would produce a wrong diff. The fetcher additionally
+          # guards against a missing merge-base by falling back to the full suite,
+          # so we never run a narrow (false-negative) selection on a bad base.
+          fetch-depth: 0
           lfs: true
 
-      - name: Filter changed files
-        uses: dorny/paths-filter@v3
-        id: filter
+      - name: Determine base ref
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git config --global --add safe.directory '*'
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # Fetch the base branch's full history too, so a merge-base always exists.
+            git fetch --no-tags origin "$BASE_REF"
+            echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
+          else
+            # push to master / manual dispatch -> no diff base -> run the full suite
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Self-test the fetcher
+        # Pure-stdlib self-tests for the selector (only needs git + python). Runs
+        # here so a broken selector is caught before it (mis)picks tests.
+        run: |
+          python3 ci/test_tests_fetcher.py
+
+      - name: Select impacted tests
+        id: fetch
+        # Pure-stdlib script; the runner's system python is fine (no deps needed).
+        run: |
+          python3 ci/tests_fetcher.py --workflow modal-torch-latest --base "${{ steps.base.outputs.ref }}"
+
+      - name: Upload test selection
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          predicate-quantifier: every
-          filters: |
-            deepspeed:
-              - 'deepspeed/**'
-              - '!deepspeed/inference/v2/**'
-            modal_workflow:
-              - '.github/workflows/modal*.yml'
-            ci:
-              - 'ci/**'
-            unit_tests:
-              - 'tests/unit/**'
-              - '!tests/unit/inference/v2/**'
-            csrc:
-              - 'csrc/**'
+          name: modal-torch-latest-test-selection
+          path: ci/.test_selection/test_list.txt
+          retention-days: 3
 
   deploy:
     name: modal-torch-latest / DeepSpeedAI CI
     runs-on: ubuntu-latest
     needs: collect-tests
 
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.collect-tests.result != 'success' || needs.collect-tests.outputs.deepspeed == 'true') }}
+    # Run when: manual dispatch, OR the selector failed (fail closed so the Required
+    # check doesn't silently pass), OR the diff impacts at least one test (mode != none).
+    # (!cancelled() adopted from upstream so a cancelled run doesn't trigger deploy.)
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.collect-tests.result != 'success' || needs.collect-tests.outputs.mode != 'none') }}
     steps:
-      - name: Fail if path filter failed
+      - name: Fail if test selection failed
         if: github.event_name != 'workflow_dispatch' && needs.collect-tests.result != 'success'
         run: exit 1
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          # Test the PR's code (not the base) so diff-driven selection is meaningful.
+          # NOTE: under pull_request_target this runs PR-authored code; the modal/HF
+          # secrets live on this runner, which is why the workflow is gated on
+          # review_requested / ready_for_review (a maintainer vets the PR first). The
+          # CI orchestration itself is restored from base in the next step so a PR
+          # can't repoint it at the secrets.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
+
+      - name: Use base-branch CI scripts
+        # Run the *base* version of ci/ (which drives `modal run` with the secrets in
+        # scope) rather than the PR's, so a PR can't modify the orchestration to
+        # exfiltrate secrets. The PR's deepspeed/ + tests/ are still what gets tested.
+        # (As noted in the header, changes to ci/* must be validated via `pull_request`
+        # or the modal CLI, since pull_request_target always uses the base ci/ here.)
+        if: github.event_name == 'pull_request_target'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git config --global --add safe.directory '*'
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git checkout "origin/$BASE_REF" -- ci/
 
       - name: Install Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: 'pip' # caching pip dependencies
+
+      - name: Download test selection
+        if: needs.collect-tests.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: modal-torch-latest-test-selection
+          path: ci/.test_selection
 
       - name: Install build dependencies
         run: |
@@ -123,6 +189,9 @@ jobs:
           MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.10.0-cuda12.8' }}
           MODAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || 'git' }}
           MODAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || 'main' }}
+          # Diff-selected pytest targets produced by collect-tests (falls back to the
+          # full tests/unit/v1 suite if the file is missing/empty).
+          DS_TEST_LIST_FILE: ci/.test_selection/test_list.txt
           # these are created at https://modal.com/settings/deepspeedai/tokens
           # they are then added to the repo's secrets at https://github.com/deepspeedai/deepspeed/settings/secrets/actions
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -9,8 +9,17 @@ name: modal-torch-latest
 # Both files are annotated to what's important and how one might change or update things if needed.
 #
 # Note that since this is a Required job we can't use `on.push.path` file filter - we are using
-# collect-tests job to do the filtering for us so that the job can be skipped and satisfy the
+# the collect-tests job to do the filtering for us so that the job can be skipped and satisfy the
 # Required status for PRs to pass.
+#
+# Test selection: collect-tests runs ci/tests_fetcher.py, which traces the import
+# graph from the PR's changed files to the impacted tests/unit/v1 tests. It emits a
+# `mode` (all | subset | none) and a test-list file:
+#   - none   -> deploy is skipped (Required status is still satisfied by the skip)
+#   - subset -> deploy runs pytest on only the impacted test files
+#   - all    -> deploy runs the whole tests/unit/v1 suite
+#
+# Full design / how to drive & change it: .github/workflows/TEST_SELECTION.md
 #
 
 
@@ -63,55 +72,111 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      deepspeed: ${{ steps.filter.outputs.deepspeed == 'true' || steps.filter.outputs.modal_workflow == 'true' || steps.filter.outputs.ci == 'true' || steps.filter.outputs.unit_tests == 'true' || steps.filter.outputs.csrc == 'true' }}
+      mode: ${{ steps.fetch.outputs.mode }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # For PRs, check out the PR head so the fetcher sees the proposed code.
+          # This job holds NO secrets and the fetcher only AST-parses (never executes)
+          # the tree, so reading PR code here is safe. Falls back to the pushed/manual
+          # commit for non-PR events.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Full history so the merge-base with the base branch is always present.
+          # This is the robust (if slower) choice: a shallow clone that can't reach
+          # the fork point would produce a wrong diff. The fetcher additionally
+          # guards against a missing merge-base by falling back to the full suite,
+          # so we never run a narrow (false-negative) selection on a bad base.
+          fetch-depth: 0
           lfs: true
 
-      - name: Filter changed files
-        uses: dorny/paths-filter@v3
-        id: filter
+      - name: Determine base ref
+        id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git config --global --add safe.directory '*'
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            # Fetch the base branch's full history too, so a merge-base always exists.
+            git fetch --no-tags origin "$BASE_REF"
+            echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
+          else
+            # push to master / manual dispatch -> no diff base -> run the full suite
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Self-test the fetcher
+        # Pure-stdlib self-tests for the selector (only needs git + python). Runs
+        # here so a broken selector is caught before it (mis)picks tests.
+        run: |
+          python3 ci/test_tests_fetcher.py
+
+      - name: Select impacted tests
+        id: fetch
+        # Pure-stdlib script; the runner's system python is fine (no deps needed).
+        run: |
+          python3 ci/tests_fetcher.py --workflow modal-torch-latest --base "${{ steps.base.outputs.ref }}"
+
+      - name: Upload test selection
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          predicate-quantifier: every
-          filters: |
-            deepspeed:
-              - 'deepspeed/**'
-              - '!deepspeed/inference/v2/**'
-            modal_workflow:
-              - '.github/workflows/modal*.yml'
-            ci:
-              - 'ci/**'
-            unit_tests:
-              - 'tests/unit/**'
-              - '!tests/unit/inference/v2/**'
-            csrc:
-              - 'csrc/**'
+          name: modal-torch-latest-test-selection
+          path: ci/.test_selection/test_list.txt
+          retention-days: 3
 
   deploy:
     name: modal-torch-latest / DeepSpeedAI CI
     runs-on: ubuntu-latest
     needs: collect-tests
 
-    if: always() && (github.event_name == 'workflow_dispatch' || needs.collect-tests.result != 'success' || needs.collect-tests.outputs.deepspeed == 'true')
+    # Run when: manual dispatch, OR the selector failed (fail closed so the Required
+    # check doesn't silently pass), OR the diff impacts at least one test (mode != none).
+    if: always() && (github.event_name == 'workflow_dispatch' || needs.collect-tests.result != 'success' || needs.collect-tests.outputs.mode != 'none')
     steps:
-      - name: Fail if path filter failed
+      - name: Fail if test selection failed
         if: github.event_name != 'workflow_dispatch' && needs.collect-tests.result != 'success'
         run: exit 1
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          # Test the PR's code (not the base) so diff-driven selection is meaningful.
+          # NOTE: under pull_request_target this runs PR-authored code; the modal/HF
+          # secrets live on this runner, which is why the workflow is gated on
+          # review_requested / ready_for_review (a maintainer vets the PR first). The
+          # CI orchestration itself is restored from base in the next step so a PR
+          # can't repoint it at the secrets.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
+
+      - name: Use base-branch CI scripts
+        # Run the *base* version of ci/ (which drives `modal run` with the secrets in
+        # scope) rather than the PR's, so a PR can't modify the orchestration to
+        # exfiltrate secrets. The PR's deepspeed/ + tests/ are still what gets tested.
+        # (As noted in the header, changes to ci/* must be validated via `pull_request`
+        # or the modal CLI, since pull_request_target always uses the base ci/ here.)
+        if: github.event_name == 'pull_request_target'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git config --global --add safe.directory '*'
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git checkout "origin/$BASE_REF" -- ci/
 
       - name: Install Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: 'pip' # caching pip dependencies
+
+      - name: Download test selection
+        if: needs.collect-tests.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: modal-torch-latest-test-selection
+          path: ci/.test_selection
 
       - name: Install build dependencies
         run: |
@@ -123,6 +188,9 @@ jobs:
           MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.10.0-cuda12.8' }}
           MODAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || 'git' }}
           MODAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || 'main' }}
+          # Diff-selected pytest targets produced by collect-tests (falls back to the
+          # full tests/unit/v1 suite if the file is missing/empty).
+          DS_TEST_LIST_FILE: ci/.test_selection/test_list.txt
           # these are created at https://modal.com/settings/deepspeedai/tokens
           # they are then added to the repo's secrets at https://github.com/deepspeedai/deepspeed/settings/secrets/actions
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -178,11 +178,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Test the PR's code (not the base) so diff-driven selection is meaningful.
-          # NOTE: under pull_request_target this runs PR-authored code; the modal/HF
-          # secrets live on this runner, which is why the workflow is gated on
-          # review_requested / ready_for_review (a maintainer vets the PR first). The
-          # CI orchestration itself is restored from base in the next step so a PR
-          # can't repoint it at the secrets.
+          # SECURITY NOTE: under pull_request_target this runs PR-authored code while
+          # the modal/HF secrets are on this runner. The trigger types include
+          # `synchronize`, so this re-runs on every push to an open PR (not only on a
+          # maintainer's review_requested / ready_for_review action) -- do not treat
+          # the maintainer gate as an absolute barrier. The primary protection is that
+          # the CI orchestration (which actually receives the secrets) is restored
+          # from the base branch in the next step, so a PR can't repoint it at the
+          # secrets; only the PR's deepspeed/ + tests/ run, inside modal.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           lfs: true
 

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -78,10 +78,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # For PRs, check out the PR head so the fetcher sees the proposed code.
-          # This job holds NO secrets and the fetcher only AST-parses (never executes)
-          # the tree, so reading PR code here is safe. Falls back to the pushed/manual
-          # commit for non-PR events.
+          # For PRs, check out the PR head so the fetcher sees the proposed
+          # deepspeed/ + tests/ code. This job holds NO secrets. The selection
+          # *logic* (ci/) is restored from the base branch in a later step so a PR
+          # can't tamper with the decision (see "Use base-branch CI scripts").
+          # Falls back to the pushed/manual commit for non-PR events.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           # Full history so the merge-base with the base branch is always present.
           # This is the robust (if slower) choice: a shallow clone that can't reach
@@ -107,23 +108,57 @@ jobs:
             echo "ref=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Use base-branch CI scripts
+        # SECURITY: this job decides whether the Required `deploy` job runs. Under
+        # pull_request_target we must NOT trust the PR's own ci/ for that decision:
+        # a PR could rewrite ci/tests_fetcher.py to emit `mode=none` (or its self
+        # tests) and skip CI entirely while still satisfying the Required check.
+        # So run the selector + self-tests from the *base* branch's ci/. The diff is
+        # computed from git history, so a PR's ci/ changes still show up in the diff
+        # and (via the base selector's `ci/**` run-all glob) force a full run.
+        if: github.event_name == 'pull_request_target'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git config --global --add safe.directory '*'
+          git checkout "origin/$BASE_REF" -- ci/
+
       - name: Self-test the fetcher
         # Pure-stdlib self-tests for the selector (only needs git + python). Runs
-        # here so a broken selector is caught before it (mis)picks tests.
+        # here so a broken selector is caught before it (mis)picks tests. Skipped
+        # when the base branch has no selector yet (bootstrap; see below).
         run: |
-          python3 ci/test_tests_fetcher.py
+          if [ -f ci/test_tests_fetcher.py ]; then
+            python3 ci/test_tests_fetcher.py
+          else
+            echo "No base-branch ci/test_tests_fetcher.py (bootstrap) -> skipping self-tests."
+          fi
 
       - name: Select impacted tests
         id: fetch
         # Pure-stdlib script; the runner's system python is fine (no deps needed).
+        # If the base branch doesn't have the selector yet (e.g. the PR that
+        # introduces it), the restored base ci/ won't contain tests_fetcher.py, so
+        # fall back to the full suite -- safe, and unblocks the bootstrap PR.
         run: |
-          python3 ci/tests_fetcher.py --workflow modal-torch-latest --base "${{ steps.base.outputs.ref }}"
+          if [ -f ci/tests_fetcher.py ]; then
+            python3 ci/tests_fetcher.py --workflow modal-torch-latest --base "${{ steps.base.outputs.ref }}"
+          else
+            echo "No base-branch ci/tests_fetcher.py (bootstrap) -> running the full suite."
+            echo "mode=all" >> "$GITHUB_OUTPUT"
+            mkdir -p ci/.test_selection
+            printf 'tests/unit/v1\n' > ci/.test_selection/test_list.txt
+          fi
 
       - name: Upload test selection
         uses: actions/upload-artifact@v4
         with:
           name: modal-torch-latest-test-selection
           path: ci/.test_selection/test_list.txt
+          # The path lives under a dot-folder; upload-artifact treats dot-prefixed
+          # paths as hidden and skips them by default (only warns), which would make
+          # deploy's download fail. Opt in explicitly.
+          include-hidden-files: true
           retention-days: 3
 
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## Ignore Python compiled files
 *.pyc
 
+## Output of the diff-based test selector (ci/tests_fetcher.py)
+ci/.test_selection/
+
 ## Ignore IDE-specific files and directories
 # JetBrains IDE settings
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,51 @@ You can also run:
 make test
 ```
 
+### Diff-based CI test selection
+Some GPU CI workflows (currently `modal-torch-latest`, which runs `tests/unit/v1/`)
+don't run the whole suite on every PR. Instead, `ci/tests_fetcher.py` looks at the
+files your PR changes, builds an import graph over `deepspeed/` and the `unit` test
+helpers, and runs only the tests that could be affected. This keeps CI fast without
+losing coverage (`push` to `master` always runs everything). The full design — and
+how to drive and extend it — is in
+[`.github/workflows/TEST_SELECTION.md`](.github/workflows/TEST_SELECTION.md).
+
+How it decides:
+* It diffs your branch against the base branch's merge-base.
+* Each changed Python file is traced *forward* to the tests that import it
+  (directly or transitively); those tests are selected.
+* It **falls back to the full suite** (never to "no tests") whenever it can't
+  safely narrow: a missing base / merge-base, a changed shared fixture, build
+  system, CI script, or core runtime file, a deleted module that something still
+  imports, or any unexpected error in the selector itself.
+
+Escape hatches:
+* **Force the full suite for a push:** put `[test all]` (or `[no filter]`) anywhere
+  in a commit message on the branch.
+* **Run all by touching infra:** changes to the run-all globs (CI config, build
+  system, `deepspeed/__init__.py`, collectives/accelerator, shared fixtures, etc.)
+  always trigger everything. See `COMMON_RUN_ALL_GLOBS` / `extra_run_all_globs` in
+  `ci/tests_fetcher.py`.
+* **Runtime/dynamic deps the import graph can't see** (monkey-patching, plugin
+  registries, JIT ops, `deepspeed.initialize()`-time injection) are wired up via
+  the curated `DYNAMIC_EDGES` map in `ci/tests_fetcher.py` — add an entry there if
+  you find a gap.
+
+Preview/debug locally (pure stdlib, no DeepSpeed install needed):
+```bash
+# What would CI run for your branch?
+python ci/tests_fetcher.py --base origin/master
+cat ci/.test_selection/test_list.txt
+
+# Why was a test (de)selected? Prints the import chains.
+python ci/tests_fetcher.py --base origin/master --explain
+```
+
+> Note: under `pull_request_target` the `deploy` job runs the PR's `deepspeed/` and
+> `tests/` but restores `ci/` from the base branch (the CI scripts hold the modal/HF
+> secrets). So changes to `ci/*` only take effect once merged — validate them via a
+> `pull_request`-triggered run or the `modal` CLI.
+
 ### Model Tests
 To execute model tests, first [install DeepSpeed](#installation). The
 [DeepSpeedExamples](https://github.com/deepspeedai/DeepSpeedExamples/) repository is cloned

--- a/ci/test_tests_fetcher.py
+++ b/ci/test_tests_fetcher.py
@@ -1,0 +1,281 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Self-tests for ci/tests_fetcher.py (#9).
+
+These build small synthetic git repos on disk and assert the selector makes the
+right call (narrow vs. full vs. nothing). They are pure-stdlib (only need ``git``
+on PATH), so they run anywhere -- including the ``collect-tests`` CI job that uses
+the fetcher -- without a DeepSpeed/torch install.
+
+Run standalone::
+
+    python ci/test_tests_fetcher.py
+
+or under pytest::
+
+    pytest ci/test_tests_fetcher.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # import the sibling module
+
+from tests_fetcher import TestSelector, WorkflowConfig  # noqa: E402
+
+CONFIG = WorkflowConfig(
+    name="test",
+    test_scopes=("tests/unit/v1", ),
+    extra_run_all_globs=(".github/workflows/modal*.yml", ),
+)
+
+# A tiny but representative repo:
+#   deepspeed.leaf    -> imported only by test_leaf
+#   deepspeed.shared  -> imported by test_shared + test_shared2
+#   deepspeed.orphan  -> imported by nobody (for clean-delete test)
+#   runtime/engine, comm/comm, accelerator/* -> core run-all globs
+#   module_inject/*   -> dynamic edge -> moe tests
+BASELINE = {
+    "deepspeed/__init__.py": "from deepspeed import runtime  # noqa\n",
+    "deepspeed/leaf.py": "VALUE = 1\n",
+    "deepspeed/shared.py": "VALUE = 2\n",
+    "deepspeed/orphan.py": "VALUE = 3\n",
+    "deepspeed/runtime/__init__.py": "",
+    "deepspeed/runtime/engine.py": "VALUE = 4\n",
+    "deepspeed/comm/__init__.py": "",
+    "deepspeed/comm/comm.py": "VALUE = 5\n",
+    "deepspeed/module_inject/__init__.py": "",
+    "deepspeed/module_inject/replace.py": "VALUE = 6\n",
+    "tests/__init__.py": "",
+    "tests/unit/__init__.py": "",
+    "tests/unit/common.py": "import deepspeed  # noqa\n",
+    "tests/unit/v1/__init__.py": "",
+    "tests/unit/v1/test_leaf.py": "from deepspeed.leaf import VALUE\n\n\ndef test_x():\n    assert VALUE == 1\n",
+    "tests/unit/v1/test_shared.py": "from deepspeed.shared import VALUE\n\n\ndef test_x():\n    assert VALUE == 2\n",
+    "tests/unit/v1/test_shared2.py": "from deepspeed.shared import VALUE\n\n\ndef test_x():\n    assert VALUE == 2\n",
+    "tests/unit/v1/test_plain.py": "import deepspeed  # noqa\n\n\ndef test_x():\n    assert True\n",
+    "tests/unit/v1/moe/__init__.py": "",
+    "tests/unit/v1/moe/test_moe.py": "import deepspeed  # noqa\n\n\ndef test_x():\n    assert True\n",
+    "README.md": "# synthetic repo\n",
+}
+
+
+class TmpRepo:
+    """A throwaway git repo seeded with BASELINE, committed on ``master``."""
+
+    def __init__(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="ds-fetcher-test-"))
+        for rel, content in BASELINE.items():
+            self.write(rel, content)
+        self._git("init", "-q", "-b", "master")
+        self._git("config", "user.email", "ci@example.com")
+        self._git("config", "user.name", "ci")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "baseline")
+        # Work on a feature branch so ``select("master")`` has a real diff.
+        self._git("checkout", "-q", "-b", "feature")
+
+    def _git(self, *args: str) -> str:
+        return subprocess.run(["git", *args], cwd=self.root, check=True, capture_output=True, text=True).stdout
+
+    def write(self, rel: str, content: str = "") -> None:
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    def delete(self, rel: str) -> None:
+        (self.root / rel).unlink()
+
+    def commit(self, message: str) -> None:
+        self._git("add", "-A")
+        self._git("commit", "-q", "--allow-empty", "-m", message)
+
+    def selector(self) -> TestSelector:
+        return TestSelector(self.root, CONFIG)
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+def _rel_names(repo: TmpRepo, tests) -> set[str]:
+    return {p.relative_to(repo.root).as_posix() for p in tests}
+
+
+# --------------------------------------------------------------------------- #
+# Individual checks. Each builds a fresh repo, mutates it, and asserts.
+# --------------------------------------------------------------------------- #
+def test_leaf_change_narrows_to_one_test() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("deepspeed/leaf.py", "VALUE = 11\n")
+        repo.commit("touch leaf")
+        sel = repo.selector().select("master")
+        assert sel.mode == "subset", sel.reason
+        assert _rel_names(repo, sel.tests) == {"tests/unit/v1/test_leaf.py"}
+    finally:
+        repo.cleanup()
+
+
+def test_shared_change_selects_all_importers() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("deepspeed/shared.py", "VALUE = 22\n")
+        repo.commit("touch shared")
+        sel = repo.selector().select("master")
+        assert sel.mode == "subset", sel.reason
+        assert _rel_names(repo, sel.tests) == {
+            "tests/unit/v1/test_shared.py",
+            "tests/unit/v1/test_shared2.py",
+        }
+    finally:
+        repo.cleanup()
+
+
+def test_core_runtime_file_runs_all() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("deepspeed/runtime/engine.py", "VALUE = 44\n")
+        repo.commit("touch engine")
+        sel = repo.selector().select("master")
+        assert sel.mode == "all", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_comm_change_runs_all() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("deepspeed/comm/comm.py", "VALUE = 55\n")
+        repo.commit("touch comm")
+        sel = repo.selector().select("master")
+        assert sel.mode == "all", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_shared_fixture_runs_all() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("tests/unit/common.py", "import deepspeed  # touched\n")
+        repo.commit("touch common")
+        sel = repo.selector().select("master")
+        assert sel.mode == "all", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_commit_tag_forces_all() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("deepspeed/leaf.py", "VALUE = 11\n")
+        repo.commit("touch leaf [test all]")
+        sel = repo.selector().select("master")
+        assert sel.mode == "all", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_non_python_change_selects_nothing() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write("README.md", "# changed\n")
+        repo.commit("docs only")
+        sel = repo.selector().select("master")
+        assert sel.mode == "none", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_new_test_file_is_selected() -> None:
+    repo = TmpRepo()
+    try:
+        repo.write(
+            "tests/unit/v1/test_new.py",
+            "import deepspeed  # noqa\n\n\ndef test_x():\n    assert True\n",
+        )
+        repo.commit("add new test")
+        sel = repo.selector().select("master")
+        assert sel.mode == "subset", sel.reason
+        assert "tests/unit/v1/test_new.py" in _rel_names(repo, sel.tests)
+    finally:
+        repo.cleanup()
+
+
+def test_clean_delete_does_not_run_all() -> None:
+    # Deleting a module nobody imports must NOT trigger a full run (#5).
+    repo = TmpRepo()
+    try:
+        repo.delete("deepspeed/orphan.py")
+        repo.commit("remove orphan")
+        sel = repo.selector().select("master")
+        assert sel.mode == "none", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_dangling_delete_runs_all() -> None:
+    # Deleting a module that a surviving file still imports IS unsafe -> full run (#5).
+    repo = TmpRepo()
+    try:
+        repo.delete("deepspeed/shared.py")  # test_shared / test_shared2 still import it
+        repo.commit("remove shared but leave importers")
+        sel = repo.selector().select("master")
+        assert sel.mode == "all", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def test_dynamic_edge_pulls_in_moe_tests() -> None:
+    # module_inject is wired in at runtime; test_moe never imports it (#4).
+    repo = TmpRepo()
+    try:
+        repo.write("deepspeed/module_inject/replace.py", "VALUE = 66\n")
+        repo.commit("touch module_inject")
+        sel = repo.selector().select("master")
+        assert sel.mode == "subset", sel.reason
+        assert "tests/unit/v1/moe/test_moe.py" in _rel_names(repo, sel.tests)
+    finally:
+        repo.cleanup()
+
+
+def test_missing_base_runs_all() -> None:
+    repo = TmpRepo()
+    try:
+        sel = repo.selector().select("")
+        assert sel.mode == "all", sel.reason
+        sel = repo.selector().select("origin/does-not-exist")
+        assert sel.mode == "all", sel.reason
+    finally:
+        repo.cleanup()
+
+
+def _all_test_functions():
+    return sorted((name, obj) for name, obj in globals().items() if name.startswith("test_") and callable(obj))
+
+
+def main() -> int:
+    failures = 0
+    for name, fn in _all_test_functions():
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {name}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failures += 1
+            print(f"ERROR {name}: {type(e).__name__}: {e}")
+    total = len(_all_test_functions())
+    print(f"\n{total - failures}/{total} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests_fetcher.py
+++ b/ci/tests_fetcher.py
@@ -1,0 +1,726 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Diff-based test selector for DeepSpeed CI.
+
+A small, self-contained take on HuggingFace transformers' ``utils/tests_fetcher.py``.
+
+Given a git diff against a base ref, it figures out the *minimal* set of test
+files (under a workflow's test scope, e.g. ``tests/unit/v1``) that could be
+affected, so CI doesn't have to run the whole suite on every PR:
+
+  1. Collect the Python files changed in the diff.
+  2. Build an import-dependency graph over the ``deepspeed`` package and the test
+     helpers (the ``unit`` package under ``tests/unit``). Module A "impacts"
+     module B when B imports A, directly or transitively.
+  3. Walk that graph backwards from the changed files to every impacted test in
+     the workflow's scope.
+  4. Write the impacted test paths to an output file (one per line), which the CI
+     runner (``ci/torch_latest.py``) feeds to ``pytest``.
+
+Design principles
+-----------------
+* **Fail safe, never fail closed silently.** A missing base ref, no merge-base
+  (shallow clone), a touched shared fixture / build / CI file, a dangling deleted
+  module, a ``[test all]`` commit tag, or *any unexpected error in the selector*
+  all fall back to running the entire scope. The one thing the selector will
+  never do on error is select *fewer* tests than reality.
+* **Config-driven.** One ``WorkflowConfig`` per CI workflow (see ``WORKFLOWS``),
+  so the same engine can drive several workflows with different scopes / extra
+  run-all triggers via ``--workflow``.
+* **Testable.** All repo/config state lives on ``TestSelector`` (constructed with
+  an arbitrary ``repo_root``), so the logic can be unit-tested against synthetic
+  repos -- see ``tests/unit/test_tests_fetcher.py``.
+
+Escape hatches (for humans)
+---------------------------
+* Put ``[test all]`` (or ``[no filter]``) anywhere in a commit message to force
+  the full suite for that push.
+* Changing a file matched by the run-all globs (CI config, build system, shared
+  fixtures, core runtime) always runs everything.
+
+Preview what CI would run for your branch::
+
+    python ci/tests_fetcher.py --base origin/master
+    cat ci/.test_selection/test_list.txt
+
+Explain *why* a test was (de)selected (prints the import chains)::
+
+    python ci/tests_fetcher.py --base origin/master --explain
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import subprocess
+import sys
+import traceback
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# --------------------------------------------------------------------------- #
+# Per-workflow configuration (#11: drive multiple workflows from one config).
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class WorkflowConfig:
+    """Knobs that differ between CI workflows.
+
+    name              : identifier, also the ``--workflow`` value.
+    test_scopes       : repo-root-relative dirs whose ``test_*.py`` files this
+                        workflow runs (and the targets used for ``mode=all``).
+    extra_run_all_globs: workflow-specific paths that force a full run (on top of
+                         ``TestSelector.COMMON_RUN_ALL_GLOBS``).
+    """
+
+    name: str
+    test_scopes: tuple[str, ...]
+    extra_run_all_globs: tuple[str, ...] = field(default_factory=tuple)
+
+
+WORKFLOWS: dict[str, WorkflowConfig] = {
+    "modal-torch-latest":
+    WorkflowConfig(
+        name="modal-torch-latest",
+        test_scopes=("tests/unit/v1", ),
+        extra_run_all_globs=(".github/workflows/modal*.yml", ),
+    ),
+}
+
+DEFAULT_WORKFLOW = "modal-torch-latest"
+
+
+@dataclass
+class Selection:
+    """Outcome of a selection run.
+
+    mode  : "all" | "subset" | "none".
+    tests : selected test files (only meaningful for "subset").
+    reason: human-readable explanation, surfaced in logs and the job summary.
+    """
+
+    mode: str
+    tests: list[Path]
+    reason: str
+
+
+class TestSelector:
+    """Diff-driven test selection engine for one repo + one workflow."""
+
+    # Importable roots that participate in the graph, as (base_subdir, top_package)
+    # *relative to the repo root*:
+    #   - ``deepspeed`` lives at the repo root (base_subdir = "").
+    #   - tests import shared helpers as the ``unit`` package rooted at ``tests/``
+    #     (e.g. ``from unit.common import DistributedTest``).
+    PACKAGE_ROOTS = (("", "deepspeed"), ("tests", "unit"))
+
+    # "Opaque" package roots whose ``__init__.py`` imports are NOT expanded in the
+    # graph. Almost every test imports ``unit.common``, which does ``import
+    # deepspeed``, ``import deepspeed.comm`` and ``from deepspeed.accelerator import
+    # get_accelerator``. Each of those ``__init__`` files eagerly imports a large
+    # subtree, so treating them as normal nodes makes nearly any ``deepspeed/**``
+    # change fan out to the entire suite. Treating them as opaque links a test only
+    # to the ``__init__.py`` itself (not its whole subtree); submodule changes are
+    # traced to the tests that import *that* submodule. Changes to the hubs
+    # themselves are covered by the run-all globs below.
+    OPAQUE_MODULES = ("deepspeed", "deepspeed.comm", "deepspeed.accelerator")
+
+    # Commit-message tags that force the whole suite.
+    RUN_ALL_COMMIT_TAGS = ("[test all]", "[no filter]")
+
+    # Changing any of these means "we can't safely narrow the suite" -> run
+    # everything. (Shell globs, matched against repo-root-relative POSIX paths.)
+    COMMON_RUN_ALL_GLOBS = (
+        "ci/**",  # the CI runner / this fetcher
+        "csrc/**",  # C/CUDA kernel sources (compiled ops)
+        "op_builder/**",  # op build system
+        "accelerator/**",  # accelerator abstraction
+        "requirements/**",  # dependency pins
+        "setup.py",
+        "tests/conftest.py",  # auto-loaded by every test
+        "tests/pytest.ini",  # global pytest config (markers, addopts)
+        "tests/unit/common.py",  # the distributed-test base used across the suite
+        "tests/unit/util.py",
+        # Core orchestration on the deepspeed.initialize() critical path. Tests
+        # exercise these at *runtime* (via deepspeed.initialize) without importing
+        # them directly, so the import graph can't see the dependency once
+        # deepspeed/__init__ is opaque (see OPAQUE_MODULES). Changing them runs the
+        # whole suite.
+        "deepspeed/__init__.py",
+        "deepspeed/runtime/engine.py",
+        "deepspeed/runtime/hybrid_engine.py",
+        "deepspeed/runtime/config.py",
+        "deepspeed/runtime/config_utils.py",
+        "deepspeed/comm/**",  # collectives used by every distributed test
+        "deepspeed/accelerator/**",  # accelerator abstraction used by every test
+    )
+
+    # Dynamic dependency edges the *static* import graph can't see (#4).
+    #
+    # Some code is wired up at runtime -- monkey-patching, registry/plugin lookup,
+    # JIT-loaded ops, replace_module() injection at deepspeed.initialize() time --
+    # so a test can depend on a module it never ``import``s. This curated map fills
+    # those gaps: it maps a *changed-file* glob to extra *test-path* globs that must
+    # be pulled in whenever a matching file changes. Keep entries conservative and
+    # reviewed; over-broad entries just cost CO2, under-broad ones miss coverage.
+    #
+    # NOTE: this is additive on top of the static graph; a file that is also a
+    # run-all trigger short-circuits to the full suite before this map is consulted.
+    DYNAMIC_EDGES: dict[str, tuple[str, ...]] = {
+        # module_inject is applied at deepspeed.initialize() time (replace_module /
+        # replace_transformer_layer); the tests it affects don't import it directly.
+        "deepspeed/module_inject/**": ("tests/unit/v1/moe/**", ),
+    }
+
+    def __init__(self, repo_root: Path | str, config: WorkflowConfig):
+        self.repo_root = Path(repo_root).resolve()
+        self.config = config
+        self.run_all_globs = self.COMMON_RUN_ALL_GLOBS + tuple(config.extra_run_all_globs)
+        # repo-root-relative ``pkg`` prefixes, e.g. ("deepspeed", "tests/unit").
+        self._source_prefixes = tuple((f"{base}/{pkg}" if base else pkg) for base, pkg in self.PACKAGE_ROOTS)
+
+    # ----------------------------------------------------------------- git --- #
+    def _run_git(self, args: list[str]) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    def _rev_exists(self, ref: str) -> bool:
+        try:
+            self._run_git(["rev-parse", "--verify", f"{ref}^{{commit}}"])
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    def _merge_base(self, base: str) -> str:
+        """Merge-base of ``base`` and ``HEAD``, or "" if it can't be determined.
+
+        An empty result (e.g. shallow clone that doesn't reach the fork point)
+        must be treated as "can't trust a narrow diff" by the caller -> run all.
+        """
+        try:
+            return self._run_git(["merge-base", base, "HEAD"]).strip()
+        except subprocess.CalledProcessError:
+            return ""
+
+    def _diff_files(self, base_rev: str) -> tuple[list[str], list[str]]:
+        """Return (changed, deleted) repo-root-relative paths for ``base_rev..HEAD``.
+
+        'changed' = added / modified / renamed-new; 'deleted' = deleted / renamed-old.
+        ``base_rev`` should be the merge-base commit so two-dot == three-dot.
+        """
+        out = self._run_git(["diff", "--name-status", "--find-renames", f"{base_rev}", "HEAD"])
+        changed: list[str] = []
+        deleted: list[str] = []
+        for line in out.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            status = parts[0]
+            if status.startswith("R") and len(parts) >= 3:
+                deleted.append(parts[1])
+                changed.append(parts[2])
+            elif status.startswith("D"):
+                deleted.append(parts[1])
+            elif len(parts) >= 2:
+                changed.append(parts[1])
+        return changed, deleted
+
+    def _commit_messages(self, base_rev: str) -> str:
+        try:
+            return self._run_git(["log", "--format=%B", f"{base_rev}..HEAD"])
+        except subprocess.CalledProcessError:
+            return ""
+
+    # ------------------------------------------------- file / module maps --- #
+    def _is_test_file(self, path: Path) -> bool:
+        try:
+            rel = path.relative_to(self.repo_root).as_posix()
+        except ValueError:
+            return False
+        if not (path.name.startswith("test_") and path.suffix == ".py"):
+            return False
+        return any(rel.startswith(scope + "/") for scope in self.config.test_scopes)
+
+    def _all_test_files(self) -> list[Path]:
+        files: set[Path] = set()
+        for scope in self.config.test_scopes:
+            for p in (self.repo_root / scope).rglob("test_*.py"):
+                if self._is_test_file(p):
+                    files.add(p)
+        return sorted(files)
+
+    def _all_source_files(self) -> list[Path]:
+        files: list[Path] = []
+        seen: set[Path] = set()
+        for base, pkg in self.PACKAGE_ROOTS:
+            for p in (self.repo_root / base / pkg).rglob("*.py"):
+                # Ignore build artifacts (e.g. build/lib/deepspeed/...).
+                if p.relative_to(self.repo_root).parts[:1] == ("build", ):
+                    continue
+                if p not in seen:
+                    seen.add(p)
+                    files.append(p)
+        return sorted(files)
+
+    def _module_name(self, path: Path) -> str | None:
+        """Dotted module name for a file under a package root, or None.
+
+        e.g. deepspeed/runtime/engine.py -> deepspeed.runtime.engine
+             tests/unit/common.py        -> unit.common
+        """
+        for base, pkg in self.PACKAGE_ROOTS:
+            base_dir = self.repo_root / base
+            pkg_dir = base_dir / pkg
+            if path == pkg_dir or pkg_dir in path.parents:
+                parts = list(path.relative_to(base_dir).with_suffix("").parts)
+                if parts and parts[-1] == "__init__":
+                    parts = parts[:-1]
+                return ".".join(parts)
+        return None
+
+    def _rel_to_module(self, rel_posix: str) -> str | None:
+        """Dotted module name from a repo-root-relative path string (for deleted files)."""
+        if not rel_posix.endswith(".py"):
+            return None
+        for base, pkg in self.PACKAGE_ROOTS:
+            prefix = f"{base}/{pkg}" if base else pkg
+            if rel_posix == f"{prefix}.py" or rel_posix.startswith(prefix + "/"):
+                sub = rel_posix[len(base) + 1:] if base else rel_posix
+                parts = sub[:-3].split("/")
+                if parts and parts[-1] == "__init__":
+                    parts = parts[:-1]
+                return ".".join(parts)
+        return None
+
+    def _under_sources(self, rel_posix: str) -> bool:
+        return rel_posix.endswith(".py") and any(rel_posix == f"{p}.py" or rel_posix.startswith(p + "/")
+                                                 for p in self._source_prefixes)
+
+    # ------------------------------------------------------ import parsing --- #
+    def _build_indexes(self, files: list[Path]) -> tuple[dict[str, Path], dict[Path, dict[str, Path]]]:
+        module_index: dict[str, Path] = {}
+        dir_local: dict[Path, dict[str, Path]] = {}
+        for f in files:
+            mod = self._module_name(f)
+            if mod:
+                module_index[mod] = f
+            dir_local.setdefault(f.parent, {})[f.stem] = f
+        return module_index, dir_local
+
+    @staticmethod
+    def _resolve_candidate(name: str, module_index: dict[str, Path]) -> Path | None:
+        parts = name.split(".")
+        while parts:
+            hit = module_index.get(".".join(parts))
+            if hit is not None:
+                return hit
+            parts = parts[:-1]
+        return None
+
+    def _file_imports(
+        self,
+        path: Path,
+        module_index: dict[str, Path],
+        dir_local: dict[Path, dict[str, Path]],
+    ) -> tuple[set[Path], set[str]]:
+        """Parse ``path`` once and return (intra-repo dep files, raw dotted import names).
+
+        - dep files: package modules + sibling helpers it imports (graph edges).
+        - raw dotted names: every dotted module name referenced, resolved or not.
+          Used to detect dangling imports of deleted modules (#5).
+        """
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, UnicodeDecodeError, OSError) as e:
+            print(f"WARNING: could not parse {path}: {e}", file=sys.stderr)
+            return set(), set()
+
+        self_mod = self._module_name(path)
+        is_init = path.name == "__init__.py"
+        deps: set[Path] = set()
+        raw: set[str] = set()
+        siblings = dir_local.get(path.parent, {})
+
+        # Don't expand a universal-hub package root (see OPAQUE_MODULES). We still
+        # record raw names so dangling-delete detection keeps working.
+        opaque = self_mod in self.OPAQUE_MODULES
+
+        def add_dotted(name: str) -> None:
+            if not name:
+                return
+            raw.add(name)
+            if opaque:
+                return
+            hit = self._resolve_candidate(name, module_index)
+            if hit is not None:
+                deps.add(hit)
+
+        def add_bare(top: str) -> None:
+            if opaque:
+                return
+            hit = siblings.get(top)
+            if hit is not None and hit != path:
+                deps.add(hit)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    add_dotted(alias.name)
+                    add_bare(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.level == 0:
+                    module = node.module or ""
+                    if module:
+                        add_dotted(module)
+                        add_bare(module.split(".")[0])
+                        for alias in node.names:
+                            add_dotted(f"{module}.{alias.name}")
+                    else:
+                        for alias in node.names:
+                            add_bare(alias.name)
+                elif self_mod is not None:
+                    pkg_parts = self_mod.split(".") if is_init else self_mod.split(".")[:-1]
+                    base_parts = pkg_parts[:len(pkg_parts) - (node.level - 1)]
+                    base = ".".join(base_parts + ([node.module] if node.module else []))
+                    if base:
+                        add_dotted(base)
+                        for alias in node.names:
+                            add_dotted(f"{base}.{alias.name}")
+        return deps, raw
+
+    def _parse_all(
+        self,
+        files: list[Path],
+        module_index: dict[str, Path],
+        dir_local: dict[Path, dict[str, Path]],
+    ) -> tuple[dict[Path, set[Path]], dict[Path, set[str]]]:
+        """Parse every file once; return (deps_by_file, raw_imports_by_file)."""
+        deps_by_file: dict[Path, set[Path]] = {}
+        raw_by_file: dict[Path, set[str]] = {}
+        for f in files:
+            deps, raw = self._file_imports(f, module_index, dir_local)
+            deps_by_file[f] = deps
+            raw_by_file[f] = raw
+        return deps_by_file, raw_by_file
+
+    @staticmethod
+    def _reverse_graph(deps_by_file: dict[Path, set[Path]]) -> dict[Path, set[Path]]:
+        """Map each file -> the set of files that import it (directly)."""
+        reverse: dict[Path, set[Path]] = {f: set() for f in deps_by_file}
+        for f, deps in deps_by_file.items():
+            for dep in deps:
+                reverse.setdefault(dep, set()).add(f)
+        return reverse
+
+    @staticmethod
+    def _impacted_files(seeds: set[Path], reverse: dict[Path, set[Path]]) -> set[Path]:
+        seen: set[Path] = set()
+        stack = list(seeds)
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            stack.extend(reverse.get(cur, ()))
+        return seen
+
+    @staticmethod
+    def _reachable_with_parents(seed: Path, reverse: dict[Path, set[Path]]) -> dict[Path, Path | None]:
+        """BFS from ``seed`` recording a predecessor for each node (for --explain)."""
+        parent: dict[Path, Path | None] = {seed: None}
+        stack = [seed]
+        while stack:
+            cur = stack.pop()
+            for imp in reverse.get(cur, ()):
+                if imp not in parent:
+                    parent[imp] = cur
+                    stack.append(imp)
+        return parent
+
+    def _matches_glob(self, rel_posix: str, globs: tuple[str, ...]) -> bool:
+        for g in globs:
+            if fnmatch(rel_posix, g):
+                return True
+            # Support ``dir/**`` matching ``dir/anything/deep``.
+            if g.endswith("/**") and (rel_posix == g[:-3] or rel_posix.startswith(g[:-2])):
+                return True
+        return False
+
+    def _dynamic_edge_tests(self, changed: list[str], all_tests: list[Path]) -> set[Path]:
+        """Extra tests pulled in by the curated dynamic-edge map (#4)."""
+        wanted_globs: set[str] = set()
+        for rel in changed:
+            for src_glob, test_globs in self.DYNAMIC_EDGES.items():
+                if self._matches_glob(rel, (src_glob, )):
+                    wanted_globs.update(test_globs)
+        if not wanted_globs:
+            return set()
+        globs = tuple(wanted_globs)
+        hits: set[Path] = set()
+        for t in all_tests:
+            rel = t.relative_to(self.repo_root).as_posix()
+            if self._matches_glob(rel, globs):
+                hits.add(t)
+        return hits
+
+    # ----------------------------------------------------------- selection --- #
+    def select(self, base: str | None, commit_message: str = "") -> Selection:
+        all_tests = self._all_test_files()
+
+        if not base:
+            return Selection("all", all_tests, "no base ref (push/manual) -> full suite")
+
+        if not self._rev_exists(base):
+            return Selection("all", all_tests, f"base ref {base!r} not resolvable -> full suite")
+
+        merge_base = self._merge_base(base)
+        if not merge_base:
+            # Shallow clone that doesn't reach the fork point, or unrelated history:
+            # a diff here would be wrong, so don't risk a narrow (false-negative) run.
+            return Selection("all", all_tests, f"no merge-base with {base!r} (shallow clone?) -> full suite")
+
+        messages = commit_message + "\n" + self._commit_messages(merge_base)
+        for tag in self.RUN_ALL_COMMIT_TAGS:
+            if tag in messages:
+                return Selection("all", all_tests, f"commit message contains {tag!r} -> full suite")
+
+        changed, deleted = self._diff_files(merge_base)
+
+        triggers = [p for p in changed if self._matches_glob(p, self.run_all_globs)]
+        if triggers:
+            shown = ", ".join(triggers[:5]) + (" ..." if len(triggers) > 5 else "")
+            return Selection("all", all_tests, f"changed shared/infra file(s) [{shown}] -> full suite")
+
+        # --- import-graph narrowing ------------------------------------------ #
+        source_files = self._all_source_files()
+        module_index, dir_local = self._build_indexes(source_files)
+        deps_by_file, raw_by_file = self._parse_all(source_files, module_index, dir_local)
+        reverse = self._reverse_graph(deps_by_file)
+
+        # #5: a deleted .py only forces a full run if a *surviving* file still
+        # imports it (a dangling import the graph can't follow). A clean deletion --
+        # where the PR also removed/updated every importer -- is covered by those
+        # importer edits (which are in ``changed`` and seeded below), so we don't
+        # blanket-run on it any more.
+        deleted_modules = {
+            m
+            for p in deleted if (m := self._rel_to_module(p)) and not self._is_test_file(self.repo_root / p)
+        }
+        if deleted_modules:
+            dangling = self._dangling_importers(deleted_modules, raw_by_file)
+            if dangling:
+                shown = ", ".join(sorted(deleted_modules)[:5])
+                return Selection(
+                    "all",
+                    all_tests,
+                    f"deleted module(s) [{shown}] still imported by surviving file(s) -> full suite",
+                )
+
+        selected: set[Path] = set()
+        for rel in changed:
+            if not self._under_sources(rel):
+                continue  # non-Python / out-of-scope change with no direct test impact
+            path = (self.repo_root / rel).resolve()
+            if path.name == "conftest.py":
+                # A directory-scoped conftest affects every test under that directory.
+                for t in all_tests:
+                    if str(t).startswith(str(path.parent) + os.sep):
+                        selected.add(t)
+                continue
+            impacted = self._impacted_files({path}, reverse)
+            selected.update(f for f in impacted if self._is_test_file(f))
+            if self._is_test_file(path):
+                selected.add(path)  # a brand-new test file has no importers yet
+
+        # #4: add dynamic-edge tests the static graph can't see.
+        selected |= self._dynamic_edge_tests(changed, all_tests)
+
+        if not selected:
+            scope = ", ".join(self.config.test_scopes)
+            return Selection("none", [], f"no {scope} tests impacted by this diff")
+        if selected >= set(all_tests):
+            return Selection("all", sorted(selected), "diff impacts the whole suite -> full suite")
+        return Selection("subset", sorted(selected), f"{len(selected)} test file(s) impacted by the diff")
+
+    @staticmethod
+    def _dangling_importers(deleted_modules: set[str], raw_by_file: dict[Path, set[str]]) -> set[Path]:
+        """Surviving files whose imports still reference a deleted module."""
+        dangling: set[Path] = set()
+        for f, raw in raw_by_file.items():
+            for name in raw:
+                if name in deleted_modules or any(name.startswith(m + ".") for m in deleted_modules):
+                    dangling.add(f)
+                    break
+        return dangling
+
+    # ------------------------------------------------------------- explain --- #
+    def explain(self, base: str | None) -> str:
+        """Human-readable trace of why each test was selected (#7)."""
+        sel = self.select(base)
+        lines = [f"# Test selection for workflow {self.config.name!r}", f"# decision: {sel.mode} -- {sel.reason}", ""]
+        if sel.mode != "subset":
+            scope = ", ".join(self.config.test_scopes)
+            lines.append(
+                f"(mode={sel.mode}: running {'the full ' + scope + ' suite' if sel.mode == 'all' else 'no tests'})")
+            return "\n".join(lines)
+
+        merge_base = self._merge_base(base) if base else ""
+        changed, _ = self._diff_files(merge_base) if merge_base else ([], [])
+        changed_src = [self.repo_root / r for r in changed if self._under_sources(r)]
+
+        source_files = self._all_source_files()
+        module_index, dir_local = self._build_indexes(source_files)
+        deps_by_file, _ = self._parse_all(source_files, module_index, dir_local)
+        reverse = self._reverse_graph(deps_by_file)
+
+        selected = set(sel.tests)
+        for seed in sorted(changed_src):
+            parent = self._reachable_with_parents(seed, reverse)
+            seed_tests = sorted(t for t in selected if t in parent)
+            rel_seed = seed.relative_to(self.repo_root).as_posix()
+            if not seed_tests:
+                lines.append(f"{rel_seed}: (no impacted tests in scope)")
+                continue
+            lines.append(f"{rel_seed} impacts:")
+            for t in seed_tests:
+                chain = []
+                node: Path | None = t
+                while node is not None:
+                    chain.append(node.relative_to(self.repo_root).as_posix())
+                    node = parent.get(node)
+                lines.append("    " + " <- ".join(chain))
+            lines.append("")
+        return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# CLI / CI glue.
+# --------------------------------------------------------------------------- #
+def _emit_github_output(mode: str, num_tests: int, reason: str) -> None:
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if not gh_out:
+        return
+    with open(gh_out, "a", encoding="utf-8") as fh:
+        fh.write(f"mode={mode}\n")
+        fh.write(f"num_tests={num_tests}\n")
+        fh.write(f"reason={reason}\n")
+
+
+def _write_step_summary(config: WorkflowConfig, sel: Selection, targets: list[str]) -> None:
+    """Emit a GitHub job summary explaining the decision (#6)."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    # chr(96) is a backtick; kept out of f-string literals so flake8's W604
+    # (Python-2 backtick) check -- which doesn't mute f-string contents -- won't fire.
+    bt = chr(96)
+
+    def code(text: object) -> str:
+        return f"{bt}{text}{bt}"
+
+    lines = [
+        f"### Test selection: {code(config.name)}",
+        "",
+        f"- **decision:** {code(sel.mode)}",
+        f"- **reason:** {sel.reason}",
+        f"- **pytest targets:** {len(targets)}",
+        "",
+    ]
+    if sel.mode == "subset":
+        lines.append("<details><summary>selected test files</summary>")
+        lines.append("")
+        for t in targets[:200]:
+            lines.append(f"- {code(t)}")
+        if len(targets) > 200:
+            lines.append(f"- ... and {len(targets) - 200} more")
+        lines.append("")
+        lines.append("</details>")
+    try:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+    except OSError as e:
+        print(f"WARNING: could not write job summary: {e}", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--workflow",
+        default=DEFAULT_WORKFLOW,
+        choices=sorted(WORKFLOWS),
+        help="Which CI workflow's scope/config to select for. Default: %(default)s.",
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/master",
+        help="Git ref to diff against (merge-base is used). Empty string -> run all tests. "
+        "Default: origin/master.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default="ci/.test_selection/test_list.txt",
+        help="Where to write the test targets to run (one per line). "
+        "mode=all writes the scope dir(s); mode=subset writes individual files; mode=none writes nothing.",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="",
+        help="Commit message to scan for [test all] / [no filter] override tags.",
+    )
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="Print the import chains from changed files to selected tests, then exit.",
+    )
+    args = parser.parse_args()
+
+    config = WORKFLOWS[args.workflow]
+    selector = TestSelector(REPO_ROOT, config)
+
+    if args.explain:
+        try:
+            print(selector.explain(args.base))
+        except Exception:  # noqa: BLE001 -- explain is a diagnostic, never fail CI on it
+            traceback.print_exc()
+        return
+
+    # #3: any unexpected failure in the selector degrades to running EVERYTHING,
+    # never to running nothing. A bug here must not silently skip tests.
+    try:
+        sel = selector.select(args.base, args.commit_message)
+    except Exception:  # noqa: BLE001
+        traceback.print_exc()
+        sel = Selection("all", selector._all_test_files(),
+                        "selector raised an unexpected error -> full suite (fail-safe)")
+
+    if sel.mode == "all":
+        targets = list(config.test_scopes)
+    else:
+        targets = [p.relative_to(REPO_ROOT).as_posix() for p in sel.tests]
+
+    out_path = (REPO_ROOT / args.output_file).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(targets) + ("\n" if targets else ""), encoding="utf-8")
+
+    print(f"\n### MODE: {sel.mode} ({sel.reason}) ###")
+    print(f"### {len(targets)} pytest target(s) -> {out_path.relative_to(REPO_ROOT)} ###")
+    for t in targets:
+        print(f"  {t}")
+
+    _emit_github_output(sel.mode, len(sel.tests), sel.reason)
+    _write_step_summary(config, sel, targets)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/tests_fetcher.py
+++ b/ci/tests_fetcher.py
@@ -31,7 +31,7 @@ Design principles
   run-all triggers via ``--workflow``.
 * **Testable.** All repo/config state lives on ``TestSelector`` (constructed with
   an arbitrary ``repo_root``), so the logic can be unit-tested against synthetic
-  repos -- see ``tests/unit/test_tests_fetcher.py``.
+  repos -- see ``ci/test_tests_fetcher.py``.
 
 Escape hatches (for humans)
 ---------------------------
@@ -58,6 +58,7 @@ import os
 import subprocess
 import sys
 import traceback
+from collections import deque
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
@@ -216,8 +217,9 @@ class TestSelector:
     def _diff_files(self, base_rev: str) -> tuple[list[str], list[str]]:
         """Return (changed, deleted) repo-root-relative paths for ``base_rev..HEAD``.
 
-        'changed' = added / modified / renamed-new; 'deleted' = deleted / renamed-old.
-        ``base_rev`` should be the merge-base commit so two-dot == three-dot.
+        'changed' = added / modified / renamed-new / copied-new; 'deleted' =
+        deleted / renamed-old. ``base_rev`` should be the merge-base commit so
+        two-dot == three-dot.
         """
         out = self._run_git(["diff", "--name-status", "--find-renames", f"{base_rev}", "HEAD"])
         changed: list[str] = []
@@ -228,7 +230,12 @@ class TestSelector:
             parts = line.split("\t")
             status = parts[0]
             if status.startswith("R") and len(parts) >= 3:
+                # rename: old path goes away, new path is what changed.
                 deleted.append(parts[1])
+                changed.append(parts[2])
+            elif status.startswith("C") and len(parts) >= 3:
+                # copy: source is untouched (do NOT mark it deleted); the new
+                # destination path is the one that's effectively "changed".
                 changed.append(parts[2])
             elif status.startswith("D"):
                 deleted.append(parts[1])
@@ -437,15 +444,19 @@ class TestSelector:
 
     @staticmethod
     def _reachable_with_parents(seed: Path, reverse: dict[Path, set[Path]]) -> dict[Path, Path | None]:
-        """BFS from ``seed`` recording a predecessor for each node (for --explain)."""
+        """BFS from ``seed`` recording a predecessor for each node (for --explain).
+
+        Uses a FIFO queue so each node's recorded parent is on a *shortest* path,
+        giving the most concise import chain in ``--explain`` output.
+        """
         parent: dict[Path, Path | None] = {seed: None}
-        stack = [seed]
-        while stack:
-            cur = stack.pop()
-            for imp in reverse.get(cur, ()):
+        queue: deque[Path] = deque([seed])
+        while queue:
+            cur = queue.popleft()
+            for imp in sorted(reverse.get(cur, ()), key=str):
                 if imp not in parent:
                     parent[imp] = cur
-                    stack.append(imp)
+                    queue.append(imp)
         return parent
 
     def _matches_glob(self, rel_posix: str, globs: tuple[str, ...]) -> bool:

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -120,6 +120,35 @@ MODAL_TORCH_IMAGE = MODAL_TORCH_CONFIG["image"]
 MODAL_TORCH_TEST_VERSION = MODAL_TORCH_CONFIG["torch_test_version"]
 MODAL_CUDA_TEST_VERSION = MODAL_TORCH_CONFIG["cuda_test_version"]
 
+# Full test sub-tree this workflow runs by default.
+DEFAULT_TEST_TARGET = "tests/unit/v1/"
+
+
+def resolve_selected_tests():
+    """pytest targets selected by the diff-driven fetcher (ci/tests_fetcher.py).
+
+    The fetcher writes one target per line (individual test files for a narrowed
+    run, or just ``tests/unit/v1`` for a full run). The ``collect-tests`` CI job
+    produces this file and the ``deploy`` job downloads it into place before
+    ``modal run``. We read it here on the runner (at image-build time) and bake the
+    targets into the image env so the remote ``pytest`` picks them up.
+
+    Falls back to the whole v1 suite when the file is missing or empty (local runs,
+    or selection skipped), so behavior is unchanged unless a selection is provided.
+    """
+    env_path = os.environ.get("DS_TEST_LIST_FILE", "")
+    list_file = Path(env_path) if env_path else ROOT_PATH / "ci" / ".test_selection" / "test_list.txt"
+    if not list_file.is_absolute():
+        list_file = ROOT_PATH / list_file
+    try:
+        targets = [line.strip() for line in list_file.read_text().splitlines() if line.strip()]
+    except OSError:
+        targets = []
+    return targets or [DEFAULT_TEST_TARGET]
+
+
+SELECTED_TESTS = resolve_selected_tests()
+
 # yapf: disable
 image = (modal.Image
          .from_registry(MODAL_TORCH_IMAGE, add_python="3.10")
@@ -127,6 +156,7 @@ image = (modal.Image
              "MODAL_TORCH_PRESET": MODAL_TORCH_CONFIG["preset"],
              "MODAL_TRANSFORMERS_SOURCE": MODAL_TRANSFORMERS_CONFIG["source"],
              "MODAL_TRANSFORMERS_REF": MODAL_TRANSFORMERS_CONFIG["ref"],
+             "DS_SELECTED_TESTS": " ".join(SELECTED_TESTS),
          })
          .run_commands("apt update && apt install -y git libaio-dev")
          .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
@@ -173,9 +203,18 @@ def pytest():
         check=True,
         cwd=ROOT_PATH / ".",
     )
+    selected_tests = os.environ.get("DS_SELECTED_TESTS", DEFAULT_TEST_TARGET).split()
+    print(f"Running pytest on diff-selected targets: {selected_tests}")
     subprocess.run(
-        f"pytest -n 4 --verbose tests/unit/v1/ --torch_ver={MODAL_TORCH_TEST_VERSION} "
-        f"--cuda_ver={MODAL_CUDA_TEST_VERSION}".split(),
+        [
+            "pytest",
+            "-n",
+            "4",
+            "--verbose",
+            *selected_tests,
+            f"--torch_ver={MODAL_TORCH_TEST_VERSION}",
+            f"--cuda_ver={MODAL_CUDA_TEST_VERSION}",
+        ],
         check=True,
         cwd=ROOT_PATH / ".",
     )


### PR DESCRIPTION
TLDR: Analyze PR's diff and filter out tests that aren't exercising what has changed, potentially cutting down runtime and expense by 95-99% most of the time.

Detailed:

Deepspeed's CI takes forever - most of the time burning $$ and wastes dev time for no reason as most changes require just a few tests to run.

HF Transformers has a system to select which tests to run based on the diff of the PR - Sylvain Gugger wrote it many years ago since that repo has now probably thousands of tests. Deepspeed's CI isn't too bad but can easily take hours.

So I asked Claude Opus 4.8 to replicate the system for Deepspeed. Please have a look. It looks super complicated, so I'm not sure how easy it'd be to maintain/operate unless we always use AI to continue maintaining it. I asked Claude to leave a detailed state file so that it or another model could pick it up where it left.

I started with just the slowest costliest workload `.github/workflows/modal-torch-latest.yml` to see if it works well. If you're happy we can replicate it to the rest of the workloads.


CC: @loadams, @tjruwase - please tag others if you think they would be helpful to discuss this.
 