### PR TITLE
fix: use local ev_values and wrap dict.values() in list()

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -3099,11 +3099,11 @@ class DeepSpeedEngine(Module):
 
                     if (self.eigenvalue_enabled()
                             and not self.gas_boundary_ctr % self.eigenvalue_gas_boundary_resolution()):
-                        ev_values = self.block_eigenvalue.values()
+                        ev_values = list(self.block_eigenvalue.values())
                         for i in range(len(ev_values)):
                             self.summary_events.append((
                                 f"Train/Eigenvalues/ModelBlockParam_{i}",
-                                self.ev_values[i][0],
+                                ev_values[i][0],
                                 self.global_samples,
                             ))
                     self.monitor.write_events(self.summary_events)


### PR DESCRIPTION
## Summary
- `self.ev_values[i][0]` on line 3106 references a nonexistent instance attribute, causing `AttributeError` at runtime when eigenvalue monitoring fires. The local variable `ev_values` (defined on line 3102) is the intended target.
- `dict.values()` returns a `dict_values` view in Python 3 which is not subscriptable. Wrapping in `list()` makes it indexable.

## Test plan
- [x] Verified `self.ev_values` has no definition or assignment anywhere in `engine.py`
- [x] Confirmed `ev_values` (local) is the correct variable from line 3102
- [x] Confirmed `list()` wrapping is needed for Python 3 `dict_values` subscriptability

Fixes #7983