### PR TITLE
fix: AutoTP partition_config uses full hierarchical module path

### DIFF
--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -571,7 +571,7 @@ class AutoTP():
             # When using partition_config (custom patterns/presets), use pattern-based routing
             # instead of linear_policies. This keeps all pattern logic centralized here.
             if self.partition_config is not None:
-                full_name = prev_name + '.' + name if prev_name else name
+                full_name = class_name + '.' + name if class_name else name
                 if isinstance(child, nn.Embedding):
                     # Check if embedding matches any pattern
                     param_name = full_name + ".weight"
@@ -588,7 +588,7 @@ class AutoTP():
                         setattr(r_module, name, new_child)
                 else:
                     self.update_mp_params(child)
-                    self._replace_module(child, full_name, class_name)
+                    self._replace_module(child, name, class_name)
             # Traditional path: use linear_policies for type-based routing
             elif child.__class__ in self.linear_policies:
                 setattr(r_module, name, self.linear_policies[child.__class__](child, prev_name + '.' + name,

--- a/tests/unit/module_inject/test_tp_partition_config_path.py
+++ b/tests/unit/module_inject/test_tp_partition_config_path.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+"""Test that partition_config receives correct full hierarchical module paths.
+
+The bug: AutoTP._replace_module built ``full_name`` from ``prev_name`` (the
+immediate parent only) instead of ``class_name`` (the accumulated hierarchical
+path).  Patterns like ``model.layers.0.self_attn.q_proj`` never matched
+because the name was just ``0.self_attn.q_proj``.
+"""
+
+import pytest
+import torch.nn as nn
+
+from deepspeed.module_inject.auto_tp import AutoTP, AutoTPConfig, PartitionType, TPLayerSpec
+
+
+class SubAttn(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(32, 32, bias=False)
+        self.k_proj = nn.Linear(32, 32, bias=False)
+        self.v_proj = nn.Linear(32, 32, bias=False)
+        self.o_proj = nn.Linear(32, 32, bias=False)
+
+
+class DecoderLayer(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.self_attn = SubAttn()
+        self.mlp = nn.Sequential(nn.Linear(32, 64), nn.GELU(), nn.Linear(64, 32))
+
+
+class DummyModel(nn.Module):
+
+    def __init__(self, num_layers=2):
+        super().__init__()
+        self.embed = nn.Embedding(100, 32)
+        self.layers = nn.ModuleList([DecoderLayer() for _ in range(num_layers)])
+        self.head = nn.Linear(32, 100, bias=False)
+
+
+def _build_config():
+    """Partition config that matches q_proj and o_proj via regex."""
+    return AutoTPConfig(layer_specs=[
+        TPLayerSpec(patterns=[r".*\.self_attn\.q_proj"], partition_type=PartitionType.COLUMN),
+        TPLayerSpec(patterns=[r".*\.self_attn\.o_proj"], partition_type=PartitionType.ROW),
+    ])
+
+
+def _capture_matched_names(model, config):
+    """Run _replace_module and capture full_name values that match a spec."""
+    matched_names = []
+    original = AutoTP._replace_with_config
+
+    def capture(self, child, full_name):
+        # Only capture if a spec actually matches
+        param_name = full_name + ".weight"
+        model_type = self._get_model_type() if hasattr(self, '_get_model_type') else None
+        spec = config.find_matching_spec(param_name, model_type)
+        if spec is not None:
+            matched_names.append(full_name)
+        return None
+
+    AutoTP._replace_with_config = capture
+    try:
+        autotp = AutoTP(
+            module=model,
+            all_reduce_linears=[],
+            prefix="model",
+            state_dict=None,
+            linear_layer_setting=None,
+            orig_layer_impl=None,
+            partition_config=config,
+        )
+        autotp._replace_module(model)
+    finally:
+        AutoTP._replace_with_config = original
+    return matched_names
+
+
+def test_partition_config_receives_full_path():
+    """Verify that pattern matching sees the full hierarchical path."""
+    model = DummyModel(num_layers=2)
+    config = _build_config()
+    matched_names = _capture_matched_names(model, config)
+
+    for layer_idx in range(2):
+        assert f"layers.{layer_idx}.self_attn.q_proj" in matched_names, \
+            f"Expected 'layers.{layer_idx}.self_attn.q_proj', got: {matched_names}"
+        assert f"layers.{layer_idx}.self_attn.o_proj" in matched_names, \
+            f"Expected 'layers.{layer_idx}.self_attn.o_proj', got: {matched_names}"
+
+
+def test_no_truncated_paths():
+    """Ensure paths are never truncated to just the immediate parent prefix."""
+    model = DummyModel(num_layers=3)
+    config = _build_config()
+    matched_names = _capture_matched_names(model, config)
+
+    for name in matched_names:
+        assert name.startswith("layers."), \
+            f"Path should start with 'layers.', got: {name}"
+        assert ".self_attn." in name, \
+            f"Path should contain '.self_attn.', got: {name}"
+        assert name.count(".") >= 3, \
+            f"Path should have at least 3 dots (layers.N.self_attn.X_proj), got: {name}"
+
+
+def test_nested_depth_correct():
+    """Verify correct count and paths at 3 layers deep."""
+    model = DummyModel(num_layers=3)
+    config = _build_config()
+    matched_names = _capture_matched_names(model, config)
+
+    expected_count = 3 * 2  # 3 layers × (q_proj + o_proj)
+    assert len(matched_names) == expected_count, \
+        f"Expected {expected_count} matches, got {len(matched_names)}: {matched_names}"
+
+    for layer_idx in range(3):
+        assert f"layers.{layer_idx}.self_attn.q_proj" in matched_names
+        assert f"layers.{layer_idx}.self_attn.o_proj" in matched_names
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

When using custom patterns with AutoTP,  built  from the immediate parent only instead of the accumulated hierarchical path.

This meant patterns like  never matched because the name passed was just  (missing  prefix).

**Impact**: Custom  patterns are silently ignored — parameters are not TP-sharded, causing OOM on multi-GPU setups with large models.

## Fix

Two changes in :

1. **Line 574**: Build `full_name` from `class_name` (accumulated hierarchical path) instead of `prev_name` (immediate parent only). This ensures patterns see the complete module path.

2. **Line 591**: Pass `name` instead of `full_name` to the recursive `_replace_module` call, preventing path duplication at deeper nesting levels. Without this, `class_name` would accumulate the full prefix twice (e.g., `model.layers.0.model.layers.0.self_attn`).

## Note

This bug only affects the `partition_config` code path (custom patterns). The default `linear_policies` and HuggingFace `tp_plan` paths are unaffected.