### PR TITLE
Fix DeepCompile profile metadata backfill

### DIFF
--- a/deepspeed/compile/inductor.py
+++ b/deepspeed/compile/inductor.py
@@ -22,6 +22,23 @@ from .graph_param import DSGraphParamManager
 from .partitioner import get_wrapped_partitioner
 
 
+def _get_graphsafe_run_with_rng_state():
+    try:
+        from torch._prims import rng_prims
+    except ImportError:
+        return None
+    return getattr(rng_prims, "graphsafe_run_with_rng_state", None)
+
+
+def _register_graphsafe_rng_state_no_reuse(register_fallback_no_reuse):
+    graphsafe_run_with_rng_state = _get_graphsafe_run_with_rng_state()
+    if graphsafe_run_with_rng_state is None:
+        return False
+
+    register_fallback_no_reuse(graphsafe_run_with_rng_state, never_reuse_output=True)
+    return True
+
+
 def patch_compiler(original_compiler, dc_compiler, z3_partition: bool, graph_id, graph_param_manager, bwd: bool):
 
     def wrapped_compiler(gm, fake_inputs):
@@ -243,6 +260,7 @@ def register_custom_ops():
                                force_free_input=True)
     register_fallback_no_reuse(torch.ops.dc.free_tensors.default, never_reuse_input=True, never_reuse_output=True)
     register_fallback_no_reuse(torch.ops.dc.end_backward.default, never_reuse_input=True, never_reuse_output=False)
+    _register_graphsafe_rng_state_no_reuse(register_fallback_no_reuse)
 
     if not hasattr(Scheduler, "is_dc_patched") or not Scheduler.is_dc_patched:
         Scheduler.is_dc_patched = True

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -12,6 +12,7 @@ from deepspeed.accelerator import get_accelerator
 import deepspeed.comm as dist
 
 from ..profilers.comm_profile import create_predictor
+from ..profilers.graph_profile import is_profile_incomplete
 from ..graph_param import DSGraphParamManager
 
 NAME = "prefetch"
@@ -37,6 +38,11 @@ def get_ds_id(node: Node):
 def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int, bool]], profiling_results,
                       create_inputs_fn, mem_budget: float, param_manager: DSGraphParamManager,
                       bwd: bool) -> GraphModule:
+
+    profile_graph = profiling_results[graph_id].bwd_graph if bwd else profiling_results[graph_id].fwd_graph
+    if is_profile_incomplete(profile_graph):
+        print_rank_0(f"schedule_prefetch graph_id={graph_id} incomplete profiling data; skipping prefetch")
+        return gm
 
     max_mem = get_accelerator().total_memory() * (1 - MARGIN)
     vals_to_bcast = torch.tensor([max_mem], device=torch.device(get_accelerator().current_device()))

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -15,6 +15,7 @@ from deepspeed.utils import log_dist
 
 from ..util import get_deepcompile_handle
 from ..graph_param import DSGraphParamManager
+from ..profilers.graph_profile import is_profile_incomplete
 
 NAME = "selective_gather"
 
@@ -66,6 +67,10 @@ def _compute_persistence_budget(all_graph_mem_records: List[List[Tuple[str, int,
     }
 
 
+def _profile_result_incomplete(prof) -> bool:
+    return is_profile_incomplete(prof.fwd_graph) or is_profile_incomplete(prof.bwd_graph)
+
+
 def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int, bool]], profiling_results,
                      create_inputs_fn, mem_budget: float, param_manager: DSGraphParamManager,
                      bwd: bool) -> GraphModule:
@@ -82,6 +87,14 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
 
     # Run only on the last backward graph
     if last_backward_graph_id is None or graph_id != last_backward_graph_id:
+        return gm
+
+    incomplete_profile_ids = [
+        profile_graph_id for profile_graph_id, prof in profiling_results.items() if _profile_result_incomplete(prof)
+    ]
+    if incomplete_profile_ids:
+        print_rank_0(f"selective_gather incomplete profiling data for graph_ids={incomplete_profile_ids}; "
+                     "skipping persistence update")
         return gm
 
     all_graph_mem_records = []

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -27,6 +27,18 @@ def print_rank_0(message):
     log_dist(message, ranks=[0])
 
 
+def _maybe_update_size_from_profile(ds_id_to_size: Dict[int, int], ds_id: int, tensor_size: int) -> None:
+    if tensor_size is not None and tensor_size > 0:
+        ds_id_to_size[ds_id] = tensor_size
+
+
+def _time_per_byte(ds_id_to_time: Dict[int, float], ds_id_to_size: Dict[int, int], ds_id: int) -> float:
+    size = ds_id_to_size.get(ds_id, 0)
+    if size <= 0:
+        return 0.0
+    return ds_id_to_time[ds_id] / size
+
+
 def _compute_persistence_budget(all_graph_mem_records: List[List[Tuple[str, int, int, int]]], total_mem: int,
                                 mem_margin: float) -> Dict[str, int]:
     usable_mem = int(total_mem * (1 - mem_margin))
@@ -106,7 +118,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
         for n in profile.fwd_graph.nodes:
             if n.target == torch.ops.dc.allgather_param.default:
                 assert "tensor_size" in n.meta
-                ds_id_to_size[n.args[2]] = n.meta["tensor_size"]
+                _maybe_update_size_from_profile(ds_id_to_size, n.args[2], n.meta["tensor_size"])
                 assert "device_time" in n.meta
                 ds_id_to_time[n.args[2]] += n.meta["device_time"]
 
@@ -117,12 +129,12 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
             for n in profile.bwd_graph.nodes:
                 if n.target == torch.ops.dc.allgather_param.default:
                     assert "tensor_size" in n.meta
-                    ds_id_to_size[n.args[2]] = n.meta["tensor_size"]
+                    _maybe_update_size_from_profile(ds_id_to_size, n.args[2], n.meta["tensor_size"])
                     assert "device_time" in n.meta
                     ds_id_to_time[n.args[2]] += n.meta["device_time"]
 
     ds_ids = [ds_id for ds_id in ds_id_to_size if ds_id not in persistent_ds_ids]
-    ds_ids.sort(key=lambda ds_id: ds_id_to_time[ds_id] / ds_id_to_size[ds_id], reverse=True)
+    ds_ids.sort(key=lambda ds_id: _time_per_byte(ds_id_to_time, ds_id_to_size, ds_id), reverse=True)
 
     # print(f"ds_id_to_size={ds_id_to_size}")
     # print(f"ds_id_to_time={ds_id_to_time}")

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -132,7 +132,6 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
             if n.target == torch.ops.dc.allgather_param.default:
                 assert "tensor_size" in n.meta
                 _maybe_update_size_from_profile(ds_id_to_size, n.args[2], n.meta["tensor_size"])
-                # Profiling backfills missing allgather timing with 0.0, so absence here is an invariant failure.
                 assert "device_time" in n.meta
                 ds_id_to_time[n.args[2]] += n.meta["device_time"]
 
@@ -144,7 +143,6 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
                 if n.target == torch.ops.dc.allgather_param.default:
                     assert "tensor_size" in n.meta
                     _maybe_update_size_from_profile(ds_id_to_size, n.args[2], n.meta["tensor_size"])
-                    # Profiling backfills missing allgather timing with 0.0, so absence here is an invariant failure.
                     assert "device_time" in n.meta
                     ds_id_to_time[n.args[2]] += n.meta["device_time"]
 

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -28,7 +28,7 @@ def print_rank_0(message):
 
 
 def _maybe_update_size_from_profile(ds_id_to_size: Dict[int, int], ds_id: int, tensor_size: int) -> None:
-    if tensor_size is not None and tensor_size > 0:
+    if tensor_size > 0:
         ds_id_to_size[ds_id] = tensor_size
 
 

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -119,6 +119,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
             if n.target == torch.ops.dc.allgather_param.default:
                 assert "tensor_size" in n.meta
                 _maybe_update_size_from_profile(ds_id_to_size, n.args[2], n.meta["tensor_size"])
+                # Profiling backfills missing allgather timing with 0.0, so absence here is an invariant failure.
                 assert "device_time" in n.meta
                 ds_id_to_time[n.args[2]] += n.meta["device_time"]
 
@@ -130,6 +131,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
                 if n.target == torch.ops.dc.allgather_param.default:
                     assert "tensor_size" in n.meta
                     _maybe_update_size_from_profile(ds_id_to_size, n.args[2], n.meta["tensor_size"])
+                    # Profiling backfills missing allgather timing with 0.0, so absence here is an invariant failure.
                     assert "device_time" in n.meta
                     ds_id_to_time[n.args[2]] += n.meta["device_time"]
 

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+import logging
 import time
 from typing import Any, Tuple, Dict
 import statistics
@@ -20,6 +21,7 @@ except ImportError:
 
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
+from deepspeed.utils import log_dist
 from ..util import is_comm_op, is_release_node, get_deepcompile_handle
 
 
@@ -125,16 +127,17 @@ class ProfilingInterpreter(Interpreter):
                     return_val = super().run(*args)
         except Exception as e:
             msg = e.msg if "msg" in dir(e) else str(e)
-            if not self.distributed or dist.get_rank() == 0:
-                print(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}")
+            log_dist(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}",
+                     ranks=[0],
+                     level=logging.WARNING)
         finally:
             try:
                 self.nz3.clear_all_gathered_params()
             finally:
-                try:
-                    self.nz3.enable_profiling(False)
-                finally:
-                    _backfill_missing_profile_metadata(self.graph)
+                # Profiling must be disabled even if parameter cleanup fails. Backfill only makes incomplete
+                # profiling results consumable; cleanup failures still propagate.
+                self.nz3.enable_profiling(False)
+                _backfill_missing_profile_metadata(self.graph)
         return return_val
 
     def run_node(self, n: torch.fx.Node) -> Any:

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -3,7 +3,6 @@
 
 # DeepSpeed Team
 
-import logging
 import time
 from typing import Any, Tuple, Dict
 import statistics
@@ -21,7 +20,6 @@ except ImportError:
 
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
-from deepspeed.utils import log_dist
 from ..util import is_comm_op, is_release_node, get_deepcompile_handle
 
 
@@ -151,17 +149,16 @@ class ProfilingInterpreter(Interpreter):
         except Exception as e:
             profile_complete = False
             msg = e.msg if "msg" in dir(e) else str(e)
-            log_dist(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}",
-                     ranks=[0],
-                     level=logging.WARNING)
+            if not self.distributed or dist.get_rank() == 0:
+                print(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}")
         finally:
             try:
                 self.nz3.clear_all_gathered_params()
             finally:
-                # Profiling must be disabled even if parameter cleanup fails. Backfill only makes incomplete
-                # profiling results consumable; cleanup failures still propagate.
-                self.nz3.enable_profiling(False)
-                _backfill_missing_profile_metadata(self.graph, profile_complete=profile_complete)
+                try:
+                    self.nz3.enable_profiling(False)
+                finally:
+                    _backfill_missing_profile_metadata(self.graph, profile_complete=profile_complete)
         return return_val
 
     def run_node(self, n: torch.fx.Node) -> Any:

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -8,7 +8,7 @@ from typing import Any, Tuple, Dict
 import statistics
 
 import torch
-from torch.fx import GraphModule, Interpreter
+from torch.fx import Graph, GraphModule, Interpreter
 from torch.fx.node import map_aggregate
 
 try:
@@ -52,6 +52,21 @@ def _args_to_key(v):
 
 def _node_size(out):
     return sum([v.element_size() * v.numel() for v in tree_leaves(out) if torch.is_tensor(v)])
+
+
+_PROFILE_META_DEFAULTS = {
+    "device_time": 0.0,
+    "wall_time": 0.0,
+    "tensor_size": 0,
+    "alloc_mem": 0,
+    "max_mem": 0,
+}
+
+
+def _backfill_missing_profile_metadata(graph: Graph):
+    for node in graph.nodes:
+        for key, default in _PROFILE_META_DEFAULTS.items():
+            node.meta.setdefault(key, default)
 
 
 def _get_mem_usage_out_of_torch():
@@ -110,10 +125,16 @@ class ProfilingInterpreter(Interpreter):
                     return_val = super().run(*args)
         except Exception as e:
             msg = e.msg if "msg" in dir(e) else str(e)
-            print(f"Profiling error {msg}")
+            if not self.distributed or dist.get_rank() == 0:
+                print(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}")
         finally:
-            self.nz3.clear_all_gathered_params()
-            self.nz3.enable_profiling(False)
+            try:
+                self.nz3.clear_all_gathered_params()
+            finally:
+                try:
+                    self.nz3.enable_profiling(False)
+                finally:
+                    _backfill_missing_profile_metadata(self.graph)
         return return_val
 
     def run_node(self, n: torch.fx.Node) -> Any:

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -63,9 +63,31 @@ _PROFILE_META_DEFAULTS = {
     "alloc_mem": 0,
     "max_mem": 0,
 }
+_PROFILE_INCOMPLETE_ATTR = "_deepcompile_profile_incomplete"
+_PROFILE_INCOMPLETE_META_KEY = "deepcompile_profile_incomplete"
 
 
-def _backfill_missing_profile_metadata(graph: Graph):
+def _mark_profile_incomplete(graph: Graph):
+    setattr(graph, _PROFILE_INCOMPLETE_ATTR, True)
+    for node in graph.nodes:
+        node.meta[_PROFILE_INCOMPLETE_META_KEY] = True
+
+
+def is_profile_incomplete(graph: Graph):
+    if graph is None:
+        return False
+    if getattr(graph, _PROFILE_INCOMPLETE_ATTR, False):
+        return True
+    return any(node.meta.get(_PROFILE_INCOMPLETE_META_KEY, False) for node in graph.nodes)
+
+
+def _has_missing_profile_metadata(graph: Graph):
+    return any(key not in node.meta for node in graph.nodes for key in _PROFILE_META_DEFAULTS)
+
+
+def _backfill_missing_profile_metadata(graph: Graph, profile_complete: bool = True):
+    if not profile_complete or _has_missing_profile_metadata(graph):
+        _mark_profile_incomplete(graph)
     for node in graph.nodes:
         for key, default in _PROFILE_META_DEFAULTS.items():
             node.meta.setdefault(key, default)
@@ -117,6 +139,7 @@ class ProfilingInterpreter(Interpreter):
         returns: The output of the graph. Tensor in the output is real tensors.
         """
         return_val = None
+        profile_complete = True
         try:
             assert _all_real_if_tensor(args), "Inputs must be real tensors"
             self.nz3.enable_profiling(True)
@@ -126,6 +149,7 @@ class ProfilingInterpreter(Interpreter):
                     self.mem_usage_out_of_torch = _get_mem_usage_out_of_torch()
                     return_val = super().run(*args)
         except Exception as e:
+            profile_complete = False
             msg = e.msg if "msg" in dir(e) else str(e)
             log_dist(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}",
                      ranks=[0],
@@ -137,7 +161,7 @@ class ProfilingInterpreter(Interpreter):
                 # Profiling must be disabled even if parameter cleanup fails. Backfill only makes incomplete
                 # profiling results consumable; cleanup failures still propagate.
                 self.nz3.enable_profiling(False)
-                _backfill_missing_profile_metadata(self.graph)
+                _backfill_missing_profile_metadata(self.graph, profile_complete=profile_complete)
         return return_val
 
     def run_node(self, n: torch.fx.Node) -> Any:

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -13,9 +13,10 @@ from torch.fx import Graph, GraphModule
 import deepspeed.compile.util as compile_util
 from deepspeed.compile import inductor as inductor_mod
 from deepspeed.compile import list_schedule as schedule_mod
+from deepspeed.compile.passes import prefetch as prefetch_mod
 from deepspeed.compile.passes import selective_gather as selective_gather_mod
 from deepspeed.compile.profilers import ProfilingResult
-from deepspeed.compile.profilers.graph_profile import _backfill_missing_profile_metadata
+from deepspeed.compile.profilers.graph_profile import _backfill_missing_profile_metadata, is_profile_incomplete
 
 _DC_LIBRARIES = []
 
@@ -209,7 +210,7 @@ def test_fast_free_schedule_keeps_single_allgather_release_order():
     assert names.index(use.name) < names.index(release.name)
 
 
-def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective_gather(monkeypatch):
+def test_profile_backfill_makes_partial_profile_safe_for_profile_dependent_passes(monkeypatch):
     graph = Graph()
 
     param = _placeholder(graph, "partial_profile_param")
@@ -228,6 +229,7 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
     graph.lint()
 
     _backfill_missing_profile_metadata(graph)
+    assert is_profile_incomplete(graph)
 
     for node in graph.nodes:
         if node in (ag, use):
@@ -267,7 +269,19 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
     }
     gm = GraphModule(torch.nn.Module(), graph)
     logs = []
+    prefetch_logs = []
     persisted = []
+
+    monkeypatch.setattr(prefetch_mod, "print_rank_0", lambda message: prefetch_logs.append(message))
+    assert prefetch_mod.schedule_prefetch(gm,
+                                          graph_id=0,
+                                          graph_order=[(0, True)],
+                                          profiling_results=profiling_results,
+                                          create_inputs_fn=lambda: (),
+                                          mem_budget=0,
+                                          param_manager=fake_param_manager,
+                                          bwd=False) is gm
+    assert any("incomplete profiling data" in message for message in prefetch_logs)
 
     monkeypatch.setattr(selective_gather_mod, "print_rank_0", lambda message: logs.append(message))
     monkeypatch.setattr(selective_gather_mod, "get_accelerator", lambda: FakeAccelerator())
@@ -283,9 +297,8 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
                                           mem_budget=0,
                                           param_manager=fake_param_manager,
                                           bwd=True)
-    assert persisted == [90]
-    assert any("candidate_bytes=14" in message for message in logs)
-    assert any("size: 14" in message for message in logs)
+    assert persisted == []
+    assert any("incomplete profiling data" in message for message in logs)
 
 
 def test_graphsafe_rng_state_outputs_are_registered_no_reuse():

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -215,6 +215,7 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
     use = _neg(graph, wait, "partial_profile_use", device_time=None)
     release = _release(graph, use, 90, "partial_profile")
 
+    ag.meta.pop("tensor_size", None)
     for node in (ag, use):
         node.meta.pop("wall_time", None)
         node.meta.pop("alloc_mem", None)
@@ -234,6 +235,7 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
         assert "tensor_size" in node.meta
         assert "alloc_mem" in node.meta
         assert "max_mem" in node.meta
+    assert ag.meta["tensor_size"] == 0
 
     names = _scheduled_names(graph)
     assert names.index(ag.name) < names.index(wait.name)
@@ -251,17 +253,23 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
         def available_memory(self):
             return 1024
 
-    fake_ds_param = SimpleNamespace(numel=1,
+    fake_ds_param = SimpleNamespace(numel=7,
                                     dtype=torch.float16,
                                     param=SimpleNamespace(ds_persist=False, ds_shape=(1, )))
     fake_param_manager = {
         0: SimpleNamespace(params={"partial_profile_param": fake_ds_param}, ds_ids={"partial_profile_param": 90})
     }
-    profiling_results = {0: ProfilingResult(fwd_graph=graph, bwd_graph=None)}
+    profiling_results = {
+        0: ProfilingResult(fwd_graph=graph, bwd_graph=None, fwd_mem=[("profiled_before_abort", 0, 0, 0)])
+    }
     gm = GraphModule(torch.nn.Module(), graph)
+    logs = []
+    persisted = []
 
-    monkeypatch.setattr(selective_gather_mod, "print_rank_0", lambda *args, **kwargs: None)
+    monkeypatch.setattr(selective_gather_mod, "print_rank_0", lambda message: logs.append(message))
     monkeypatch.setattr(selective_gather_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(selective_gather_mod, "get_deepcompile_handle",
+                        lambda: SimpleNamespace(set_persistent=persisted.append))
     monkeypatch.setattr(selective_gather_mod.dist, "all_reduce", lambda *args, **kwargs: None)
 
     selective_gather_mod.selective_gather(gm,
@@ -272,3 +280,6 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
                                           mem_budget=0,
                                           param_manager=fake_param_manager,
                                           bwd=True)
+    assert persisted == [90]
+    assert any("candidate_bytes=14" in message for message in logs)
+    assert any("size: 14" in message for message in logs)

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -4,13 +4,17 @@
 # DeepSpeed Team
 
 import operator
+from types import SimpleNamespace
 
 import pytest
 import torch
-from torch.fx import Graph
+from torch.fx import Graph, GraphModule
 
 import deepspeed.compile.util as compile_util
 from deepspeed.compile import list_schedule as schedule_mod
+from deepspeed.compile.passes import selective_gather as selective_gather_mod
+from deepspeed.compile.profilers import ProfilingResult
+from deepspeed.compile.profilers.graph_profile import _backfill_missing_profile_metadata
 
 _DC_LIBRARIES = []
 
@@ -49,7 +53,8 @@ def stub_deepcompile_ops(monkeypatch):
 
 def _with_meta(node, tensor_size=0, device_time=0):
     node.meta["tensor_size"] = tensor_size
-    node.meta["device_time"] = device_time
+    if device_time is not None:
+        node.meta["device_time"] = device_time
     return node
 
 
@@ -199,3 +204,71 @@ def test_fast_free_schedule_keeps_single_allgather_release_order():
     assert names.index(ag.name) < names.index(wait.name)
     assert names.index(wait.name) < names.index(use.name)
     assert names.index(use.name) < names.index(release.name)
+
+
+def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective_gather(monkeypatch):
+    graph = Graph()
+
+    param = _placeholder(graph, "partial_profile_param")
+    ag = _allgather(graph, param, 90, "partial_profile", device_time=None)
+    wait = _wait(graph, ag, 90, "partial_profile")
+    use = _neg(graph, wait, "partial_profile_use", device_time=None)
+    release = _release(graph, use, 90, "partial_profile")
+
+    for node in (ag, use):
+        node.meta.pop("wall_time", None)
+        node.meta.pop("alloc_mem", None)
+        node.meta.pop("max_mem", None)
+
+    graph.output((release, ))
+    graph.lint()
+
+    _backfill_missing_profile_metadata(graph)
+
+    for node in graph.nodes:
+        if node in (ag, use):
+            assert node.meta["device_time"] == 0.0
+        else:
+            assert "device_time" in node.meta
+        assert "wall_time" in node.meta
+        assert "tensor_size" in node.meta
+        assert "alloc_mem" in node.meta
+        assert "max_mem" in node.meta
+
+    names = _scheduled_names(graph)
+    assert names.index(ag.name) < names.index(wait.name)
+    assert names.index(wait.name) < names.index(use.name)
+    assert names.index(use.name) < names.index(release.name)
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 1024
+
+        def available_memory(self):
+            return 1024
+
+    fake_ds_param = SimpleNamespace(numel=1,
+                                    dtype=torch.float16,
+                                    param=SimpleNamespace(ds_persist=False, ds_shape=(1, )))
+    fake_param_manager = {
+        0: SimpleNamespace(params={"partial_profile_param": fake_ds_param}, ds_ids={"partial_profile_param": 90})
+    }
+    profiling_results = {0: ProfilingResult(fwd_graph=graph, bwd_graph=None)}
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    monkeypatch.setattr(selective_gather_mod, "print_rank_0", lambda *args, **kwargs: None)
+    monkeypatch.setattr(selective_gather_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(selective_gather_mod.dist, "all_reduce", lambda *args, **kwargs: None)
+
+    selective_gather_mod.selective_gather(gm,
+                                          graph_id=0,
+                                          graph_order=[(0, True)],
+                                          profiling_results=profiling_results,
+                                          create_inputs_fn=lambda: (),
+                                          mem_budget=0,
+                                          param_manager=fake_param_manager,
+                                          bwd=True)

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -11,6 +11,7 @@ import torch
 from torch.fx import Graph, GraphModule
 
 import deepspeed.compile.util as compile_util
+from deepspeed.compile import inductor as inductor_mod
 from deepspeed.compile import list_schedule as schedule_mod
 from deepspeed.compile.passes import selective_gather as selective_gather_mod
 from deepspeed.compile.profilers import ProfilingResult
@@ -35,6 +36,8 @@ def _define_dc_ops():
             "wait_allgather(Tensor(a) a, int graph_id, int id) -> Tensor(a)",
             "release_param(Tensor(a) a, int graph_id, int id, int n_users) -> Tensor(a)",
             "reduce_grad(Tensor a, int graph_id, int id) -> Tensor",
+            "free_tensors(Tensor[] tensors) -> ()",
+            "end_backward(Tensor[] tensors, int graph_id, bool release_reduce_buckets = True) -> ()",
     ):
         try:
             lib.define(schema)
@@ -283,3 +286,46 @@ def test_profile_backfill_makes_partial_profile_safe_for_scheduler_and_selective
     assert persisted == [90]
     assert any("candidate_bytes=14" in message for message in logs)
     assert any("size: 14" in message for message in logs)
+
+
+def test_graphsafe_rng_state_outputs_are_registered_no_reuse():
+    graphsafe_run_with_rng_state = inductor_mod._get_graphsafe_run_with_rng_state()
+    if graphsafe_run_with_rng_state is None:
+        pytest.skip("graphsafe_run_with_rng_state is unavailable in this torch build")
+
+    calls = []
+
+    def fake_register(op_overload, **kwargs):
+        calls.append((op_overload, kwargs))
+
+    assert inductor_mod._register_graphsafe_rng_state_no_reuse(fake_register)
+    assert calls == [(graphsafe_run_with_rng_state, {"never_reuse_output": True})]
+
+
+def test_register_custom_ops_includes_graphsafe_rng_state_no_reuse(monkeypatch):
+    graphsafe_run_with_rng_state = inductor_mod._get_graphsafe_run_with_rng_state()
+    if graphsafe_run_with_rng_state is None:
+        pytest.skip("graphsafe_run_with_rng_state is unavailable in this torch build")
+
+    _define_dc_ops()
+    registered_ops = []
+
+    def fake_add_needs_realized_inputs(_op_overload):
+        return None
+
+    def fake_register_lowering(op_overload, **_kwargs):
+
+        def record_handler(handler):
+            registered_ops.append(op_overload)
+            return handler
+
+        return record_handler
+
+    monkeypatch.setattr(inductor_mod, "add_needs_realized_inputs", fake_add_needs_realized_inputs)
+    monkeypatch.setattr(inductor_mod, "register_lowering", fake_register_lowering)
+    monkeypatch.setattr(inductor_mod, "fallbacks", set())
+    monkeypatch.setattr(inductor_mod.Scheduler, "is_dc_patched", True, raising=False)
+
+    inductor_mod.register_custom_ops()
+
+    assert graphsafe_run_with_rng_state in registered_ops


### PR DESCRIPTION
DeepCompile ZeRO-3 scheduling can crash with KeyError or AssertionError on missing device_time when graph profiling fails partway and leaves some nodes without timing metadata.

This PR backfills default timing and memory metadata after profiling cleanup so the profiler guarantees downstream passes see complete metadata on every node.