### PR TITLE
Don't swallow KeyboardInterrupt/SystemExit in NPUOpBuilder

### DIFF
--- a/op_builder/npu/builder.py
+++ b/op_builder/npu/builder.py
@@ -30,7 +30,7 @@ class NPUOpBuilder(OpBuilder):
         self._torch_npu_path = os.path.join(os.path.dirname(os.path.abspath(torch_npu.__file__)))
         try:
             self._cann_version = self.installed_cann_version(self.name)
-        except BaseException:
+        except Exception:
             print(f"{self.name} ascend_cann is missing, npu ops cannot be compiled!")
 
     def cann_defs(self):


### PR DESCRIPTION
Addresses #8093.

`NPUOpBuilder.__init__` wraps `installed_cann_version()` in `except BaseException:`, which also catches `KeyboardInterrupt` and `SystemExit` and then prints `"... ascend_cann is missing, npu ops cannot be compiled!"`. So hitting Ctrl+C during that call is silently swallowed and turned into a misleading message.

This changes it to `except Exception:`, which still catches every normal failure mode (missing CANN path, env var, or version lookup error) but lets interrupts propagate.

Scope note: this is the only `BaseException`/bare-`except` clause in the codebase. The `except Exception:` clauses do not catch `KeyboardInterrupt`/`SystemExit` (those are `BaseException`, not `Exception`), so they are out of scope for this specific impact. Narrowing those to more specific types would be a separate, larger change.

pre-commit (yapf / flake8 / codespell / license) passes.
