### PR TITLE
Feat: zero3 deprecate elastic checkpoint

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -150,8 +150,8 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
 
     elastic_checkpoint: bool = False
     """
-    Enable loading checkpoint that was saved by job with different GPU count.
-    No longer supported.
+    Legacy elastic checkpoint support. ZeRO-3 elastic checkpointing is no
+    longer supported; use Universal Checkpointing instead.
     """
 
     offload_param: Optional[DeepSpeedZeroOffloadParamConfig] = None
@@ -390,4 +390,12 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
         offload_config = self.offload_optimizer
         if offload_config and offload_config.ratio < 1.0:
             assert self.stage == ZeroStageEnum.weights, "Partial offloading only supported for ZeRO Stage 3."
+        return self
+
+    @model_validator(mode="after")
+    def elastic_checkpoint_deprecated(self):
+        if self.stage == ZeroStageEnum.weights and self.elastic_checkpoint:
+            logger.warning(
+                "ZeRO-3 elastic checkpointing is deprecated and no longer supported. Use Universal Checkpointing instead."
+            )
         return self

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -3128,7 +3128,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             torch.save(checkpoint, "saved.pth")
         """
         if self.elastic_checkpoint:
-            raise NotImplementedError("ZeRO-3 does not yet support elastic checkpointing, please disable for now.")
+            raise NotImplementedError(
+                "ZeRO-3 elastic checkpointing is deprecated and unsupported. Use Universal Checkpointing instead.")
 
         return self._rigid_state_dict()
 
@@ -3288,7 +3289,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         """
 
         if self.elastic_checkpoint:
-            raise NotImplementedError("ZeRO-3 does not yet support elastic checkpointing, please disable for now.")
+            raise NotImplementedError(
+                "ZeRO-3 elastic checkpointing is deprecated and unsupported. Use Universal Checkpointing instead.")
 
         if checkpoint_folder:
             self._load_universal_checkpoint(checkpoint_folder, load_optimizer_states, load_from_fp32_weights)

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -459,7 +459,7 @@ Enabling and configuring ZeRO memory optimizations
     "stage3_prefetch_bucket_size" : 5e8,
     "stage3_param_persistence_threshold" : 1e6,
     "sub_group_size" : 1e12,
-    "elastic_checkpoint" : [true|false],
+    "elastic_checkpoint" : [true|false] (deprecated; use Universal Checkpointing for ZeRO-3),
     "stage3_gather_16bit_weights_on_model_save": [true|false],
     "ignore_unused_parameters": [true|false],
     "round_robin_gradients": [true|false],

--- a/tests/unit/checkpoint/test_zero_optimizer.py
+++ b/tests/unit/checkpoint/test_zero_optimizer.py
@@ -9,6 +9,7 @@ from deepspeed.ops.op_builder import CPUAdamBuilder
 from deepspeed.checkpoint.utils import clone_tensors_for_torch_save, get_model_ckpt_name_for_rank
 from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.zero import ZeroParamStatus
+from deepspeed.runtime.zero.config import DeepSpeedZeroConfig
 from deepspeed.utils.torch import required_torch_version
 
 from unit.common import DistributedTest, DistributedFixture
@@ -649,6 +650,19 @@ class TestSaveTensorClone(DistributedTest):
 
         compare_state_dicts(torch.load(ref_ckpt_file, weights_only=False),
                             torch.load(clone_ckpt_file, weights_only=False))
+
+
+def test_elastic_checkpoint_is_deprecated_for_zero3(monkeypatch):
+    warning_messages = []
+
+    def mock_logger_warning(message, *args, **kwargs):
+        warning_messages.append(message)
+
+    monkeypatch.setattr("deepspeed.utils.logger.warning", mock_logger_warning)
+
+    DeepSpeedZeroConfig(stage=3, elastic_checkpoint=True)
+
+    assert any("elastic checkpointing is deprecated" in str(message).lower() for message in warning_messages)
 
 
 class TestZeRONonDistributed(DistributedTest):


### PR DESCRIPTION
## Summary

This PR is a small follow-up to align ZeRO-3 checkpoint behavior with the current project direction toward Universal Checkpointing (UCP).

It treats the ZeRO-3 `elastic_checkpoint` path as deprecated/unsupported and updates user-facing messaging accordingly, without broad refactoring.

## Changes

- Marked ZeRO-3 `elastic_checkpoint` usage as deprecated at config level.
- Added a warning when:
  - `zero_optimization.stage == 3`
  - `zero_optimization.elastic_checkpoint == true`
- Updated ZeRO-3 error messages to explicitly point users to Universal Checkpointing.
- Updated config documentation to label `elastic_checkpoint` as deprecated for ZeRO-3.
- Added a focused unit test that verifies the deprecation warning path.

## Scope (Intentionally Small)

This PR **does not**:

- remove the `elastic_checkpoint` config key,
- remove/refactor Stage 1/2 legacy elastic checkpoint implementation,
- introduce checkpoint format migrations,
- change non-ZeRO-3 checkpoint flows.

## Motivation

Maintainer feedback indicated that UCP is the path forward and the older elastic checkpoint path should be deprecated.  
This PR takes the minimal first step to make behavior and messaging consistent while keeping risk low.

## Validation

- Added targeted test coverage for ZeRO-3 deprecation warning behavior.
- Kept runtime behavior changes minimal and localized to warning/error messaging for ZeRO-3 elastic checkpoint usage.

## Follow-ups

- Evaluate full cleanup/removal strategy for legacy elastic checkpoint paths in a separate PR.
- Add migration guidance (elastic checkpoint -> UCP) if broader user-facing docs are needed.

## Test Result
```
root@26a3ec8d2006:/workspace/DeepSpeed_woo# pytest -q tests/unit/checkpoint/test_zero_optimizer.py -k deprecate
================================================================== test session starts ===================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3.12
cachedir: .pytest_cache
rootdir: /workspace/DeepSpeed_woo/tests
configfile: pytest.ini
plugins: anyio-4.12.0
collected 69 items / 68 deselected / 1 selected                                                                                                          

tests/unit/checkpoint/test_zero_optimizer.py::test_elastic_checkpoint_is_deprecated_for_zero3 PASSED                                               [100%]

==================================================================== warnings summary ====================================================================
<string>:8
  <string>:8: PytestDeprecationWarning: A private pytest class or function was used.

unit/checkpoint/test_zero_optimizer.py::test_elastic_checkpoint_is_deprecated_for_zero3
  /workspace/DeepSpeed_woo/tests/conftest.py:47: UserWarning: Running test without verifying torch version, please provide an expected torch version with --torch_ver
    warnings.warn(

unit/checkpoint/test_zero_optimizer.py::test_elastic_checkpoint_is_deprecated_for_zero3
  /workspace/DeepSpeed_woo/tests/conftest.py:54: UserWarning: Running test without verifying cuda version, please provide an expected cuda version with --cuda_ver
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== slowest durations ====================================================================

(3 durations < 1s hidden.)
===================================================== 1 passed, 68 deselected, 3 warnings in 25.39s ======================================================
```

cc @sfc-gh-truwase — this is the follow-up to your comment in #8031 about deprecating elastic checkpointing.

I scoped this PR to ZeRO-3, where the path is already unsupported, and updated the warning/error/docs/test coverage to point users to Universal Checkpointing. Stage 1/2 legacy cleanup is intentionally left for a separate follow-up unless you’d prefer this PR to cover it too.