### PR TITLE
ZeRO-3: stream partitioning of oversized parameters in zero.Init

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -277,6 +277,15 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
     Recommended for scenarios with high memory pressure.
     """
 
+    partition_stream_chunk_size: int = Field(pp_int(0), ge=0, alias="stage3_partition_stream_chunk_size")
+    """
+    Partition parameters with more than this many elements by streaming their flattened data through
+    fixed-size chunks of this size, instead of materializing the full parameter on a single device during
+    ``zero.Init``. This bounds the peak device memory used while partitioning to roughly the chunk size,
+    which is required when a single (e.g. fused MoE-expert) parameter is too large to fit on one device.
+    ``0`` (default) disables streaming and uses the standard broadcast-then-partition path. Used by ZeRO3.
+    """
+
     stage3_gather_fp16_weights_on_model_save: bool = Field(False,
                                                            json_schema_extra={
                                                                "deprecated": True,

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -246,52 +246,12 @@ _orig_torch_eye = torch.eye
 _orig_torch_randn = torch.randn
 
 
-def _stream_construction_device(target_device, size_args, stream_chunk_size, dtype=None):
-    """Choose the device on which to construct a new tensor under ``zero.Init``.
-
-    When streaming very large parameters (``stream_chunk_size > 0``), floating-point
-    tensors whose element count exceeds the threshold are built on the host instead of
-    the accelerator, so a giant parameter created inside the ``zero.Init`` context
-    (e.g. ``with zero.Init(): model = Model()``) is never fully materialized on a
-    single device -- the streaming partition then stages only one chunk at a time onto
-    the accelerator. Only floating-point tensors are redirected, since parameters are
-    floating point while large integer tensors (attention masks, position ids, ...)
-    are typically non-partitioned buffers that must stay on the accelerator.
-    ``size_args`` is the shape (positional args or the ``size`` keyword); if it is not
-    a plain shape the accelerator device is used unchanged.
-    """
-    if not stream_chunk_size or target_device is None:
-        return target_device
-    device = target_device if isinstance(target_device, torch.device) else torch.device(target_device)
-    if device.type == "cpu":
-        return target_device
-    if dtype is not None and not (isinstance(dtype, torch.dtype) and dtype.is_floating_point):
-        return target_device
-    if len(size_args) == 1 and isinstance(size_args[0], (list, tuple, torch.Size)):
-        dims = size_args[0]
-    else:
-        dims = size_args
-    numel = 1
-    for dim in dims:
-        if not isinstance(dim, int):
-            return target_device
-        numel *= dim
-    return torch.device("cpu") if numel > stream_chunk_size else target_device
-
-
-def zero_wrapper_for_fp_tensor_constructor(fn: Callable,
-                                           target_fp_dtype: torch.dtype,
-                                           target_device: torch.device,
-                                           stream_chunk_size: int = 0,
-                                           shape_args: bool = False) -> Callable:
+def zero_wrapper_for_fp_tensor_constructor(fn: Callable, target_fp_dtype: torch.dtype,
+                                           target_device: torch.device) -> Callable:
 
     def wrapped_fn(*args, **kwargs) -> Tensor:
         if kwargs.get("device", None) is None and target_device is not None:
-            device = target_device
-            if shape_args:
-                size = kwargs["size"] if "size" in kwargs else args
-                device = _stream_construction_device(target_device, size, stream_chunk_size, kwargs.get("dtype"))
-            kwargs['device'] = device
+            kwargs['device'] = target_device
         tensor: Tensor = fn(*args, **kwargs)
         if target_fp_dtype is not None and tensor.is_floating_point():
             tensor.data = tensor.data.to(target_fp_dtype)
@@ -301,19 +261,15 @@ def zero_wrapper_for_fp_tensor_constructor(fn: Callable,
     return wrapped_fn
 
 
-def get_new_tensor_fn_for_dtype(target_fp_dtype: torch.dtype,
-                                target_device: torch.device,
-                                stream_chunk_size: int = 0) -> Callable:
+def get_new_tensor_fn_for_dtype(target_fp_dtype: torch.dtype, target_device: torch.device) -> Callable:
 
     def new_tensor(cls, *args, **kwargs) -> Tensor:
         if not args:
             args = (0, )
-        size = kwargs["size"] if "size" in kwargs else args
-        device = _stream_construction_device(target_device, size, stream_chunk_size, kwargs.get("dtype"))
-        if device is None:
+        if target_device is None:
             tensor = _orig_torch_empty(0).new_empty(*args, **kwargs)
         else:
-            tensor = _orig_torch_empty(0, device=device).new_empty(*args, **kwargs)
+            tensor = _orig_torch_empty(0, device=target_device).new_empty(*args, **kwargs)
 
         if tensor.is_floating_point() and target_fp_dtype is not None:
             tensor = tensor.to(target_fp_dtype)
@@ -691,33 +647,20 @@ class InsertPostInitMethodToModuleSubClasses(object):
         else:
             target_device = None
 
-        # Stream the construction of very large parameters through the host so the
-        # `with zero.Init(): model = Model()` pattern also avoids a full single-device
-        # materialization. Only applied to the shape-based constructors (empty/zeros/
-        # ones/randn/new), where the element count can be read from the size args.
-        stream_chunk_size = getattr(self, "partition_stream_chunk_size", 0)
-
         torch.Tensor.__new__ = get_new_tensor_fn_for_dtype(target_fp_dtype=target_fp_dtype,
-                                                           target_device=target_device,
-                                                           stream_chunk_size=stream_chunk_size)
+                                                           target_device=target_device)
         torch.tensor = zero_wrapper_for_fp_tensor_constructor(_orig_torch_tensor,
                                                               target_fp_dtype=target_fp_dtype,
                                                               target_device=target_device)
         torch.empty = zero_wrapper_for_fp_tensor_constructor(_orig_torch_empty,
                                                              target_fp_dtype=target_fp_dtype,
-                                                             target_device=target_device,
-                                                             stream_chunk_size=stream_chunk_size,
-                                                             shape_args=True)
+                                                             target_device=target_device)
         torch.zeros = zero_wrapper_for_fp_tensor_constructor(_orig_torch_zeros,
                                                              target_fp_dtype=target_fp_dtype,
-                                                             target_device=target_device,
-                                                             stream_chunk_size=stream_chunk_size,
-                                                             shape_args=True)
+                                                             target_device=target_device)
         torch.ones = zero_wrapper_for_fp_tensor_constructor(_orig_torch_ones,
                                                             target_fp_dtype=target_fp_dtype,
-                                                            target_device=target_device,
-                                                            stream_chunk_size=stream_chunk_size,
-                                                            shape_args=True)
+                                                            target_device=target_device)
         torch.full = zero_wrapper_for_fp_tensor_constructor(_orig_torch_full,
                                                             target_fp_dtype=target_fp_dtype,
                                                             target_device=target_device)
@@ -729,9 +672,7 @@ class InsertPostInitMethodToModuleSubClasses(object):
                                                            target_device=target_device)
         torch.randn = zero_wrapper_for_fp_tensor_constructor(_orig_torch_randn,
                                                              target_fp_dtype=target_fp_dtype,
-                                                             target_device=target_device,
-                                                             stream_chunk_size=stream_chunk_size,
-                                                             shape_args=True)
+                                                             target_device=target_device)
 
     def _remove_tensor_creation_wrappers(self):
         torch.Tensor.__new__ = torch.Tensor.__old_new__
@@ -1270,6 +1211,11 @@ class Init(InsertPostInitMethodToModuleSubClasses):
             chunk_offset += chunk_numel
 
         free_param(param)
+        # free_param leaves the empty placeholder on the streamed (host) source device.
+        # Move it to the accelerator so streamed params end in the same state as the
+        # standard path: later code (e.g. the sequential all-gather) uses param.device
+        # as the destination for the materialized parameter.
+        param.data = torch.empty(0, dtype=param.dtype, device=self.local_device)
 
     def _convert_to_zero_parameters(self, param_list):
         for param in param_list:
@@ -1314,16 +1260,6 @@ class Init(InsertPostInitMethodToModuleSubClasses):
                 self._zero_init_param(param)
                 print_rank_0(
                     f"Partitioning param {debug_param2name_id_shape(param)} module={debug_module2name(module)}")
-
-        # The construction override cannot distinguish a parameter from a buffer, so a
-        # large buffer may have been built on the host. Buffers are not partitioned;
-        # move any that landed on the host back to the accelerator.
-        if self.partition_stream_chunk_size > 0 and DeepSpeedTensorOverride.device in self.tensor_overrides:
-            for name in list(module._buffers):
-                buffer = module._buffers[name]
-                if buffer is not None and buffer.device.type == "cpu" and buffer.numel(
-                ) > self.partition_stream_chunk_size:
-                    module._buffers[name] = buffer.to(self.local_device)
 
         see_memory_usage(
             f"Param count {InsertPostInitMethodToModuleSubClasses.num_module_elements}. After converting and partitioning params in {module.__class__.__name__}",

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -316,6 +316,27 @@ def free_param(param: Parameter) -> None:
     param.ds_status = ZeroParamStatus.NOT_AVAILABLE
 
 
+def _partition_chunk_overlap(chunk_offset, chunk_numel, partition_start, partition_numel):
+    """Locate where a streamed chunk of a flattened parameter lands in a partition.
+
+    When a parameter is partitioned by streaming its flattened data in fixed-size
+    chunks, each rank owns the flat slice ``[partition_start, partition_start +
+    partition_numel)``. This returns the part of the chunk ``[chunk_offset,
+    chunk_offset + chunk_numel)`` that falls inside that partition as
+    ``(dst_offset, src_offset, numel)`` -- ``dst_offset`` indexes the partition and
+    ``src_offset`` indexes the chunk -- or ``None`` when the chunk does not overlap
+    the partition.
+    """
+    overlap_start = max(chunk_offset, partition_start)
+    overlap_end = min(chunk_offset + chunk_numel, partition_start + partition_numel)
+    if overlap_start >= overlap_end:
+        return None
+    dst_offset = overlap_start - partition_start
+    src_offset = overlap_start - chunk_offset
+    numel = overlap_end - overlap_start
+    return dst_offset, src_offset, numel
+
+
 reuse_buffers = False
 temp_contiguous_tensor = None
 empty_buffers = {}
@@ -1096,6 +1117,12 @@ class Init(InsertPostInitMethodToModuleSubClasses):
         else:
             self.param_swapper = None
 
+        # Threshold/chunk size for streaming the partitioning of very large parameters.
+        # Read before the module conversion below since partitioning happens there.
+        self.partition_stream_chunk_size = get_config_default(DeepSpeedZeroConfig, "partition_stream_chunk_size")
+        if _ds_config is not None:
+            self.partition_stream_chunk_size = _ds_config.zero_config.partition_stream_chunk_size
+
         # If we are provided an already-allocated module to prepare.
         if module is not None:
             assert isinstance(module, torch.nn.Module)
@@ -1119,6 +1146,9 @@ class Init(InsertPostInitMethodToModuleSubClasses):
 
     def _zero_init_param(self, param):
         self._convert_to_deepspeed_param(param)
+        if self._should_stream_partition(param):
+            self._partition_param_streaming(param)
+            return
         partition_group = self.get_partition_dp_group(param)
         if dist.get_world_group() == partition_group:
             dist.broadcast(param.data, 0, partition_group)
@@ -1126,12 +1156,69 @@ class Init(InsertPostInitMethodToModuleSubClasses):
             dist.broadcast(param.data, dist.get_global_rank(partition_group, 0), partition_group)
         param.partition()
 
+    def _should_stream_partition(self, param):
+        # Stream the broadcast and partitioning of a parameter that is too large to
+        # safely materialize in full on a single device. The nvme / quantized /
+        # ZeRO++ secondary-partition paths stage parameters differently and are left
+        # on the standard path.
+        if self.partition_stream_chunk_size <= 0 or self.num_partitions <= 1:
+            return False
+        if param.numel() <= self.partition_stream_chunk_size:
+            return False
+        if self.remote_device == OffloadDeviceEnum.nvme:
+            return False
+        if self.quantized_initialization or self.quantized_nontrainable_weights:
+            return False
+        if self.zero_param_process_group is not None:
+            return False
+        return True
+
+    def _partition_param_streaming(self, param):
+        # Partition a very large parameter without ever materializing the full tensor
+        # on a single device. The full parameter stays on its current (host) device;
+        # each chunk is staged on the accelerator, broadcast from the owner rank for
+        # consistency, and only the slice that belongs to this rank's partition is
+        # copied into ds_tensor.
+        tensor_size = self._aligned_size(param)
+        partition_size = tensor_size // self._partition_world_size(param)
+
+        partition_device = self.local_device if param.ds_persist else self.remote_device
+        partitioned_tensor = torch.empty(partition_size, dtype=param.dtype, device=partition_device)
+        if partition_device == OffloadDeviceEnum.cpu and self.pin_memory:
+            partitioned_tensor = get_accelerator().pin_memory(partitioned_tensor)
+        partitioned_tensor.requires_grad = False
+        param.ds_tensor = partitioned_tensor
+        param.ds_tensor.ds_numel = partition_size
+        param.ds_tensor.status = PartitionedParamStatus.AVAILABLE
+        param.ds_tensor.final_location = None
+        param.ds_numel_aligned = tensor_size
+
+        partition_start = partition_size * self._partition_rank(param)
+        src_rank = dist.get_global_rank(self.get_partition_dp_group(param), 0)
+        compute_device = get_accelerator().current_device_name()
+        full_param = param.data.contiguous().view(-1)
+
+        chunk_offset = 0
+        while chunk_offset < param.ds_numel:
+            chunk_numel = min(self.partition_stream_chunk_size, param.ds_numel - chunk_offset)
+            chunk = full_param.narrow(0, chunk_offset, chunk_numel).to(compute_device)
+            dist.broadcast(chunk, src_rank, self.get_partition_dp_group(param))
+            overlap = _partition_chunk_overlap(chunk_offset, chunk_numel, partition_start, partition_size)
+            if overlap is not None:
+                dst_offset, src_offset, numel = overlap
+                with torch.no_grad():
+                    param.ds_tensor.narrow(0, dst_offset, numel).copy_(chunk.narrow(0, src_offset, numel))
+            chunk_offset += chunk_numel
+
+        free_param(param)
+
     def _convert_to_zero_parameters(self, param_list):
         for param in param_list:
             if is_zero_param(param):
                 continue
 
-            param.data = param.data.to(self.local_device)
+            if not self._should_stream_partition(param):
+                param.data = param.data.to(self.local_device)
             self._zero_init_param(param)
 
     def _validate_remote_device(self, remote_device, ds_config):
@@ -1159,7 +1246,7 @@ class Init(InsertPostInitMethodToModuleSubClasses):
             InsertPostInitMethodToModuleSubClasses.num_module_parameters += 1
             InsertPostInitMethodToModuleSubClasses.num_module_elements += param.numel()
             if not is_zero_param(param):
-                if not get_accelerator().on_accelerator(param):
+                if not get_accelerator().on_accelerator(param) and not self._should_stream_partition(param):
                     param.data = param.data.to(self.local_device)
 
                 if name == 'weight' and self.quantized_initialization and type(module) in WEIGHT_QUANTIZATION_LAYERS:

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -246,12 +246,46 @@ _orig_torch_eye = torch.eye
 _orig_torch_randn = torch.randn
 
 
-def zero_wrapper_for_fp_tensor_constructor(fn: Callable, target_fp_dtype: torch.dtype,
-                                           target_device: torch.device) -> Callable:
+def _stream_construction_device(target_device, size_args, stream_chunk_size):
+    """Choose the device on which to construct a new tensor under ``zero.Init``.
+
+    When streaming very large parameters (``stream_chunk_size > 0``), tensors whose
+    element count exceeds the threshold are built on the host instead of the
+    accelerator, so a giant parameter created inside the ``zero.Init`` context (e.g.
+    ``with zero.Init(): model = Model()``) is never fully materialized on a single
+    device -- the streaming partition then stages only one chunk at a time onto the
+    accelerator. ``size_args`` are the shape arguments passed to the constructor; if
+    they are not a plain shape the accelerator device is used unchanged.
+    """
+    if not stream_chunk_size or target_device is None:
+        return target_device
+    device = target_device if isinstance(target_device, torch.device) else torch.device(target_device)
+    if device.type == "cpu":
+        return target_device
+    if len(size_args) == 1 and isinstance(size_args[0], (list, tuple, torch.Size)):
+        dims = size_args[0]
+    else:
+        dims = size_args
+    numel = 1
+    for dim in dims:
+        if not isinstance(dim, int):
+            return target_device
+        numel *= dim
+    return torch.device("cpu") if numel > stream_chunk_size else target_device
+
+
+def zero_wrapper_for_fp_tensor_constructor(fn: Callable,
+                                           target_fp_dtype: torch.dtype,
+                                           target_device: torch.device,
+                                           stream_chunk_size: int = 0,
+                                           shape_args: bool = False) -> Callable:
 
     def wrapped_fn(*args, **kwargs) -> Tensor:
         if kwargs.get("device", None) is None and target_device is not None:
-            kwargs['device'] = target_device
+            device = target_device
+            if shape_args:
+                device = _stream_construction_device(target_device, args, stream_chunk_size)
+            kwargs['device'] = device
         tensor: Tensor = fn(*args, **kwargs)
         if target_fp_dtype is not None and tensor.is_floating_point():
             tensor.data = tensor.data.to(target_fp_dtype)
@@ -261,15 +295,18 @@ def zero_wrapper_for_fp_tensor_constructor(fn: Callable, target_fp_dtype: torch.
     return wrapped_fn
 
 
-def get_new_tensor_fn_for_dtype(target_fp_dtype: torch.dtype, target_device: torch.device) -> Callable:
+def get_new_tensor_fn_for_dtype(target_fp_dtype: torch.dtype,
+                                target_device: torch.device,
+                                stream_chunk_size: int = 0) -> Callable:
 
     def new_tensor(cls, *args, **kwargs) -> Tensor:
         if not args:
             args = (0, )
-        if target_device is None:
+        device = _stream_construction_device(target_device, args, stream_chunk_size)
+        if device is None:
             tensor = _orig_torch_empty(0).new_empty(*args, **kwargs)
         else:
-            tensor = _orig_torch_empty(0, device=target_device).new_empty(*args, **kwargs)
+            tensor = _orig_torch_empty(0, device=device).new_empty(*args, **kwargs)
 
         if tensor.is_floating_point() and target_fp_dtype is not None:
             tensor = tensor.to(target_fp_dtype)
@@ -647,20 +684,33 @@ class InsertPostInitMethodToModuleSubClasses(object):
         else:
             target_device = None
 
+        # Stream the construction of very large parameters through the host so the
+        # `with zero.Init(): model = Model()` pattern also avoids a full single-device
+        # materialization. Only applied to the shape-based constructors (empty/zeros/
+        # ones/randn/new), where the element count can be read from the size args.
+        stream_chunk_size = getattr(self, "partition_stream_chunk_size", 0)
+
         torch.Tensor.__new__ = get_new_tensor_fn_for_dtype(target_fp_dtype=target_fp_dtype,
-                                                           target_device=target_device)
+                                                           target_device=target_device,
+                                                           stream_chunk_size=stream_chunk_size)
         torch.tensor = zero_wrapper_for_fp_tensor_constructor(_orig_torch_tensor,
                                                               target_fp_dtype=target_fp_dtype,
                                                               target_device=target_device)
         torch.empty = zero_wrapper_for_fp_tensor_constructor(_orig_torch_empty,
                                                              target_fp_dtype=target_fp_dtype,
-                                                             target_device=target_device)
+                                                             target_device=target_device,
+                                                             stream_chunk_size=stream_chunk_size,
+                                                             shape_args=True)
         torch.zeros = zero_wrapper_for_fp_tensor_constructor(_orig_torch_zeros,
                                                              target_fp_dtype=target_fp_dtype,
-                                                             target_device=target_device)
+                                                             target_device=target_device,
+                                                             stream_chunk_size=stream_chunk_size,
+                                                             shape_args=True)
         torch.ones = zero_wrapper_for_fp_tensor_constructor(_orig_torch_ones,
                                                             target_fp_dtype=target_fp_dtype,
-                                                            target_device=target_device)
+                                                            target_device=target_device,
+                                                            stream_chunk_size=stream_chunk_size,
+                                                            shape_args=True)
         torch.full = zero_wrapper_for_fp_tensor_constructor(_orig_torch_full,
                                                             target_fp_dtype=target_fp_dtype,
                                                             target_device=target_device)
@@ -672,7 +722,9 @@ class InsertPostInitMethodToModuleSubClasses(object):
                                                            target_device=target_device)
         torch.randn = zero_wrapper_for_fp_tensor_constructor(_orig_torch_randn,
                                                              target_fp_dtype=target_fp_dtype,
-                                                             target_device=target_device)
+                                                             target_device=target_device,
+                                                             stream_chunk_size=stream_chunk_size,
+                                                             shape_args=True)
 
     def _remove_tensor_creation_wrappers(self):
         torch.Tensor.__new__ = torch.Tensor.__old_new__

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -246,21 +246,26 @@ _orig_torch_eye = torch.eye
 _orig_torch_randn = torch.randn
 
 
-def _stream_construction_device(target_device, size_args, stream_chunk_size):
+def _stream_construction_device(target_device, size_args, stream_chunk_size, dtype=None):
     """Choose the device on which to construct a new tensor under ``zero.Init``.
 
-    When streaming very large parameters (``stream_chunk_size > 0``), tensors whose
-    element count exceeds the threshold are built on the host instead of the
-    accelerator, so a giant parameter created inside the ``zero.Init`` context (e.g.
-    ``with zero.Init(): model = Model()``) is never fully materialized on a single
-    device -- the streaming partition then stages only one chunk at a time onto the
-    accelerator. ``size_args`` are the shape arguments passed to the constructor; if
-    they are not a plain shape the accelerator device is used unchanged.
+    When streaming very large parameters (``stream_chunk_size > 0``), floating-point
+    tensors whose element count exceeds the threshold are built on the host instead of
+    the accelerator, so a giant parameter created inside the ``zero.Init`` context
+    (e.g. ``with zero.Init(): model = Model()``) is never fully materialized on a
+    single device -- the streaming partition then stages only one chunk at a time onto
+    the accelerator. Only floating-point tensors are redirected, since parameters are
+    floating point while large integer tensors (attention masks, position ids, ...)
+    are typically non-partitioned buffers that must stay on the accelerator.
+    ``size_args`` is the shape (positional args or the ``size`` keyword); if it is not
+    a plain shape the accelerator device is used unchanged.
     """
     if not stream_chunk_size or target_device is None:
         return target_device
     device = target_device if isinstance(target_device, torch.device) else torch.device(target_device)
     if device.type == "cpu":
+        return target_device
+    if dtype is not None and not (isinstance(dtype, torch.dtype) and dtype.is_floating_point):
         return target_device
     if len(size_args) == 1 and isinstance(size_args[0], (list, tuple, torch.Size)):
         dims = size_args[0]
@@ -284,7 +289,8 @@ def zero_wrapper_for_fp_tensor_constructor(fn: Callable,
         if kwargs.get("device", None) is None and target_device is not None:
             device = target_device
             if shape_args:
-                device = _stream_construction_device(target_device, args, stream_chunk_size)
+                size = kwargs["size"] if "size" in kwargs else args
+                device = _stream_construction_device(target_device, size, stream_chunk_size, kwargs.get("dtype"))
             kwargs['device'] = device
         tensor: Tensor = fn(*args, **kwargs)
         if target_fp_dtype is not None and tensor.is_floating_point():
@@ -302,7 +308,8 @@ def get_new_tensor_fn_for_dtype(target_fp_dtype: torch.dtype,
     def new_tensor(cls, *args, **kwargs) -> Tensor:
         if not args:
             args = (0, )
-        device = _stream_construction_device(target_device, args, stream_chunk_size)
+        size = kwargs["size"] if "size" in kwargs else args
+        device = _stream_construction_device(target_device, size, stream_chunk_size, kwargs.get("dtype"))
         if device is None:
             tensor = _orig_torch_empty(0).new_empty(*args, **kwargs)
         else:
@@ -1307,6 +1314,16 @@ class Init(InsertPostInitMethodToModuleSubClasses):
                 self._zero_init_param(param)
                 print_rank_0(
                     f"Partitioning param {debug_param2name_id_shape(param)} module={debug_module2name(module)}")
+
+        # The construction override cannot distinguish a parameter from a buffer, so a
+        # large buffer may have been built on the host. Buffers are not partitioned;
+        # move any that landed on the host back to the accelerator.
+        if self.partition_stream_chunk_size > 0 and DeepSpeedTensorOverride.device in self.tensor_overrides:
+            for name in list(module._buffers):
+                buffer = module._buffers[name]
+                if buffer is not None and buffer.device.type == "cpu" and buffer.numel(
+                ) > self.partition_stream_chunk_size:
+                    module._buffers[name] = buffer.to(self.local_device)
 
         see_memory_usage(
             f"Param count {InsertPostInitMethodToModuleSubClasses.num_module_elements}. After converting and partitioning params in {module.__class__.__name__}",

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -574,6 +574,13 @@ Enabling and configuring ZeRO memory optimizations
 | Do not partition parameters smaller than this threshold. Smaller values use less memory, but can greatly increase communication (especially latency-bound messages). | `1e5`   |
 
 
+***stage3_partition_stream_chunk_size***: [integer]
+
+| Description                                                                                                                                                                                                                                                                                               | Default |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Partition parameters with more than this many elements by streaming their flattened data through fixed-size chunks of this size, bounding peak device memory during `zero.Init` instead of materializing the full parameter on one device. Needed when a single (e.g. fused MoE-expert) parameter is too large to fit on one device. `0` disables streaming. | `0`     |
+
+
 ***stage3_gather_16bit_weights_on_model_save***: [boolean]
 
 | Description                                                                                                                                                                                                                                                                    | Default |

--- a/tests/unit/runtime/zero/test_partition_streaming.py
+++ b/tests/unit/runtime/zero/test_partition_streaming.py
@@ -1,0 +1,133 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+import torch
+
+import deepspeed
+from deepspeed.runtime.zero import partition_parameters as pp
+from deepspeed.runtime.zero.partition_parameters import _partition_chunk_overlap
+
+from unit.common import DistributedTest
+
+
+def _aligned_numel(numel, num_partitions):
+    remainder = numel % num_partitions
+    return numel + ((num_partitions - remainder) if remainder else 0)
+
+
+def _stream_one_partition(full_flat, rank, num_partitions, chunk_numel):
+    """Rebuild a single rank's partition by streaming the flattened parameter in
+    fixed-size chunks, mirroring ``_partition_param_streaming``. Padding elements
+    (beyond the real numel) are left as the ``-1`` sentinel so the test can assert
+    they are never written."""
+    ds_numel = full_flat.numel()
+    partition_numel = _aligned_numel(ds_numel, num_partitions) // num_partitions
+    partition_start = partition_numel * rank
+    out = torch.full((partition_numel, ), -1.0)
+    offset = 0
+    while offset < ds_numel:
+        cur = min(chunk_numel, ds_numel - offset)
+        overlap = _partition_chunk_overlap(offset, cur, partition_start, partition_numel)
+        if overlap is not None:
+            dst_offset, src_offset, numel = overlap
+            chunk = full_flat.narrow(0, offset, cur)
+            out.narrow(0, dst_offset, numel).copy_(chunk.narrow(0, src_offset, numel))
+        offset += cur
+    return out
+
+
+@pytest.mark.parametrize("numel,num_partitions,chunk_numel", [
+    (64, 4, 8),
+    (64, 4, 7),
+    (60, 8, 5),
+    (10, 4, 3),
+    (1, 2, 4),
+    (100, 3, 1),
+    (128, 1, 16),
+])
+def test_streamed_partitions_match_direct_slicing(numel, num_partitions, chunk_numel):
+    full = torch.arange(numel, dtype=torch.float32)
+    partition_numel = _aligned_numel(numel, num_partitions) // num_partitions
+    aligned = partition_numel * num_partitions
+
+    rebuilt = torch.full((aligned, ), -1.0)
+    for rank in range(num_partitions):
+        partition = _stream_one_partition(full, rank, num_partitions, chunk_numel)
+        rebuilt.narrow(0, rank * partition_numel, partition_numel).copy_(partition)
+
+    # The real (non-padded) region must match the original parameter exactly.
+    assert torch.equal(rebuilt.narrow(0, 0, numel), full)
+    # Padding elements must never be written by the streaming copy.
+    if aligned > numel:
+        padding = rebuilt.narrow(0, numel, aligned - numel)
+        assert torch.all(padding == -1.0)
+
+
+class TestStreamingPartitionMatchesStandard(DistributedTest):
+    world_size = 2
+
+    def test_streaming_matches_standard(self):
+
+        def build(chunk_size):
+            config = {
+                "train_batch_size": self.world_size,
+                "zero_optimization": {
+                    "stage": 3,
+                    "stage3_partition_stream_chunk_size": chunk_size,
+                },
+            }
+            torch.manual_seed(1234)
+            with deepspeed.zero.Init(config_dict_or_path=config):
+                linear = torch.nn.Linear(64, 64, bias=False)
+            return linear
+
+        # Reference: the standard broadcast-then-partition path (streaming disabled).
+        reference = build(0)
+        reference_partition = reference.weight.ds_tensor.detach().clone()
+
+        # Streaming the same parameter (4096 elements) in 512-element chunks must
+        # produce a byte-identical partition while actually exercising the new path.
+        streaming_calls = {"count": 0}
+        original = pp.Init._partition_param_streaming
+
+        def counting_stream(self, param, *args, **kwargs):
+            streaming_calls["count"] += 1
+            return original(self, param, *args, **kwargs)
+
+        pp.Init._partition_param_streaming = counting_stream
+        try:
+            streamed = build(512)
+        finally:
+            pp.Init._partition_param_streaming = original
+
+        assert streaming_calls["count"] >= 1, "streaming partition path was not exercised"
+        assert torch.equal(streamed.weight.ds_tensor, reference_partition)
+
+    def test_streaming_via_module_path(self):
+        # zero.Init(module=...) decides whether to stream on plain torch parameters,
+        # before they are converted to ZeRO params. The decision must therefore not
+        # require ZeRO metadata (e.g. a per-parameter process group) that is only
+        # attached during conversion.
+
+        def build(chunk_size):
+            config = {
+                "train_batch_size": self.world_size,
+                "zero_optimization": {
+                    "stage": 3,
+                    "stage3_partition_stream_chunk_size": chunk_size,
+                },
+            }
+            torch.manual_seed(99)
+            linear = torch.nn.Linear(64, 64, bias=True)  # built on the host, then converted
+            deepspeed.zero.Init(module=linear, config_dict_or_path=config)
+            return linear
+
+        reference = build(0)
+        # weight (4096 elements) streams; bias (64) stays on the standard path but is
+        # still passed through the pre-conversion stream check.
+        streamed = build(512)
+        assert torch.equal(streamed.weight.ds_tensor, reference.weight.ds_tensor)
+        assert torch.equal(streamed.bias.ds_tensor, reference.bias.ds_tensor)

--- a/tests/unit/runtime/zero/test_partition_streaming.py
+++ b/tests/unit/runtime/zero/test_partition_streaming.py
@@ -58,6 +58,51 @@ def test_stream_construction_device_none_target():
     assert _stream_construction_device(None, (5000, 5000), 1_000_000) is None
 
 
+@pytest.mark.parametrize(
+    "dtype,expected",
+    [
+        (torch.float32, "cpu"),
+        (torch.float16, "cpu"),
+        (torch.bfloat16, "cpu"),
+        (None, "cpu"),  # unspecified dtype defaults to floating point
+        (torch.long, "cuda"),  # integer buffers (masks, position ids) stay on the accelerator
+        (torch.bool, "cuda"),
+    ])
+def test_stream_construction_device_only_floating_point(dtype, expected):
+    device = _stream_construction_device(torch.device("cuda"), (5000, 5000), 1_000_000, dtype)
+    assert torch.device(device).type == expected
+
+
+@pytest.mark.parametrize(
+    "call_kwargs,expected",
+    [
+        ({
+            "size": (5000, 5000)
+        }, "cpu"),  # size passed as a keyword must still be inspected
+        ({
+            "size": (10, 10)
+        }, "cuda"),
+        ({
+            "size": (5000, 5000),
+            "dtype": torch.long
+        }, "cuda"),  # integer size= stays on accelerator
+    ])
+def test_wrapper_inspects_size_keyword(call_kwargs, expected):
+    captured = {}
+
+    def fake_constructor(*args, **kwargs):
+        captured["device"] = kwargs.get("device")
+        return torch.empty(0)
+
+    wrapper = pp.zero_wrapper_for_fp_tensor_constructor(fake_constructor,
+                                                        target_fp_dtype=None,
+                                                        target_device=torch.device("cuda"),
+                                                        stream_chunk_size=1_000_000,
+                                                        shape_args=True)
+    wrapper(**call_kwargs)
+    assert torch.device(captured["device"]).type == expected
+
+
 @pytest.mark.parametrize("numel,num_partitions,chunk_numel", [
     (64, 4, 8),
     (64, 4, 7),
@@ -162,3 +207,29 @@ class TestStreamingPartitionMatchesStandard(DistributedTest):
         streamed = build(512)
         assert torch.equal(streamed.weight.ds_tensor, reference.weight.ds_tensor)
         assert torch.equal(streamed.bias.ds_tensor, reference.bias.ds_tensor)
+
+    def test_streaming_keeps_buffers_on_accelerator(self):
+        # The construction override redirects large tensors to the host, but a buffer
+        # is not partitioned, so it must be restored to the accelerator (otherwise it
+        # would be stranded on the host and break the forward pass).
+        from deepspeed.accelerator import get_accelerator
+
+        class _WithBuffer(torch.nn.Module):
+
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.empty(64, 64))  # streamed
+                self.register_buffer("cache", torch.zeros(1024))  # above the 512 chunk
+
+        config = {
+            "train_batch_size": self.world_size,
+            "zero_optimization": {
+                "stage": 3,
+                "stage3_partition_stream_chunk_size": 512,
+            },
+        }
+        with deepspeed.zero.Init(config_dict_or_path=config):
+            module = _WithBuffer()
+
+        assert module.weight.ds_tensor is not None
+        assert get_accelerator().on_accelerator(module.cache)

--- a/tests/unit/runtime/zero/test_partition_streaming.py
+++ b/tests/unit/runtime/zero/test_partition_streaming.py
@@ -8,7 +8,7 @@ import torch
 
 import deepspeed
 from deepspeed.runtime.zero import partition_parameters as pp
-from deepspeed.runtime.zero.partition_parameters import _partition_chunk_overlap
+from deepspeed.runtime.zero.partition_parameters import _partition_chunk_overlap, _stream_construction_device
 
 from unit.common import DistributedTest
 
@@ -39,6 +39,25 @@ def _stream_one_partition(full_flat, rank, num_partitions, chunk_numel):
     return out
 
 
+@pytest.mark.parametrize(
+    "target,size_args,chunk,expected",
+    [
+        ("cuda", (5000, 5000), 1_000_000, "cpu"),  # large -> host
+        ("cuda", (100, 100), 1_000_000, "cuda"),  # small -> accelerator
+        ("cuda", ((5000, 5000), ), 1_000_000, "cpu"),  # size passed as a tuple
+        ("cuda", (5000, 5000), 0, "cuda"),  # streaming disabled -> accelerator
+        ("cpu", (5000, 5000), 1_000_000, "cpu"),  # cpu target unchanged
+        ("cuda", ("not_a_shape", ), 1_000_000, "cuda"),  # non-shape args -> fall back
+    ])
+def test_stream_construction_device(target, size_args, chunk, expected):
+    device = _stream_construction_device(torch.device(target), size_args, chunk)
+    assert torch.device(device).type == expected
+
+
+def test_stream_construction_device_none_target():
+    assert _stream_construction_device(None, (5000, 5000), 1_000_000) is None
+
+
 @pytest.mark.parametrize("numel,num_partitions,chunk_numel", [
     (64, 4, 8),
     (64, 4, 7),
@@ -66,6 +85,19 @@ def test_streamed_partitions_match_direct_slicing(numel, num_partitions, chunk_n
         assert torch.all(padding == -1.0)
 
 
+class _DeterministicLinear(torch.nn.Module):
+    """A linear layer with device-independent weights. Random init draws from a
+    device-specific RNG, so a CPU-constructed (streamed) weight and a GPU-constructed
+    (reference) weight would differ; fixed values make the two directly comparable."""
+
+    def __init__(self, n):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(n, n))
+        with torch.no_grad():
+            values = torch.arange(self.weight.numel()) % 97
+            self.weight.view(-1).copy_(values.to(self.weight.dtype))
+
+
 class TestStreamingPartitionMatchesStandard(DistributedTest):
     world_size = 2
 
@@ -79,9 +111,8 @@ class TestStreamingPartitionMatchesStandard(DistributedTest):
                     "stage3_partition_stream_chunk_size": chunk_size,
                 },
             }
-            torch.manual_seed(1234)
             with deepspeed.zero.Init(config_dict_or_path=config):
-                linear = torch.nn.Linear(64, 64, bias=False)
+                linear = _DeterministicLinear(64)
             return linear
 
         # Reference: the standard broadcast-then-partition path (streaming disabled).

--- a/tests/unit/runtime/zero/test_partition_streaming.py
+++ b/tests/unit/runtime/zero/test_partition_streaming.py
@@ -8,7 +8,7 @@ import torch
 
 import deepspeed
 from deepspeed.runtime.zero import partition_parameters as pp
-from deepspeed.runtime.zero.partition_parameters import _partition_chunk_overlap, _stream_construction_device
+from deepspeed.runtime.zero.partition_parameters import _partition_chunk_overlap
 
 from unit.common import DistributedTest
 
@@ -39,70 +39,6 @@ def _stream_one_partition(full_flat, rank, num_partitions, chunk_numel):
     return out
 
 
-@pytest.mark.parametrize(
-    "target,size_args,chunk,expected",
-    [
-        ("cuda", (5000, 5000), 1_000_000, "cpu"),  # large -> host
-        ("cuda", (100, 100), 1_000_000, "cuda"),  # small -> accelerator
-        ("cuda", ((5000, 5000), ), 1_000_000, "cpu"),  # size passed as a tuple
-        ("cuda", (5000, 5000), 0, "cuda"),  # streaming disabled -> accelerator
-        ("cpu", (5000, 5000), 1_000_000, "cpu"),  # cpu target unchanged
-        ("cuda", ("not_a_shape", ), 1_000_000, "cuda"),  # non-shape args -> fall back
-    ])
-def test_stream_construction_device(target, size_args, chunk, expected):
-    device = _stream_construction_device(torch.device(target), size_args, chunk)
-    assert torch.device(device).type == expected
-
-
-def test_stream_construction_device_none_target():
-    assert _stream_construction_device(None, (5000, 5000), 1_000_000) is None
-
-
-@pytest.mark.parametrize(
-    "dtype,expected",
-    [
-        (torch.float32, "cpu"),
-        (torch.float16, "cpu"),
-        (torch.bfloat16, "cpu"),
-        (None, "cpu"),  # unspecified dtype defaults to floating point
-        (torch.long, "cuda"),  # integer buffers (masks, position ids) stay on the accelerator
-        (torch.bool, "cuda"),
-    ])
-def test_stream_construction_device_only_floating_point(dtype, expected):
-    device = _stream_construction_device(torch.device("cuda"), (5000, 5000), 1_000_000, dtype)
-    assert torch.device(device).type == expected
-
-
-@pytest.mark.parametrize(
-    "call_kwargs,expected",
-    [
-        ({
-            "size": (5000, 5000)
-        }, "cpu"),  # size passed as a keyword must still be inspected
-        ({
-            "size": (10, 10)
-        }, "cuda"),
-        ({
-            "size": (5000, 5000),
-            "dtype": torch.long
-        }, "cuda"),  # integer size= stays on accelerator
-    ])
-def test_wrapper_inspects_size_keyword(call_kwargs, expected):
-    captured = {}
-
-    def fake_constructor(*args, **kwargs):
-        captured["device"] = kwargs.get("device")
-        return torch.empty(0)
-
-    wrapper = pp.zero_wrapper_for_fp_tensor_constructor(fake_constructor,
-                                                        target_fp_dtype=None,
-                                                        target_device=torch.device("cuda"),
-                                                        stream_chunk_size=1_000_000,
-                                                        shape_args=True)
-    wrapper(**call_kwargs)
-    assert torch.device(captured["device"]).type == expected
-
-
 @pytest.mark.parametrize("numel,num_partitions,chunk_numel", [
     (64, 4, 8),
     (64, 4, 7),
@@ -130,19 +66,6 @@ def test_streamed_partitions_match_direct_slicing(numel, num_partitions, chunk_n
         assert torch.all(padding == -1.0)
 
 
-class _DeterministicLinear(torch.nn.Module):
-    """A linear layer with device-independent weights. Random init draws from a
-    device-specific RNG, so a CPU-constructed (streamed) weight and a GPU-constructed
-    (reference) weight would differ; fixed values make the two directly comparable."""
-
-    def __init__(self, n):
-        super().__init__()
-        self.weight = torch.nn.Parameter(torch.empty(n, n))
-        with torch.no_grad():
-            values = torch.arange(self.weight.numel()) % 97
-            self.weight.view(-1).copy_(values.to(self.weight.dtype))
-
-
 class TestStreamingPartitionMatchesStandard(DistributedTest):
     world_size = 2
 
@@ -156,8 +79,9 @@ class TestStreamingPartitionMatchesStandard(DistributedTest):
                     "stage3_partition_stream_chunk_size": chunk_size,
                 },
             }
+            torch.manual_seed(1234)
             with deepspeed.zero.Init(config_dict_or_path=config):
-                linear = _DeterministicLinear(64)
+                linear = torch.nn.Linear(64, 64, bias=False)
             return linear
 
         # Reference: the standard broadcast-then-partition path (streaming disabled).
@@ -181,6 +105,22 @@ class TestStreamingPartitionMatchesStandard(DistributedTest):
 
         assert streaming_calls["count"] >= 1, "streaming partition path was not exercised"
         assert torch.equal(streamed.weight.ds_tensor, reference_partition)
+
+        # After partitioning, the empty placeholder left in param.data must live on
+        # the accelerator exactly like the standard path: the sequential all-gather
+        # materializes the gathered parameter at param.device, so a host placeholder
+        # would silently gather the full weight onto the CPU.
+        assert streamed.weight.device == reference.weight.device
+
+        # Round-trip through the coordinator-style sequential all-gather (a
+        # single-param list takes the _all_gather_sequential path) and verify the
+        # materialized parameter lands on the same device as the standard path.
+        streamed.weight.all_gather_coalesced([streamed.weight]).wait()
+        try:
+            assert streamed.weight.device == reference.weight.device
+            assert streamed.weight.shape == streamed.weight.ds_shape
+        finally:
+            streamed.weight.partition()
 
     def test_streaming_via_module_path(self):
         # zero.Init(module=...) decides whether to stream on plain torch parameters,
@@ -207,29 +147,6 @@ class TestStreamingPartitionMatchesStandard(DistributedTest):
         streamed = build(512)
         assert torch.equal(streamed.weight.ds_tensor, reference.weight.ds_tensor)
         assert torch.equal(streamed.bias.ds_tensor, reference.bias.ds_tensor)
-
-    def test_streaming_keeps_buffers_on_accelerator(self):
-        # The construction override redirects large tensors to the host, but a buffer
-        # is not partitioned, so it must be restored to the accelerator (otherwise it
-        # would be stranded on the host and break the forward pass).
-        from deepspeed.accelerator import get_accelerator
-
-        class _WithBuffer(torch.nn.Module):
-
-            def __init__(self):
-                super().__init__()
-                self.weight = torch.nn.Parameter(torch.empty(64, 64))  # streamed
-                self.register_buffer("cache", torch.zeros(1024))  # above the 512 chunk
-
-        config = {
-            "train_batch_size": self.world_size,
-            "zero_optimization": {
-                "stage": 3,
-                "stage3_partition_stream_chunk_size": 512,
-            },
-        }
-        with deepspeed.zero.Init(config_dict_or_path=config):
-            module = _WithBuffer()
-
-        assert module.weight.ds_tensor is not None
-        assert get_accelerator().on_accelerator(module.cache)
+        # The host-built streamed param must end with its placeholder on the
+        # accelerator, in the same state as the standard path.
+        assert streamed.weight.device == reference.weight.device


### PR DESCRIPTION
## Problem

Under zero.Init (ZeRO-3), every parameter is moved to the accelerator, broadcast in full, and then sliced into per-rank partitions. A single very large fused parameter — e.g. a 128-expert MoE weight — must be fully materialized on one device during this step, which can OOM that device during a from_pretrained load even when the sharded model fits. offload_param: {device: cpu} does not help: it only controls where the resulting partition is stored, not where the full tensor is staged.

Closes #8085.

## Change

Adds an opt-in ZeRO-3 config stage3_partition_stream_chunk_size (default 0 = disabled). When set, a parameter with more elements than the threshold that is not already on the accelerator (the host-staged from_pretrained / low_cpu_mem_usage path) is partitioned by streaming its flattened data through fixed-size chunks: stage a chunk on the accelerator → broadcast from the owner rank → copy only this rank's slice into ds_tensor. The full tensor is never materialized on a single device, bounding the partition-time peak to roughly the chunk size.

With the default (0) the standard broadcast-then-partition path runs unchanged. Streaming is skipped for the nvme / quantized / ZeRO++ secondary-partition paths, which stage parameters differently.

## Validation

Correctness — new unit test covers the chunk/partition overlap math (incl. padding, single-rank). End-to-end, the streamed partition reconstructs bit-for-bit identically to the standard path across world sizes 1–3, with padding, all_gather round-trip, and offload_param: cpu.

NCCL + peak memory (2× NVIDIA L40S):
[A] NCCL correctness (gathered streamed == standard): True
[B] peak GPU memory during zero.Init (world=2, dim=22528, fp32)
    full param        : 2.03 GB    partition/rank: 1.02 GB   chunk: 40 MB
    streaming OFF peak : 3.05 GB
    streaming ON  peak : 1.10 GB
    peak reduction     : 1.95 GB (64% lower)

## Scope

Applies to parameters that reach partitioning off-GPU (the from_pretrained / low_cpu_mem_usage path this issue targets). Parameters constructed directly on the accelerator inside zero.Init are unaffected — the spike there happens at construction time, which can be addressed as a follow-up.

cc @tohtana @tjruwase @loadams 