### PR TITLE
Fix DeepCompile profiling memory cleanup

### DIFF
--- a/deepspeed/compile/backend.py
+++ b/deepspeed/compile/backend.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     pass
 
+import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
 
 from .fx import add_free_activations
@@ -107,7 +108,7 @@ def launch_compile_passes(global_steps: int):
         frames_partitioned.clear()
 
 
-def set_time_and_tensor_size(graph_id, graph: Graph, mem, bwd, profiling_results):
+def set_time_and_tensor_size(graph_id, graph: Graph, mem, bwd, profiling_results, mem_complete=True):
     node_time = []
     tensor_sizes = []
 
@@ -121,11 +122,22 @@ def set_time_and_tensor_size(graph_id, graph: Graph, mem, bwd, profiling_results
         profiling_results[graph_id].bwd_time = node_time
         profiling_results[graph_id].bwd_tensor_sizes = tensor_sizes
         profiling_results[graph_id].bwd_mem = mem
+        profiling_results[graph_id].bwd_mem_complete = mem_complete
     else:
         profiling_results[graph_id].fwd_graph = graph
         profiling_results[graph_id].fwd_time = node_time
         profiling_results[graph_id].fwd_tensor_sizes = tensor_sizes
         profiling_results[graph_id].fwd_mem = mem
+        profiling_results[graph_id].fwd_mem_complete = mem_complete
+
+
+def _sync_memory_profile_complete(profile_complete: bool) -> bool:
+    if not dist.is_initialized():
+        return profile_complete
+
+    complete = torch.tensor([1 if profile_complete else 0], device=torch.device(get_accelerator().current_device()))
+    dist.all_reduce(complete, dist.ReduceOp.MIN)
+    return bool(complete.item())
 
 
 def evaluate_symint_from_shape_env(sym_int_v):
@@ -213,9 +225,13 @@ def run_opt_passes(opt_passes: List[Callable],
 
             mem_prof = MemoryProfilingInterpreter(gm, debug_log=debug_log)
             mem_prof.run(*create_inputs_fn())
-            mem = [(name, current_alloc, delta, peak) for name, current_alloc, delta, peak in mem_prof.mem_record]
+            profile_complete = _sync_memory_profile_complete(mem_prof.profile_complete)
+            if profile_complete:
+                mem = [(name, current_alloc, delta, peak) for name, current_alloc, delta, peak in mem_prof.mem_record]
+            else:
+                mem = []
 
-            set_time_and_tensor_size(graph_id, gm.graph, mem, bwd, profiling_results)
+            set_time_and_tensor_size(graph_id, gm.graph, mem, bwd, profiling_results, profile_complete)
 
         with unset_fake_temporarily():
             get_accelerator().synchronize()

--- a/deepspeed/compile/partitioner.py
+++ b/deepspeed/compile/partitioner.py
@@ -75,10 +75,9 @@ def _recompute_param_aliases(joint_graph: Graph, param_indices: List[Tuple[int, 
             any([(isinstance(a, Node) and (a in ds_param_inputs or a in recomputed_nodes)) for a in node.args]):
             node.meta["recompute"] = CheckpointPolicy.MUST_RECOMPUTE
             recomputed_nodes.add(node)
-        else:
-            # If checkpointing is not enabled for this graph, assume all
-            # activations required by the backward pass should be saved.
-            node.meta.setdefault("recompute", CheckpointPolicy.MUST_SAVE)
+        # Leave non-parameter activations to the default min-cut policy. Forcing
+        # every other node to MUST_SAVE prevents safe activation rematerialization
+        # and can make long-sequence compiled backward graphs OOM.
 
 
 def get_wrapped_partitioner(

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -39,8 +39,10 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                       create_inputs_fn, mem_budget: float, param_manager: DSGraphParamManager,
                       bwd: bool) -> GraphModule:
 
-    profile_graph = profiling_results[graph_id].bwd_graph if bwd else profiling_results[graph_id].fwd_graph
-    if is_profile_incomplete(profile_graph):
+    profile = profiling_results[graph_id]
+    profile_graph = profile.bwd_graph if bwd else profile.fwd_graph
+    mem_complete = profile.bwd_mem_complete if bwd else profile.fwd_mem_complete
+    if is_profile_incomplete(profile_graph) or not mem_complete:
         print_rank_0(f"schedule_prefetch graph_id={graph_id} incomplete profiling data; skipping prefetch")
         return gm
 

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -54,7 +54,7 @@ def _compute_persistence_budget(all_graph_mem_records: List[List[Tuple[str, int,
             "profiled_list_count": 0,
         }
 
-    # Persistent parameters add to live allocations that remain resident past an op boundary.
+    # Persistent parameters stay live during transient allocations inside an op.
     peak_resident_alloc = max(record[1] for mem_records in non_empty_records for record in mem_records)
     transient_peak = max(record[3] for mem_records in non_empty_records for record in mem_records)
 
@@ -62,13 +62,14 @@ def _compute_persistence_budget(all_graph_mem_records: List[List[Tuple[str, int,
         "usable_mem": usable_mem,
         "peak_resident_alloc": peak_resident_alloc,
         "transient_peak": transient_peak,
-        "available_mem": max(0, usable_mem - peak_resident_alloc),
+        "available_mem": max(0, usable_mem - transient_peak),
         "profiled_list_count": len(non_empty_records),
     }
 
 
 def _profile_result_incomplete(prof) -> bool:
-    return is_profile_incomplete(prof.fwd_graph) or is_profile_incomplete(prof.bwd_graph)
+    return (is_profile_incomplete(prof.fwd_graph) or is_profile_incomplete(prof.bwd_graph) or not prof.fwd_mem_complete
+            or (prof.needs_backward and not prof.bwd_mem_complete))
 
 
 def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int, bool]], profiling_results,
@@ -171,7 +172,8 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
     current_available_mem = vals_to_bcast[1].item()
 
     budget = _compute_persistence_budget(all_graph_mem_records, total_mem, MEM_MARGIN)
-    available_mem = int(current_available_mem * (1 - MEM_MARGIN))
+    profiled_available_mem = budget["available_mem"]
+    available_mem = profiled_available_mem
 
     ds_id_to_param = {}
     for g_id, g_pm in param_manager.items():
@@ -185,7 +187,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
         f"selective_gather target_graph_id={target_graph_id} profiled_mem_lists={budget['profiled_list_count']} "
         f"total_mem={total_mem} usable_mem={budget['usable_mem']} peak_resident_alloc={budget['peak_resident_alloc']} "
         f"transient_peak={budget['transient_peak']} current_available_mem={current_available_mem} "
-        f"usable_available_mem={available_mem} "
+        f"profiled_transient_available_mem={profiled_available_mem} "
         f"persistent_count={len(persistent_ds_ids)} persistent_bytes={persistent_bytes} "
         f"candidate_count={len(ds_ids)} candidate_bytes={candidate_bytes}")
 
@@ -198,7 +200,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
         return gm
 
     if available_mem == 0:
-        print_rank_0("selective_gather no currently available memory for new persistent params")
+        print_rank_0("selective_gather no profiled headroom for new persistent params")
         return gm
 
     persistent_mem = 0

--- a/deepspeed/compile/profilers/__init__.py
+++ b/deepspeed/compile/profilers/__init__.py
@@ -16,6 +16,8 @@ class ProfilingResult:
     needs_backward: bool = False
     fwd_mem: List[Tuple[str, int, int, int]] = field(default_factory=list)  # name, current_alloc, delta, peak
     bwd_mem: List[Tuple[str, int, int, int]] = field(default_factory=list)
+    fwd_mem_complete: bool = True
+    bwd_mem_complete: bool = True
     fwd_time: List[Tuple[str, int, int]] = field(default_factory=list)  # name, device_time, wall_time
     bwd_time: List[Tuple[str, int, int]] = field(default_factory=list)
     fwd_tensor_sizes: List[Tuple[str, int]] = field(default_factory=list)  # name, size

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -91,6 +91,25 @@ def _backfill_missing_profile_metadata(graph: Graph, profile_complete: bool = Tr
             node.meta.setdefault(key, default)
 
 
+def _run_warmup_for_profile(call_fn, warmup):
+    for _ in range(warmup):
+        warmup_out = call_fn()
+        del warmup_out
+
+
+def _run_repeatedly_for_profile(call_fn, iteration, start_events, end_events):
+    out = None
+    for i in range(iteration):
+        start_events[i].record()
+        out = call_fn()
+        end_events[i].record()
+        if i + 1 < iteration:
+            del out
+            out = None
+
+    return out
+
+
 def _get_mem_usage_out_of_torch():
 
     adjust = 0
@@ -218,19 +237,18 @@ class ProfilingInterpreter(Interpreter):
         alloc_mem_start = get_accelerator().memory_allocated()
         max_mem_start = get_accelerator().max_memory_allocated()
 
-        if not run_only_once:
-            for i in range(self.warmup):
-                out = getattr(self, n.op)(n.target, args, kwargs)
+        def run_target():
+            return getattr(self, n.op)(n.target, args, kwargs)
+
+        warmup = 0 if run_only_once else self.warmup
+        _run_warmup_for_profile(run_target, warmup)
 
         if is_comm_op(n):
             assert self.distributed, f"Distributed environment is not initialized but comm operator {n.name} {n.target} is used."
             dist.barrier()
 
         start = time.time()
-        for i in range(iteration):
-            start_events[i].record()
-            out = getattr(self, n.op)(n.target, args, kwargs)
-            end_events[i].record()
+        out = _run_repeatedly_for_profile(run_target, iteration, start_events, end_events)
         accelerator.synchronize()
         walltime_sum = time.time() - start
 
@@ -295,6 +313,7 @@ class MemoryProfilingInterpreter(Interpreter):
         self.device = torch.device(get_accelerator().current_device())
         self.mem_record = []
         self.last_alloc = get_accelerator().memory_allocated()
+        self.profile_complete = True
 
         self.node_counter = 0
         self.node_num = len(gm.graph.nodes)
@@ -302,6 +321,7 @@ class MemoryProfilingInterpreter(Interpreter):
 
     def run(self, *args) -> Any:
         return_val = None
+        self.profile_complete = True
         try:
             assert _all_real_if_tensor(args), "Inputs must be real tensors"
             self.nz3.enable_profiling(True)
@@ -311,9 +331,14 @@ class MemoryProfilingInterpreter(Interpreter):
                 with get_accelerator().random().fork_rng(devices=[self.device]):
                     return_val = super().run(*args)
         except Exception as e:
+            self.profile_complete = False
+            self.mem_record.clear()
             print(f"MemoryProfiling error {e}")
         finally:
-            self.nz3.enable_profiling(False)
+            try:
+                self.nz3.clear_all_gathered_params()
+            finally:
+                self.nz3.enable_profiling(False)
 
         return return_val
 

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -11,6 +11,7 @@ import torch
 from torch.fx import Graph, GraphModule
 
 import deepspeed.compile.util as compile_util
+from deepspeed.compile import backend as backend_mod
 from deepspeed.compile import inductor as inductor_mod
 from deepspeed.compile import list_schedule as schedule_mod
 from deepspeed.compile.passes import prefetch as prefetch_mod
@@ -64,6 +65,31 @@ def _with_meta(node, tensor_size=0, device_time=0):
 
 def _placeholder(graph, name):
     return _with_meta(graph.placeholder(name))
+
+
+def test_sync_memory_profile_complete_noops_without_distributed(monkeypatch):
+    monkeypatch.setattr(backend_mod.dist, "is_initialized", lambda: False)
+
+    def fail_all_reduce(*args, **kwargs):
+        raise AssertionError("all_reduce should not run without distributed init")
+
+    monkeypatch.setattr(backend_mod.dist, "all_reduce", fail_all_reduce)
+
+    assert backend_mod._sync_memory_profile_complete(True)
+    assert not backend_mod._sync_memory_profile_complete(False)
+
+
+def test_sync_memory_profile_complete_reduces_asymmetric_failure(monkeypatch):
+    monkeypatch.setattr(backend_mod.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(backend_mod, "get_accelerator", lambda: SimpleNamespace(current_device=lambda: "cpu"))
+
+    def mark_any_rank_failed(tensor, op):
+        assert op == backend_mod.dist.ReduceOp.MIN
+        tensor[0] = 0
+
+    monkeypatch.setattr(backend_mod.dist, "all_reduce", mark_any_rank_failed)
+
+    assert not backend_mod._sync_memory_profile_complete(True)
 
 
 def _allgather(graph, arg, ds_id, name, tensor_size=1, device_time=1):
@@ -298,6 +324,42 @@ def test_profile_backfill_makes_partial_profile_safe_for_profile_dependent_passe
                                           param_manager=fake_param_manager,
                                           bwd=True)
     assert persisted == []
+    assert any("incomplete profiling data" in message for message in logs)
+
+
+def test_schedule_prefetch_skips_when_memory_profile_incomplete(monkeypatch):
+    graph = Graph()
+
+    param = _placeholder(graph, "mem_incomplete_param")
+    ag = _allgather(graph, param, 91, "mem_incomplete")
+    wait = _wait(graph, ag, 91, "mem_incomplete")
+    use = _neg(graph, wait, "mem_incomplete_use")
+    release = _release(graph, use, 91, "mem_incomplete")
+
+    graph.output((release, ))
+    graph.lint()
+
+    profiling_results = {
+        0:
+        ProfilingResult(fwd_graph=graph,
+                        bwd_graph=None,
+                        fwd_mem=[("profiled_before_abort", 0, 0, 0)],
+                        fwd_mem_complete=False)
+    }
+    gm = GraphModule(torch.nn.Module(), graph)
+    logs = []
+
+    monkeypatch.setattr(prefetch_mod, "print_rank_0", lambda message: logs.append(message))
+
+    assert prefetch_mod.schedule_prefetch(gm,
+                                          graph_id=0,
+                                          graph_order=[(0, False)],
+                                          profiling_results=profiling_results,
+                                          create_inputs_fn=lambda: (),
+                                          mem_budget=0,
+                                          param_manager={},
+                                          bwd=False) is gm
+    assert gm.graph is graph
     assert any("incomplete profiling data" in message for message in logs)
 
 

--- a/tests/unit/v1/compile/test_graph_profile.py
+++ b/tests/unit/v1/compile/test_graph_profile.py
@@ -1,0 +1,193 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+import torch
+from torch.fx import Graph, GraphModule
+
+import deepspeed.compile.profilers.graph_profile as graph_profile
+
+
+class FakeRandom:
+
+    def fork_rng(self, devices):
+        return self
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeAccelerator:
+
+    def __init__(self):
+        self.event_count = 0
+
+    def current_device(self):
+        return "cpu"
+
+    def memory_allocated(self):
+        return 0
+
+    def max_memory_allocated(self):
+        return 0
+
+    def reset_peak_memory_stats(self):
+        return None
+
+    def Event(self, enable_timing=True):
+        event = FakeEvent(f"event-{self.event_count}")
+        self.event_count += 1
+        return event
+
+    def synchronize(self):
+        return None
+
+    def random(self):
+        return FakeRandom()
+
+
+class FakeDeepCompileHandle:
+
+    def __init__(self):
+        self.events = []
+
+    def enable_profiling(self, enabled):
+        self.events.append(("enable", enabled))
+
+    def clear_all_gathered_params(self):
+        self.events.append(("clear", None))
+
+
+class FakeEvent:
+
+    def __init__(self, name):
+        self.name = name
+        self.records = []
+
+    def record(self):
+        self.records.append(self.name)
+
+    def elapsed_time(self, end_event):
+        return 1.0
+
+
+def _make_empty_graph_module():
+    graph = Graph()
+    graph.output(None)
+    return GraphModule(torch.nn.Module(), graph)
+
+
+def test_profile_helpers_drop_warmup_and_intermediate_outputs():
+    deleted = []
+
+    class Output:
+
+        def __init__(self, index):
+            self.index = index
+
+        def __del__(self):
+            deleted.append(self.index)
+
+    outputs_created = []
+
+    def call_fn():
+        output = Output(len(outputs_created))
+        outputs_created.append(output.index)
+        return output
+
+    start_events = [FakeEvent(f"start-{i}") for i in range(3)]
+    end_events = [FakeEvent(f"end-{i}") for i in range(3)]
+
+    graph_profile._run_warmup_for_profile(call_fn, warmup=2)
+    out = graph_profile._run_repeatedly_for_profile(call_fn,
+                                                    iteration=3,
+                                                    start_events=start_events,
+                                                    end_events=end_events)
+
+    assert out.index == 4
+    assert outputs_created == [0, 1, 2, 3, 4]
+    assert deleted == [0, 1, 2, 3]
+    assert [event.records for event in start_events] == [["start-0"], ["start-1"], ["start-2"]]
+    assert [event.records for event in end_events] == [["end-0"], ["end-1"], ["end-2"]]
+
+
+def test_profiling_interpreter_wall_time_excludes_warmup(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+    fake_accelerator = FakeAccelerator()
+
+    monkeypatch.setattr(graph_profile, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(graph_profile, "get_accelerator", lambda: fake_accelerator)
+    monkeypatch.setattr(graph_profile, "_get_mem_usage_out_of_torch", lambda: 0)
+    monkeypatch.setattr(graph_profile, "is_comm_op", lambda node: False)
+    monkeypatch.setattr(graph_profile, "is_release_node", lambda node: False)
+    monkeypatch.setattr(graph_profile.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(graph_profile.dist, "get_rank", lambda: 0)
+
+    timestamps = iter(range(20))
+    monkeypatch.setattr(graph_profile.time, "time", lambda: next(timestamps))
+
+    def timed_identity(x):
+        graph_profile.time.time()
+        return x
+
+    graph = Graph()
+    x = graph.placeholder("x")
+    y = graph.call_function(timed_identity, (x, ))
+    graph.output(y)
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    interpreter = graph_profile.ProfilingInterpreter(gm, iteration=3, warmup=2)
+    interpreter.run(torch.ones(1))
+
+    call_node = next(node for node in gm.graph.nodes if node.op == "call_function")
+    assert call_node.meta["wall_time"] == pytest.approx((4 / 3) * 1000)
+
+
+def test_memory_profiling_interpreter_clears_gathered_params_after_failure(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    monkeypatch.setattr(graph_profile, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(graph_profile, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(graph_profile, "_all_real_if_tensor", lambda args: True)
+    monkeypatch.setattr(graph_profile, "_get_mem_usage_out_of_torch", lambda: 0)
+
+    def raise_from_run(self, *args):
+        raise RuntimeError("synthetic memory profile failure")
+
+    monkeypatch.setattr(graph_profile.Interpreter, "run", raise_from_run)
+
+    interpreter = graph_profile.MemoryProfilingInterpreter(_make_empty_graph_module())
+    interpreter.mem_record.append(("partial", 1, 1, 1))
+
+    assert interpreter.run() is None
+    assert not interpreter.profile_complete
+    assert interpreter.mem_record == []
+    assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]
+
+
+def test_memory_profiling_interpreter_disables_profiling_if_cleanup_fails(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    def fail_clear():
+        fake_handle.events.append(("clear", None))
+        raise RuntimeError("cleanup failed")
+
+    fake_handle.clear_all_gathered_params = fail_clear
+
+    monkeypatch.setattr(graph_profile, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(graph_profile, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(graph_profile, "_all_real_if_tensor", lambda args: True)
+    monkeypatch.setattr(graph_profile, "_get_mem_usage_out_of_torch", lambda: 0)
+    monkeypatch.setattr(graph_profile.Interpreter, "run", lambda self, *args: None)
+
+    interpreter = graph_profile.MemoryProfilingInterpreter(_make_empty_graph_module())
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        interpreter.run()
+
+    assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]

--- a/tests/unit/v1/compile/test_partitioner.py
+++ b/tests/unit/v1/compile/test_partitioner.py
@@ -1,0 +1,46 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import torch
+from torch.fx import Graph, GraphModule
+from torch.utils.checkpoint import CheckpointPolicy
+
+import deepspeed.compile.partitioner as partitioner
+
+
+def test_recompute_param_aliases_leaves_unrelated_activations_to_min_cut(monkeypatch):
+    monkeypatch.setattr(partitioner, "get_no_copy_ops", lambda: {torch.ops.aten.view.default})
+
+    graph = Graph()
+    param = graph.placeholder("param")
+    activation = graph.placeholder("activation")
+    param_alias = graph.call_function(torch.ops.aten.view.default, args=(param, [4]))
+    activation_node = graph.call_function(torch.ops.aten.neg.default, args=(activation, ))
+    graph.output((param_alias, activation_node))
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    partitioner._recompute_param_aliases(gm.graph, [(0, 1, torch.Size([4]))])
+
+    assert param_alias.meta["recompute"] == CheckpointPolicy.MUST_RECOMPUTE
+    assert "recompute" not in activation_node.meta
+    assert all(node.meta["ac_graph_id"] == 1 for node in gm.graph.nodes)
+
+
+def test_recompute_param_aliases_preserves_existing_non_param_policy(monkeypatch):
+    monkeypatch.setattr(partitioner, "get_no_copy_ops", lambda: {torch.ops.aten.view.default})
+
+    graph = Graph()
+    param = graph.placeholder("param")
+    activation = graph.placeholder("activation")
+    param_alias = graph.call_function(torch.ops.aten.view.default, args=(param, [4]))
+    activation_node = graph.call_function(torch.ops.aten.neg.default, args=(activation, ))
+    activation_node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+    graph.output((param_alias, activation_node))
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    partitioner._recompute_param_aliases(gm.graph, [(0, 1, torch.Size([4]))])
+
+    assert param_alias.meta["recompute"] == CheckpointPolicy.MUST_RECOMPUTE
+    assert activation_node.meta["recompute"] == CheckpointPolicy.MUST_SAVE

--- a/tests/unit/v1/compile/test_selective_gather.py
+++ b/tests/unit/v1/compile/test_selective_gather.py
@@ -43,7 +43,7 @@ def _make_param(numel, ds_persist=False):
                            param=SimpleNamespace(ds_persist=ds_persist, ds_shape=(numel, )))
 
 
-def test_compute_persistence_budget_prefers_peak_resident_alloc():
+def test_compute_persistence_budget_uses_transient_peak_for_headroom():
     budget = selective_gather_pass._compute_persistence_budget(all_graph_mem_records=[[("fwd", 700, 0, 980)],
                                                                                       [("bwd", 720, 20, 800)]],
                                                                total_mem=1000,
@@ -52,11 +52,11 @@ def test_compute_persistence_budget_prefers_peak_resident_alloc():
     assert budget["usable_mem"] == 900
     assert budget["peak_resident_alloc"] == 720
     assert budget["transient_peak"] == 980
-    assert budget["available_mem"] == 180
+    assert budget["available_mem"] == 0
     assert budget["profiled_list_count"] == 2
 
 
-def test_compute_persistence_budget_clamps_when_resident_alloc_exceeds_budget():
+def test_compute_persistence_budget_clamps_when_transient_peak_exceeds_budget():
     budget = selective_gather_pass._compute_persistence_budget(all_graph_mem_records=[[("fwd", 920, 0, 980)],
                                                                                       [("bwd", 910, -10, 950)]],
                                                                total_mem=1000,
@@ -64,10 +64,11 @@ def test_compute_persistence_budget_clamps_when_resident_alloc_exceeds_budget():
 
     assert budget["usable_mem"] == 900
     assert budget["peak_resident_alloc"] == 920
+    assert budget["transient_peak"] == 980
     assert budget["available_mem"] == 0
 
 
-def test_selective_gather_sets_persistent_params_when_resident_headroom_exists(monkeypatch):
+def test_selective_gather_sets_persistent_params_when_transient_headroom_exists(monkeypatch):
     fake_handle = FakeDeepCompileHandle()
 
     monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=220))
@@ -79,7 +80,7 @@ def test_selective_gather_sets_persistent_params_when_resident_headroom_exists(m
         0:
         ProfilingResult(fwd_graph=SimpleNamespace(nodes=[]),
                         bwd_graph=SimpleNamespace(nodes=[]),
-                        fwd_mem=[("fwd", 700, 0, 950)],
+                        fwd_mem=[("fwd", 700, 0, 800)],
                         bwd_mem=[("bwd", 680, -20, 720)])
     }
     param_manager = {
@@ -106,3 +107,128 @@ def test_selective_gather_sets_persistent_params_when_resident_headroom_exists(m
 
     assert returned is gm
     assert fake_handle.persistent_ds_ids == [1]
+
+
+def test_selective_gather_uses_profiled_headroom_instead_of_current_available_memory(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=1000))
+    monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+
+    profiling_results = {
+        0:
+        ProfilingResult(fwd_graph=SimpleNamespace(nodes=[]),
+                        bwd_graph=SimpleNamespace(nodes=[]),
+                        fwd_mem=[("fwd", 780, 0, 780)],
+                        bwd_mem=[("bwd", 760, -20, 780)])
+    }
+    param_manager = {
+        0:
+        SimpleNamespace(params={
+            "small": _make_param(10),
+            "medium": _make_param(20),
+            "large": _make_param(30),
+        },
+                        ds_ids={
+                            "small": 1,
+                            "medium": 2,
+                            "large": 3,
+                        })
+    }
+    gm = object()
+
+    returned = selective_gather_pass.selective_gather(gm,
+                                                      graph_id=0,
+                                                      graph_order=[(0, True)],
+                                                      profiling_results=profiling_results,
+                                                      create_inputs_fn=None,
+                                                      mem_budget=0.0,
+                                                      param_manager=param_manager,
+                                                      bwd=True)
+
+    assert returned is gm
+    assert fake_handle.persistent_ds_ids == [1, 2]
+
+
+def test_selective_gather_uses_profiled_headroom_when_current_available_memory_is_low(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=100))
+    monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+
+    profiling_results = {
+        0:
+        ProfilingResult(fwd_graph=SimpleNamespace(nodes=[]),
+                        bwd_graph=SimpleNamespace(nodes=[]),
+                        fwd_mem=[("fwd", 780, 0, 780)],
+                        bwd_mem=[("bwd", 760, -20, 780)])
+    }
+    param_manager = {
+        0:
+        SimpleNamespace(params={
+            "small": _make_param(10),
+            "medium": _make_param(20),
+            "large": _make_param(30),
+        },
+                        ds_ids={
+                            "small": 1,
+                            "medium": 2,
+                            "large": 3,
+                        })
+    }
+    gm = object()
+
+    returned = selective_gather_pass.selective_gather(gm,
+                                                      graph_id=0,
+                                                      graph_order=[(0, True)],
+                                                      profiling_results=profiling_results,
+                                                      create_inputs_fn=None,
+                                                      mem_budget=0.0,
+                                                      param_manager=param_manager,
+                                                      bwd=True)
+
+    assert returned is gm
+    assert fake_handle.persistent_ds_ids == [1, 2]
+
+
+def test_selective_gather_skips_persistence_when_memory_profile_incomplete(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=1000))
+    monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+
+    profiling_results = {
+        0:
+        ProfilingResult(fwd_graph=SimpleNamespace(nodes=[]),
+                        bwd_graph=SimpleNamespace(nodes=[]),
+                        needs_backward=True,
+                        fwd_mem=[("fwd", 700, 0, 780)],
+                        bwd_mem=[("partial_bwd", 720, 20, 780)],
+                        bwd_mem_complete=False)
+    }
+    param_manager = {
+        0: SimpleNamespace(params={
+            "small": _make_param(10),
+        }, ds_ids={
+            "small": 1,
+        })
+    }
+    gm = object()
+
+    returned = selective_gather_pass.selective_gather(gm,
+                                                      graph_id=0,
+                                                      graph_order=[(0, True)],
+                                                      profiling_results=profiling_results,
+                                                      create_inputs_fn=None,
+                                                      mem_budget=0.0,
+                                                      param_manager=param_manager,
+                                                      bwd=True)
+
+    assert returned is gm
+    assert fake_handle.persistent_ds_ids == []


### PR DESCRIPTION
This PR reduces DeepCompile ZeRO-3 memory pressure in profiling and compiled backward by fixing three related issues:

- Let the partitioner keep using its min-cut rematerialization policy for non-parameter activations, while still forcing ZeRO-3 parameter aliases/casts to be recomputed.
- Compute selective-gather persistence capacity from profiled transient headroom instead of current allocator availability.
- Avoid retaining temporary profiling outputs across warmup/measured profiling iterations, and clear gathered ZeRO-3 parameters when profiling exits through an exception.
- Mark incomplete memory profiles explicitly, synchronize the completion status across ranks, and skip profile-dependent prefetch/selective-gather decisions when profiling data is incomplete.