### PR TITLE
Fix Python 3.9 import-time TypeError in AutoEP ep_router

### DIFF
--- a/deepspeed/moe/ep_router.py
+++ b/deepspeed/moe/ep_router.py
@@ -15,6 +15,8 @@ This module is self-contained: no imports from deepspeed.module_inject
 or deepspeed.runtime.
 """
 
+from __future__ import annotations
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/tests/unit/v1/moe/test_autoep_unit.py
+++ b/tests/unit/v1/moe/test_autoep_unit.py
@@ -4,6 +4,7 @@
 # DeepSpeed Team
 """Compact critical-path tests for AutoEP."""
 
+import ast
 import inspect
 from collections import OrderedDict
 from types import SimpleNamespace
@@ -1109,3 +1110,66 @@ class TestModelDetectionAndReplacement:
         assert replaced.router.e_score_correction_bias is not None
         torch.testing.assert_close(replaced.router.e_score_correction_bias, source_bias)
         assert ["router.e_score_correction_bias"] in [call["names"] for call in FakeGatheredParameters.calls]
+
+
+def _eager_pep604_lines(module):
+    """Line numbers where a module evaluates PEP 604 unions at import time."""
+    tree = ast.parse(inspect.getsource(module))
+    defers_annotations = any(
+        isinstance(node, ast.ImportFrom) and node.module == "__future__" and any(alias.name == "annotations"
+                                                                                 for alias in node.names)
+        for node in tree.body)
+    if defers_annotations:
+        return []
+    offending_lines = []
+    for node in ast.walk(tree):
+        annotations = []
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            arguments = node.args
+            for arg in arguments.args + arguments.posonlyargs + arguments.kwonlyargs + [
+                    arguments.vararg, arguments.kwarg
+            ]:
+                if arg is not None and arg.annotation is not None:
+                    annotations.append(arg.annotation)
+            if node.returns is not None:
+                annotations.append(node.returns)
+        elif isinstance(node, ast.AnnAssign):
+            annotations.append(node.annotation)
+        for annotation in annotations:
+            for sub_node in ast.walk(annotation):
+                if isinstance(sub_node, ast.BinOp) and isinstance(sub_node.op, ast.BitOr):
+                    offending_lines.append(sub_node.lineno)
+    return sorted(set(offending_lines))
+
+
+class TestPy39AnnotationSafety:
+
+    def test_autoep_import_chain_defers_pep604_annotations(self):
+        """PEP 604 unions (``int | None``) in def signatures or class-level
+        annotations are evaluated at import time, so on Python 3.9 they raise
+        TypeError while the module is imported; that escapes the engine's
+        ``except ImportError`` guards around AutoEP and breaks every
+        ``deepspeed.initialize()`` (issue #8102). Every module in the AutoEP
+        import chain must defer annotation evaluation with
+        ``from __future__ import annotations``."""
+        import deepspeed.moe.ep_count as ep_count
+        import deepspeed.moe.ep_experts as ep_experts
+        import deepspeed.moe.ep_kernels as ep_kernels
+        import deepspeed.moe.ep_router as ep_router
+        import deepspeed.module_inject.auto_ep as auto_ep
+        import deepspeed.module_inject.auto_ep_config as auto_ep_config
+        import deepspeed.module_inject.auto_ep_layer as auto_ep_layer
+        import deepspeed.module_inject.auto_ep_preset_adapters as preset_adapters
+        import deepspeed.module_inject.auto_ep_presets.base as presets_base
+        import deepspeed.module_inject.auto_ep_presets.registry as presets_registry
+
+        autoep_import_chain = [
+            ep_count, ep_experts, ep_kernels, ep_router, ep_repack, auto_ep, auto_ep_config, auto_ep_layer,
+            preset_adapters, presets_base, presets_registry
+        ]
+        for module in autoep_import_chain:
+            offending_lines = _eager_pep604_lines(module)
+            assert not offending_lines, (
+                f"{module.__name__} evaluates PEP 604 unions at import time (lines {offending_lines}); "
+                f"on Python 3.9 this raises TypeError during import and escapes the engine's "
+                f"except-ImportError guards (issue #8102). Add 'from __future__ import annotations'.")


### PR DESCRIPTION
## What

Fixes #8102.

On Python 3.9, every `deepspeed.initialize()` call crashes at import time with:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Root cause

`deepspeed/moe/ep_router.py` uses PEP 604 unions in eagerly evaluated annotation positions (`num_expert_groups: int | None` and `num_limited_groups: int | None` in `TokenChoiceTopKRouter.__init__`, `expert_bias: torch.Tensor | None = None` in `forward`). Def-signature annotations are evaluated at function-definition time, and an AST scan of the whole package shows `ep_router.py` is the only module that uses this syntax without `from __future__ import annotations`; every sibling AutoEP module (`auto_ep.py`, `auto_ep_layer.py`, `auto_ep_config.py`, `ep_repack.py`, the presets) already has the future import, so their annotations are deferred and harmless.

The crash escapes DeepSpeed's own safety net: `engine.py` wraps `from deepspeed.module_inject.auto_ep_layer import AutoEPMoELayer` (which imports `ep_router`) in `except ImportError` inside `_configure_distributed_model`, but the exception raised is `TypeError`, not `ImportError`, so it propagates out of every `deepspeed.initialize()` on Python 3.9. Note the issue body points at `auto_ep.py` / `auto_ep_presets/base.py`; those files already defer annotations, `ep_router.py` is the actual offender.

`setup.py` still advertises Python 3.8+ support, so this restores importability rather than changing the syntax: the fix adds the same `from __future__ import annotations` line the rest of AutoEP uses. No runtime behavior change.

## Reproduction

Verified on real Python 3.9.6: executing current-master `ep_router.py` raises exactly the reported `TypeError`; with the future import added it imports cleanly.

## Test

Adds `TestPy39AnnotationSafety::test_autoep_import_chain_defers_pep604_annotations` to `tests/unit/v1/moe/test_autoep_unit.py`: it AST-scans every module in the AutoEP import chain and fails, naming the module and line numbers, if any of them evaluates a PEP 604 union at import time without deferring annotations. It is version-independent (fails on the bug even when CI runs 3.10+). Fails before this fix (`deepspeed.moe.ep_router ... lines [53, 54, 137]`), passes after. Full `test_autoep_unit.py` suite: 60 passed, 1 skipped. `pre-commit run` clean on both changed files.
