### PR TITLE
Add input validation for save_checkpoint and warmup LR schedulers

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -4327,6 +4327,9 @@ class DeepSpeedEngine(Module):
         process with rank 0.
 
         """
+        if not save_dir:
+            raise ValueError(f"save_dir must be a non-empty string, got {save_dir!r}")
+
         if self._optimizer_has_ckpt_event_prologue():
             # Custom preparation for checkpoint save, if applicable
             self.optimizer.checkpoint_event_prologue()

--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -664,6 +664,9 @@ class WarmupLR(object):
                  warmup_type: str = WARMUP_LOG_RATE,
                  last_batch_iteration: int = -1):
 
+        if not isinstance(warmup_num_steps, int) or warmup_num_steps <= 0:
+            raise ValueError(f"warmup_num_steps must be a positive integer, got {warmup_num_steps}")
+
         self.optimizer = get_torch_optimizer(optimizer)
 
         if warmup_max_lr is None:
@@ -809,6 +812,9 @@ class WarmupCosineLR(object):
                  cos_min_ratio: float = 0.0001,
                  warmup_type: str = WARMUP_LOG_RATE,
                  last_batch_iteration: int = -1):
+
+        if not isinstance(warmup_num_steps, int) or warmup_num_steps <= 0:
+            raise ValueError(f"warmup_num_steps must be a positive integer, got {warmup_num_steps}")
 
         self.optimizer = get_torch_optimizer(optimizer)
 

--- a/tests/unit/checkpoint/test_tag_validation.py
+++ b/tests/unit/checkpoint/test_tag_validation.py
@@ -60,3 +60,26 @@ class TestCheckpointValidationTag(DistributedTest):
 
         with pytest.raises(deepspeed.DeepSpeedConfigError):
             model, _, _, _ = deepspeed.initialize(config=config_dict, model=model, model_parameters=model.parameters())
+
+
+class TestSaveCheckpointInvalidDir(DistributedTest):
+    world_size = 2
+
+    @pytest.mark.parametrize('save_dir', [None, ""])
+    def test_save_checkpoint_empty_dir(self, save_dir):
+        config_dict = {
+            "train_batch_size": 2,
+            "steps_per_print": 1,
+            "optimizer": {
+                "type": "Adam",
+                "params": {
+                    "lr": 0.00015
+                }
+            }
+        }
+        hidden_dim = 10
+        model = SimpleModel(hidden_dim)
+
+        model, _, _, _ = deepspeed.initialize(config=config_dict, model=model, model_parameters=model.parameters())
+        with pytest.raises(ValueError):
+            model.save_checkpoint(save_dir=save_dir)

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -16,6 +16,7 @@ from deepspeed.runtime.lr_schedules import ONE_CYCLE, CYCLE_MIN_LR, CYCLE_MAX_LR
 from deepspeed.runtime.lr_schedules import CYCLE_MIN_MOM, CYCLE_MAX_MOM, DECAY_MOM_RATE
 from deepspeed.runtime.lr_schedules import WARMUP_DECAY_LR, TOTAL_NUM_STEPS
 from deepspeed.runtime.lr_schedules import WARMUP_COSINE_LR, WARMUP_MIN_RATIO, COS_MIN_RATIO, WarmupCosineLR
+from deepspeed.runtime.lr_schedules import WarmupLR, WarmupDecayLR
 
 
 def _verify_continuous_decrease(values):
@@ -543,3 +544,17 @@ def test_warmup_cosine_lr_initializes_all_param_groups():
     assert scheduler.get_lr() == pytest.approx(expected_lrs)
     assert scheduler.get_last_lr() == pytest.approx(expected_lrs)
     assert [group["lr"] for group in optimizer.param_groups] == pytest.approx(expected_lrs)
+
+
+@pytest.mark.parametrize("scheduler_cls", [WarmupLR, WarmupDecayLR, WarmupCosineLR])
+@pytest.mark.parametrize("bad_warmup_num_steps", [None, -5])
+def test_warmup_schedulers_reject_invalid_warmup_num_steps(scheduler_cls, bad_warmup_num_steps):
+    param = torch.nn.Parameter(torch.zeros(1))
+    optimizer = torch.optim.Adam([param], lr=0.001)
+
+    kwargs = {"optimizer": optimizer, "warmup_num_steps": bad_warmup_num_steps}
+    if scheduler_cls in (WarmupDecayLR, WarmupCosineLR):
+        kwargs["total_num_steps"] = 100
+
+    with pytest.raises(ValueError):
+        scheduler_cls(**kwargs)


### PR DESCRIPTION
## Summary
Fixes #8097. Some public-facing functions silently accept invalid input (None, empty string, negative numbers) leading to confusing downstream errors or hangs. This PR adds explicit validation in two places:

- `DeepSpeedEngine.save_checkpoint`: raises `ValueError` if `save_dir` is None/empty, before any rank-synchronization logic runs (prevents multi-GPU hang from partial-rank failure).
- `WarmupLR.__init__` / `WarmupCosineLR.__init__`: raises `ValueError` if `warmup_num_steps` isn't a positive int. `WarmupDecayLR` inherits the check via `WarmupLR`.

## Test plan
- [x] `pytest tests/unit/runtime/test_lr_schedulers.py -k warmup` — new parametrized test passes for all 3 scheduler classes
- [x] `pytest --forked tests/unit/checkpoint/test_tag_validation.py` — new test added; skips locally (needs 2 GPUs, unavailable on this machine), expected to run in CI
- [x] `pre-commit run` on all changed files — clean