### PR TITLE
fix(zero-offload): mitigate CPU RSS waste on ZeRO-2 optimizer offload (#7693)

### DIFF
--- a/deepspeed/ops/adam/cpu_adam.py
+++ b/deepspeed/ops/adam/cpu_adam.py
@@ -10,6 +10,26 @@ from deepspeed.utils.logging import should_log_le
 from deepspeed.ops.op_builder import CPUAdamBuilder
 
 
+def _malloc_trim():
+    """Release freed CPU memory back to the OS on Linux.
+
+    PyTorch's CPU allocator caches freed memory blocks by size rather than
+    returning them to the OS.  After the first optimizer step several large
+    temporary tensors (contiguous copies, gradient scale buffers, etc.) have
+    been created and freed, but their memory remains pinned in the allocator
+    cache and is not reused by subsequent differently-sized allocations.
+
+    malloc_trim(0) asks glibc to release freed arena memory back to the OS.
+    This is a best-effort RSS mitigation for CPU-offload workloads, not a
+    correctness fix.  This is a no-op on non-Linux platforms.
+    """
+    try:
+        import ctypes
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError):
+        pass
+
+
 class DeepSpeedCPUAdam(torch.optim.Optimizer):
     optimizer_id = 0
 
@@ -160,6 +180,18 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
                 self.ds_opt_adam.adam_update(self.opt_id, state['step'], group['lr'], beta1, beta2, group['eps'],
                                              group['weight_decay'], group['bias_correction'], p.data, p.grad.data,
                                              state['exp_avg'], state['exp_avg_sq'])
+
+            # ZeRO-2 CPU offload calls step() once per param group.  Trim after
+            # each group's first step so later groups' lazy state init is also
+            # released. See #7693 / Codex review on #8132.
+            trimmed = getattr(self, '_trimmed_groups', None)
+            if trimmed is None:
+                trimmed = set()
+                self._trimmed_groups = trimmed
+            if group_id not in trimmed:
+                trimmed.add(group_id)
+                _malloc_trim()
+
         return loss
 
     @torch.no_grad()
@@ -197,6 +229,16 @@ class DeepSpeedCPUAdam(torch.optim.Optimizer):
                 self.ds_opt_adam.adam_update(self.opt_id, state['step'], group['lr'], beta1, beta2, group['eps'],
                                              group['weight_decay'], group['bias_correction'], p.data, p.grad.data,
                                              state['exp_avg'], state['exp_avg_sq'])
+
+        # Trim after this subgroup's first step (ZeRO-3 subgroup path).
+        trimmed = getattr(self, '_trimmed_groups', None)
+        if trimmed is None:
+            trimmed = set()
+            self._trimmed_groups = trimmed
+        if subgroup_id not in trimmed:
+            trimmed.add(subgroup_id)
+            _malloc_trim()
+
         return loss
 
     @torch.no_grad()

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2306,6 +2306,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             clip = torch.clamp(clip, min=1.0)
             combined_scale = clip * self.loss_scale
 
+        # Only convert to a Python float on the CPU-offload path.  On GPU ZeRO,
+        # total_norm / combined_scale may live on the accelerator; an unconditional
+        # float() would force a device sync every step.  The allocator concern in
+        # #7693 is CPU-specific, so keep the GPU path on-device. See #7693 / #8132.
+        if self.cpu_offload:
+            combined_scale = float(combined_scale)
+
         for grad in grad_groups_flat:
             if isinstance(grad, list):
                 sub_partitions = grad

--- a/tests/unit/runtime/zero/test_cpu_offload_memory.py
+++ b/tests/unit/runtime/zero/test_cpu_offload_memory.py
@@ -1,0 +1,146 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+import torch
+
+try:
+    from deepspeed.ops.adam.cpu_adam import DeepSpeedCPUAdam, _malloc_trim
+    _cpu_adam_available = True
+except (ImportError, ModuleNotFoundError):
+    _cpu_adam_available = False
+
+try:
+    from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
+    _zero_optimizer_available = True
+except (ImportError, ModuleNotFoundError):
+    _zero_optimizer_available = False
+
+
+@pytest.mark.skipif(not _cpu_adam_available, reason="DeepSpeedCPUAdam not available")
+def test_malloc_trim_helper_exists():
+    """Verify _malloc_trim helper is importable and callable."""
+    assert callable(_malloc_trim)
+    # Should not raise on any platform (no-op on non-Linux)
+    _malloc_trim()
+
+
+@pytest.mark.skipif(not _cpu_adam_available, reason="DeepSpeedCPUAdam not available")
+def test_malloc_trim_called_per_param_group(monkeypatch):
+    """Verify _malloc_trim runs once per param group on first step.
+
+    ZeRO-2 CPU offload invokes step() once per group; an optimizer-wide flag
+    would skip trim for later groups (Codex review on #8132).
+    """
+    p0 = torch.nn.Parameter(torch.randn(50, device='cpu'))
+    p1 = torch.nn.Parameter(torch.randn(50, device='cpu'))
+    optimizer = DeepSpeedCPUAdam([{'params': [p0]}, {'params': [p1]}], lr=1e-3)
+
+    call_count = 0
+
+    def fake_trim():
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr("deepspeed.ops.adam.cpu_adam._malloc_trim", fake_trim)
+
+    # First call: both groups step together (normal DeepSpeedCPUAdam.step)
+    p0.grad = torch.randn_like(p0)
+    p1.grad = torch.randn_like(p1)
+    optimizer.step()
+    assert call_count == 2, "malloc_trim should run once per param group"
+
+    # Second call: no additional trim
+    p0.grad = torch.randn_like(p0)
+    p1.grad = torch.randn_like(p1)
+    optimizer.step()
+    assert call_count == 2, "malloc_trim should not re-run for already-trimmed groups"
+
+
+@pytest.mark.skipif(not _cpu_adam_available, reason="DeepSpeedCPUAdam not available")
+def test_cpu_adam_first_step_initializes_optimizer_states():
+    """Smoke test: first CPUAdam step creates contiguous fp32 optimizer states."""
+    param = torch.randn(1000, device='cpu', dtype=torch.float32)
+    grad = torch.randn(1000, device='cpu', dtype=torch.float32)
+    optimizer = DeepSpeedCPUAdam([param], lr=1e-3)
+
+    param.grad = grad
+    optimizer.step()
+
+    state = optimizer.state[param]
+    assert 'exp_avg' in state
+    assert 'exp_avg_sq' in state
+    assert state['exp_avg'].is_contiguous()
+    assert state['exp_avg_sq'].is_contiguous()
+    assert state['exp_avg'].numel() == param.numel()
+    assert state['exp_avg_sq'].numel() == param.numel()
+
+
+@pytest.mark.skipif(not _zero_optimizer_available, reason="DeepSpeedZeroOptimizer not available")
+def test_unscale_and_clip_grads_cpu_offload_uses_float_scale():
+    """On cpu_offload, combined_scale is converted to float before mul_."""
+
+    class MockOptimizer:
+        loss_scale = 16.0
+        clip_grad = 1.0
+        cpu_offload = True
+
+        unscale_and_clip_grads = DeepSpeedZeroOptimizer.unscale_and_clip_grads
+
+    opt = MockOptimizer()
+    grad = torch.randn(100, device='cpu', dtype=torch.float32)
+    original_data_ptr = grad.data_ptr()
+    total_norm = torch.tensor(10.0, device='cpu', dtype=torch.float32)
+
+    opt.unscale_and_clip_grads([grad], total_norm)
+
+    assert grad.data_ptr() == original_data_ptr, \
+        "unscale_and_clip_grads should not allocate a new tensor"
+
+
+@pytest.mark.skipif(not _zero_optimizer_available, reason="DeepSpeedZeroOptimizer not available")
+def test_unscale_and_clip_grads_no_clip():
+    """Verify unscale_and_clip_grads works correctly when clip_grad is 0."""
+
+    class MockOptimizer:
+        loss_scale = 16.0
+        clip_grad = 0.0
+        cpu_offload = True
+
+        unscale_and_clip_grads = DeepSpeedZeroOptimizer.unscale_and_clip_grads
+
+    opt = MockOptimizer()
+    grad = torch.randn(100, device='cpu', dtype=torch.float32)
+    original_data_ptr = grad.data_ptr()
+    original_values = grad.clone()
+
+    total_norm = torch.tensor(10.0, device='cpu', dtype=torch.float32)
+    opt.unscale_and_clip_grads([grad], total_norm)
+
+    expected = original_values / opt.loss_scale
+    assert torch.allclose(grad, expected, rtol=1e-5)
+    assert grad.data_ptr() == original_data_ptr
+
+
+@pytest.mark.skipif(not _zero_optimizer_available, reason="DeepSpeedZeroOptimizer not available")
+def test_unscale_and_clip_grads_gpu_path_skips_float_conversion():
+    """Without cpu_offload, do not force float() (avoids GPU sync regression)."""
+
+    class MockOptimizer:
+        loss_scale = 16.0
+        clip_grad = 0.0
+        cpu_offload = False
+
+        unscale_and_clip_grads = DeepSpeedZeroOptimizer.unscale_and_clip_grads
+
+    opt = MockOptimizer()
+    grad = torch.randn(100, device='cpu', dtype=torch.float32)
+    original = grad.clone()
+    total_norm = torch.tensor(10.0, device='cpu', dtype=torch.float32)
+
+    # clip_grad==0 keeps combined_scale as loss_scale (float already); just
+    # ensure the non-offload path still scales correctly.
+    opt.unscale_and_clip_grads([grad], total_norm)
+    assert torch.allclose(grad, original / opt.loss_scale, rtol=1e-5)


### PR DESCRIPTION
## Summary

Best-effort mitigations for CPU RSS waste in ZeRO-2 + CPU optimizer offload tracked by #7693.

This PR does **not** claim a complete resolution of all overhead in that issue (H2D cast/copy buffer tiling and other unaccounted bytes remain open). Another commenter also reported being unable to reproduce the two ~4 bytes/param leaks on a newer PyTorch build.

## Changes

### 1. `unscale_and_clip_grads` — float conversion only on CPU offload (`stage_1_and_2.py`)

Convert `combined_scale` to a Python `float` **only when `cpu_offload` is enabled**, so `mul_` receives a scalar on the CPU path.

Per Codex review: an unconditional `float()` would read a CUDA scalar back to Python when ZeRO-1/2 runs without CPU offload and `clip_grad > 0`, forcing a device sync every step. The GPU clipping path stays on-device.

### 2. `DeepSpeedCPUAdam` — per-group `malloc_trim(0)` (`cpu_adam.py`)

Call `malloc_trim(0)` once per param group / subgroup on that group's **first** step.

Per Codex review: ZeRO-2 CPU offload invokes `step()` once per `bit16_groups` entry. An optimizer-wide “first step” flag would skip trim for later groups after group 0. Per-group tracking fixes that.

This is a best-effort glibc RSS mitigation (Linux-only no-op elsewhere), not a correctness fix.

### 3. Tests (`test_cpu_offload_memory.py`)

- per-group trim call count
- CPU-offload float unscale path keeps storage
- non-offload path still scales correctly
- LF line endings

## Removed after review

- Dropped the `ds_adam_step` `is_contiguous()` guard in `cpu_adam_impl.cpp`. As @delock pointed out, `Tensor.contiguous()` already returns `self` when the tensor is contiguous, so the explicit check was a no-op.

## Test plan

- [x] `test_malloc_trim_helper_exists`
- [x] `test_malloc_trim_called_per_param_group`
- [x] `test_cpu_adam_first_step_initializes_optimizer_states`
- [x] `test_unscale_and_clip_grads_cpu_offload_uses_float_scale`
- [x] `test_unscale_and_clip_grads_no_clip`
- [x] `test_unscale_and_clip_grads_gpu_path_skips_float_conversion`

## Notes

- Addressed Codex P2 comments on #8132 (GPU sync + per-group trim).
- Addressed @delock review: removed unnecessary `.contiguous()` change.
- DCO: author/committer email matches `Signed-off-by: liuyun7345 <liuyun7345@sina.com>`.

Addresses #7693
