### PR TITLE
Fix CommsLogger.stop_profiling_comms not disabling global profiling

### DIFF
--- a/deepspeed/utils/comms_logging.py
+++ b/deepspeed/utils/comms_logging.py
@@ -91,7 +91,7 @@ class CommsLogger:
         self.prof_all = True
 
     def stop_profiling_comms(self):
-        self.prof_all = True
+        self.prof_all = False
 
     # E.g. start_profiling_op('all_reduce')
     def start_profiling_op(self, op_name_list):

--- a/tests/unit/comm/test_comms_logger.py
+++ b/tests/unit/comm/test_comms_logger.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) DeepSpeed Team.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/tests/unit/comm/test_comms_logger.py
+++ b/tests/unit/comm/test_comms_logger.py
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from deepspeed.utils.comms_logging import CommsLogger
+
+
+def test_stop_profiling_comms_disables_prof_all():
+    # start_profiling_comms()/stop_profiling_comms() toggle the global comm
+    # profiling flag prof_all. stop_profiling_comms() must clear it; otherwise
+    # global comm profiling can never be turned off once it has been started.
+    comms_logger = CommsLogger()
+
+    comms_logger.start_profiling_comms()
+    assert comms_logger.prof_all is True
+
+    comms_logger.stop_profiling_comms()
+    assert comms_logger.prof_all is False


### PR DESCRIPTION
## What

`CommsLogger.stop_profiling_comms()` set `self.prof_all = True`, the same value `start_profiling_comms()` sets, so calling stop was a no-op:

```python
def start_profiling_comms(self):
    self.prof_all = True

def stop_profiling_comms(self):
    self.prof_all = True   # should be False
```

`prof_all` is the flag that makes the comms logger profile every collective (`deepspeed/comm/comm.py` gates on `... or comms_logger.prof_all or ...`). Because stop set it back to `True`, once global comm profiling was started it could never be turned off. The sibling pair in the same class, `start_profiling_op` / `stop_profiling_op`, correctly adds then removes ops, which confirms the intended start=on / stop=off asymmetry.

## Fix

Set `prof_all = False` in `stop_profiling_comms()`.

## Test

Added `tests/unit/comm/test_comms_logger.py`, a CPU-only unit test that starts then stops comm profiling and asserts `prof_all` ends up `False`. It fails before the change (stays `True`) and passes after.
