### PR TITLE
[DeepCompile] Add lightweight pass contracts for optimization passes

### DIFF
--- a/deepspeed/compile/backend.py
+++ b/deepspeed/compile/backend.py
@@ -77,8 +77,11 @@ opt_passes = {}
 fwd_real_inputs = []
 
 
-def register_compile_pass(name: str, opt_pass_fn):
+def register_compile_pass(name: str, opt_pass_fn, contract=None):
     opt_passes[name] = opt_pass_fn
+    if contract is not None:
+        from .passes.contract import register_pass_contract
+        register_pass_contract(contract)
 
 
 def init_schedule(schedule):

--- a/deepspeed/compile/backend.py
+++ b/deepspeed/compile/backend.py
@@ -78,10 +78,11 @@ fwd_real_inputs = []
 
 
 def register_compile_pass(name: str, opt_pass_fn, contract=None):
+    from .passes.contract import register_pass_contract
     opt_passes[name] = opt_pass_fn
-    if contract is not None:
-        from .passes.contract import register_pass_contract
-        register_pass_contract(contract)
+    # Replace the callable and its contract together under the same name; contract=None clears any
+    # contract previously registered for the pass.
+    register_pass_contract(name, contract)
 
 
 def init_schedule(schedule):

--- a/deepspeed/compile/passes/contract.py
+++ b/deepspeed/compile/passes/contract.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) DeepSpeed Team.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/deepspeed/compile/passes/contract.py
+++ b/deepspeed/compile/passes/contract.py
@@ -20,9 +20,11 @@ class PassContract:
     passes that name each other in ``conflicts_with`` may not share a schedule. ``phase`` is
     informational for now and records whether a pass rewrites the forward graph, the backward
     graph, or both.
+
+    A contract does not carry the pass name: the registry key set by ``register_compile_pass`` is
+    the single source of truth for a pass's identity.
     """
 
-    name: str
     provides: FrozenSet[str] = frozenset()
     requires: FrozenSet[str] = frozenset()
     conflicts_with: FrozenSet[str] = frozenset()
@@ -36,33 +38,47 @@ class PassContractError(ValueError):
 _pass_contracts: Dict[str, PassContract] = {}
 
 
-def register_pass_contract(contract: PassContract) -> None:
-    _pass_contracts[contract.name] = contract
+def register_pass_contract(name: str, contract: Optional[PassContract]) -> None:
+    # ``contract=None`` clears any contract previously registered under ``name`` so a pass that is
+    # re-registered through the two-argument API does not keep a stale contract.
+    if contract is None:
+        _pass_contracts.pop(name, None)
+    else:
+        _pass_contracts[name] = contract
 
 
 def get_pass_contract(name: str) -> Optional[PassContract]:
     return _pass_contracts.get(name)
 
 
-def _resolve_pass_name(pass_ref, fn_to_name: Optional[Dict]) -> Optional[str]:
-    # Schedules may reference a pass either by its registered name or by its callable. We only
-    # know how to look up a contract by name, so translate callables back to their name here.
+def _resolve_pass_name(pass_ref, name_registry: Optional[Dict]) -> Optional[str]:
+    # Schedules usually reference passes by their registered name, but a user may also drop a raw
+    # callable into a schedule. Contracts are keyed by name, so resolve a callable back to its
+    # name by object identity (avoiding any reliance on the callable being hashable or comparable).
     if isinstance(pass_ref, str):
         return pass_ref
-    if fn_to_name is not None:
-        return fn_to_name.get(pass_ref)
+    if name_registry is None:
+        return None
+    matches = [name for name, fn in name_registry.items() if fn is pass_ref]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise PassContractError(f"Pass callable is registered under multiple names {sorted(matches)}; reference it by "
+                                f"name in the schedule so the intended contract can be selected.")
     return None
 
 
-def validate_schedule(schedule: List[Tuple[int, List]], fn_to_name: Optional[Dict] = None) -> None:
+def validate_schedule(schedule: List[Tuple[int, List]], name_registry: Optional[Dict] = None) -> None:
     """Validate that a DeepCompile pass schedule satisfies the registered pass contracts.
 
-    ``schedule`` uses the ``[(step, passes), ...]`` format consumed by ``init_schedule``. Each
-    entry in ``passes`` may be a registered pass name or a pass callable; pass ``fn_to_name`` to
-    resolve callables (typically ``{fn: name for name, fn in opt_passes.items()}``). Passes that
-    have no registered contract are treated as unconstrained and skipped, so mixed schedules of
-    contracted and ad-hoc passes remain valid. Raises :class:`PassContractError` on the first
-    unmet requirement or conflict.
+    ``schedule`` uses the ``[(step, passes), ...]`` format consumed by ``init_schedule``. Validate
+    it before names are converted to callables so the pass identity the user selected is preserved.
+    Each entry in ``passes`` is normally a registered pass name; a raw callable is resolved back to
+    its name through ``name_registry`` (the ``{name: fn}`` registry) by object identity, and a
+    callable registered under more than one name must instead be referenced by name. Passes with no
+    registered contract are treated as unconstrained and skipped, so mixed schedules of contracted
+    and ad-hoc passes remain valid. Raises :class:`PassContractError` on the first unmet requirement
+    or conflict.
 
     Each step is validated independently: DeepCompile resets Dynamo and recompiles from the
     original graph at every launched step (see ``launch_compile_passes``), so capabilities a pass
@@ -74,7 +90,7 @@ def validate_schedule(schedule: List[Tuple[int, List]], fn_to_name: Optional[Dic
         applied: List[str] = []
 
         for pass_ref in passes:
-            name = _resolve_pass_name(pass_ref, fn_to_name)
+            name = _resolve_pass_name(pass_ref, name_registry)
             if name is None:
                 continue
 

--- a/deepspeed/compile/passes/contract.py
+++ b/deepspeed/compile/passes/contract.py
@@ -1,0 +1,101 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, List, Optional, Tuple
+
+# Capability tags produced and consumed by the built-in DeepCompile passes. Keeping the tags
+# in one place lets passes declare dependencies on each other without hard-coding pass names.
+CAP_Z3_GATHER_RELEASE = "z3_gather_release"
+
+
+@dataclass(frozen=True)
+class PassContract:
+    """Lightweight metadata describing what an optimization pass expects and produces.
+
+    Contracts let DeepCompile validate a pass schedule before it runs. A pass may only appear
+    after every capability it ``requires`` has been ``provides``-d by an earlier pass, and two
+    passes that name each other in ``conflicts_with`` may not share a schedule. ``phase`` is
+    informational for now and records whether a pass rewrites the forward graph, the backward
+    graph, or both.
+    """
+
+    name: str
+    provides: FrozenSet[str] = frozenset()
+    requires: FrozenSet[str] = frozenset()
+    conflicts_with: FrozenSet[str] = frozenset()
+    phase: str = "both"
+
+
+class PassContractError(ValueError):
+    """Raised when a pass schedule violates the registered pass contracts."""
+
+
+_pass_contracts: Dict[str, PassContract] = {}
+
+
+def register_pass_contract(contract: PassContract) -> None:
+    _pass_contracts[contract.name] = contract
+
+
+def get_pass_contract(name: str) -> Optional[PassContract]:
+    return _pass_contracts.get(name)
+
+
+def _resolve_pass_name(pass_ref, fn_to_name: Optional[Dict]) -> Optional[str]:
+    # Schedules may reference a pass either by its registered name or by its callable. We only
+    # know how to look up a contract by name, so translate callables back to their name here.
+    if isinstance(pass_ref, str):
+        return pass_ref
+    if fn_to_name is not None:
+        return fn_to_name.get(pass_ref)
+    return None
+
+
+def validate_schedule(schedule: List[Tuple[int, List]], fn_to_name: Optional[Dict] = None) -> None:
+    """Validate that a DeepCompile pass schedule satisfies the registered pass contracts.
+
+    ``schedule`` uses the ``[(step, passes), ...]`` format consumed by ``init_schedule``. Each
+    entry in ``passes`` may be a registered pass name or a pass callable; pass ``fn_to_name`` to
+    resolve callables (typically ``{fn: name for name, fn in opt_passes.items()}``). Passes that
+    have no registered contract are treated as unconstrained and skipped, so mixed schedules of
+    contracted and ad-hoc passes remain valid. Raises :class:`PassContractError` on the first
+    unmet requirement or conflict.
+
+    Each step is validated independently: DeepCompile resets Dynamo and recompiles from the
+    original graph at every launched step (see ``launch_compile_passes``), so capabilities a pass
+    provides in one step do not carry over to later steps. A pass must therefore find every
+    capability it requires among the passes scheduled earlier within the same step.
+    """
+    for step, passes in schedule:
+        provided: set = set()
+        applied: List[str] = []
+
+        for pass_ref in passes:
+            name = _resolve_pass_name(pass_ref, fn_to_name)
+            if name is None:
+                continue
+
+            contract = _pass_contracts.get(name)
+            if contract is None:
+                continue
+
+            missing = contract.requires - provided
+            if missing:
+                raise PassContractError(f"Pass '{name}' (step {step}) requires {sorted(missing)}, which no earlier "
+                                        f"pass provides. Passes scheduled so far: {applied}.")
+
+            # Conflicts are treated symmetrically: either pass may declare the incompatibility.
+            conflicts = set(contract.conflicts_with.intersection(applied))
+            for prev_name in applied:
+                prev_contract = _pass_contracts.get(prev_name)
+                if prev_contract is not None and name in prev_contract.conflicts_with:
+                    conflicts.add(prev_name)
+            if conflicts:
+                raise PassContractError(f"Pass '{name}' (step {step}) conflicts with already-scheduled pass(es) "
+                                        f"{sorted(conflicts)}.")
+
+            provided |= contract.provides
+            applied.append(name)

--- a/deepspeed/compile/passes/offload_adam_states.py
+++ b/deepspeed/compile/passes/offload_adam_states.py
@@ -21,10 +21,13 @@ except ImportError:
 from ..profilers import ProfilingResult
 from ..graph_param import DSGraphParamManager
 from ..fx import move_primals_to_head
+from .contract import PassContract
 
 import deepspeed.comm as dist
 
 NAME = "offload_adam_states"
+# Offloads optimizer state and does not depend on the graph-rewriting passes.
+CONTRACT = PassContract(name=NAME)
 
 
 def print_r0(msg):

--- a/deepspeed/compile/passes/offload_adam_states.py
+++ b/deepspeed/compile/passes/offload_adam_states.py
@@ -27,7 +27,7 @@ import deepspeed.comm as dist
 
 NAME = "offload_adam_states"
 # Offloads optimizer state and does not depend on the graph-rewriting passes.
-CONTRACT = PassContract(name=NAME)
+CONTRACT = PassContract()
 
 
 def print_r0(msg):

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -14,8 +14,11 @@ import deepspeed.comm as dist
 from ..profilers.comm_profile import create_predictor
 from ..profilers.graph_profile import is_profile_incomplete
 from ..graph_param import DSGraphParamManager
+from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 NAME = "prefetch"
+# Reorders the all-gathers that zero3_compile emits, so it must run after that pass.
+CONTRACT = PassContract(name=NAME, requires=frozenset({CAP_Z3_GATHER_RELEASE}))
 
 FUSE_FACTOR = 0.8
 MARGIN = 0.1

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -18,7 +18,7 @@ from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 NAME = "prefetch"
 # Reorders the all-gathers that zero3_compile emits, so it must run after that pass.
-CONTRACT = PassContract(name=NAME, requires=frozenset({CAP_Z3_GATHER_RELEASE}))
+CONTRACT = PassContract(requires=frozenset({CAP_Z3_GATHER_RELEASE}))
 
 FUSE_FACTOR = 0.8
 MARGIN = 0.1

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -16,8 +16,11 @@ from deepspeed.utils import log_dist
 from ..util import get_deepcompile_handle
 from ..graph_param import DSGraphParamManager
 from ..profilers.graph_profile import is_profile_incomplete
+from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 NAME = "selective_gather"
+# Chooses which zero3_compile all-gathers to keep resident, so it depends on that pass.
+CONTRACT = PassContract(name=NAME, requires=frozenset({CAP_Z3_GATHER_RELEASE}))
 
 max_alloc_mem = 0
 last_optimize_step = 0

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -20,7 +20,7 @@ from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 NAME = "selective_gather"
 # Chooses which zero3_compile all-gathers to keep resident, so it depends on that pass.
-CONTRACT = PassContract(name=NAME, requires=frozenset({CAP_Z3_GATHER_RELEASE}))
+CONTRACT = PassContract(requires=frozenset({CAP_Z3_GATHER_RELEASE}))
 
 max_alloc_mem = 0
 last_optimize_step = 0

--- a/deepspeed/compile/passes/zero3_compile.py
+++ b/deepspeed/compile/passes/zero3_compile.py
@@ -15,11 +15,14 @@ from ..fx import (add_postprocess, _make_node_meta, get_output_node, move_primal
                   replace_reduce_outputs_with_none, should_release_reduce_buckets)
 from ..profilers.graph_profile import ProfilingInterpreter
 from ..list_schedule import fast_free_schedule
+from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
 
 NAME = "zero3_compile"
+# Inserts the ZeRO-3 all-gather/release ops that prefetch and selective-gather later build on.
+CONTRACT = PassContract(name=NAME, provides=frozenset({CAP_Z3_GATHER_RELEASE}))
 
 
 def add_allgather(graph_id: int, graph: Graph, node: Node, ds_id: int, dtype: torch.dtype):

--- a/deepspeed/compile/passes/zero3_compile.py
+++ b/deepspeed/compile/passes/zero3_compile.py
@@ -22,7 +22,7 @@ from deepspeed.accelerator import get_accelerator
 
 NAME = "zero3_compile"
 # Inserts the ZeRO-3 all-gather/release ops that prefetch and selective-gather later build on.
-CONTRACT = PassContract(name=NAME, provides=frozenset({CAP_Z3_GATHER_RELEASE}))
+CONTRACT = PassContract(provides=frozenset({CAP_Z3_GATHER_RELEASE}))
 
 
 def add_allgather(graph_id: int, graph: Graph, node: Node, ds_id: int, dtype: torch.dtype):

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -144,6 +144,7 @@ from deepspeed.runtime.config import DtypeEnum
 from deepspeed.compile.util import (is_deepcompile_supported, get_deepcompile_handle, deepcompile_backward_prologue,
                                     deepcompile_backward_epilogue)
 from deepspeed.compile.backend import register_compile_pass, opt_passes
+from deepspeed.compile.passes.contract import validate_schedule
 from deepspeed.compile.passes import zero3_compile, prefetch, selective_gather, offload_adam_states
 from deepspeed.compile.init_z1 import init_z1
 from deepspeed.compile.init_z3 import init_z3
@@ -458,10 +459,12 @@ class DeepSpeedEngine(Module):
         self._is_compiled = False
         if is_deepcompile_supported():
             # Predefined compile passes
-            self.register_compile_pass(zero3_compile.NAME, zero3_compile.add_z3_gather_release)
-            self.register_compile_pass(prefetch.NAME, prefetch.schedule_prefetch)
-            self.register_compile_pass(selective_gather.NAME, selective_gather.selective_gather)
-            self.register_compile_pass(offload_adam_states.NAME, offload_adam_states.move_opt_states)
+            self.register_compile_pass(zero3_compile.NAME, zero3_compile.add_z3_gather_release, zero3_compile.CONTRACT)
+            self.register_compile_pass(prefetch.NAME, prefetch.schedule_prefetch, prefetch.CONTRACT)
+            self.register_compile_pass(selective_gather.NAME, selective_gather.selective_gather,
+                                       selective_gather.CONTRACT)
+            self.register_compile_pass(offload_adam_states.NAME, offload_adam_states.move_opt_states,
+                                       offload_adam_states.CONTRACT)
 
         # We now support PyTorch style backward, but it relies on the counter in ZeRO optimizers.
         # However, we need some internal APIs to count the number of only used parameters.
@@ -5455,6 +5458,7 @@ class DeepSpeedEngine(Module):
                 return [p if callable(p) else opt_passes[p] for p in passes]
 
             schedule = [(step, passes_name_to_fn(passes)) for step, passes in schedule]
+            validate_schedule(schedule, {fn: name for name, fn in opt_passes.items()})
 
         assert backend in ['inductor', 'eager'], f"Backend {backend} is not supported for DeepCompile."
 
@@ -5541,8 +5545,8 @@ class DeepSpeedEngine(Module):
         from deepspeed.compile.backend import opt_pass_times
         return opt_pass_times
 
-    def register_compile_pass(self, pass_name: str, pass_fn: Callable) -> None:
-        register_compile_pass(pass_name, pass_fn)
+    def register_compile_pass(self, pass_name: str, pass_fn: Callable, contract=None) -> None:
+        register_compile_pass(pass_name, pass_fn, contract)
 
     def is_deepcompile_enabled(self) -> bool:
         return self._config.compile_config.deepcompile

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -5457,8 +5457,8 @@ class DeepSpeedEngine(Module):
                     assert callable(p) or p in opt_passes, f"Unknown pass {p}"
                 return [p if callable(p) else opt_passes[p] for p in passes]
 
+            validate_schedule(schedule, opt_passes)
             schedule = [(step, passes_name_to_fn(passes)) for step, passes in schedule]
-            validate_schedule(schedule, {fn: name for name, fn in opt_passes.items()})
 
         assert backend in ['inductor', 'eager'], f"Backend {backend} is not supported for DeepCompile."
 

--- a/tests/unit/compile/test_pass_contract.py
+++ b/tests/unit/compile/test_pass_contract.py
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) DeepSpeed Team.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/tests/unit/compile/test_pass_contract.py
+++ b/tests/unit/compile/test_pass_contract.py
@@ -22,15 +22,25 @@ def clean_registry():
 
 
 def _register_zero3_and_prefetch():
-    register_pass_contract(PassContract(name="zero3", provides=frozenset({"z3"})))
-    register_pass_contract(PassContract(name="prefetch", requires=frozenset({"z3"})))
+    register_pass_contract("zero3", PassContract(provides=frozenset({"z3"})))
+    register_pass_contract("prefetch", PassContract(requires=frozenset({"z3"})))
 
 
 def test_register_and_get(clean_registry):
-    contract = PassContract(name="zero3", provides=frozenset({"z3"}))
-    register_pass_contract(contract)
+    contract = PassContract(provides=frozenset({"z3"}))
+    register_pass_contract("zero3", contract)
     assert get_pass_contract("zero3") is contract
     assert get_pass_contract("missing") is None
+
+
+def test_none_contract_clears_previous(clean_registry):
+    # Re-registering a pass without a contract must drop the stale one, not keep it.
+    register_pass_contract("prefetch", PassContract(requires=frozenset({"z3"})))
+    assert get_pass_contract("prefetch") is not None
+    register_pass_contract("prefetch", None)
+    assert get_pass_contract("prefetch") is None
+    # With the contract cleared, the pass is unconstrained again.
+    validate_schedule([(0, ["prefetch"])])
 
 
 def test_valid_order_passes(clean_registry):
@@ -60,8 +70,8 @@ def test_requirement_does_not_carry_across_steps(clean_registry):
 
 
 def test_conflict_is_symmetric(clean_registry):
-    register_pass_contract(PassContract(name="a", conflicts_with=frozenset({"b"})))
-    register_pass_contract(PassContract(name="b"))
+    register_pass_contract("a", PassContract(conflicts_with=frozenset({"b"})))
+    register_pass_contract("b", PassContract())
     # "b" declares nothing, but "a" lists it as a conflict; either ordering must be rejected.
     with pytest.raises(PassContractError, match="conflicts"):
         validate_schedule([(0, ["a", "b"])])
@@ -75,7 +85,7 @@ def test_uncontracted_passes_are_skipped(clean_registry):
     validate_schedule([(0, ["zero3", "ad_hoc_pass", "prefetch"])])
 
 
-def test_callables_resolved_via_fn_to_name(clean_registry):
+def test_callables_resolved_by_identity(clean_registry):
     _register_zero3_and_prefetch()
 
     def zero3_fn():
@@ -84,7 +94,19 @@ def test_callables_resolved_via_fn_to_name(clean_registry):
     def prefetch_fn():
         pass
 
-    fn_to_name = {zero3_fn: "zero3", prefetch_fn: "prefetch"}
-    validate_schedule([(0, [zero3_fn]), (10, [prefetch_fn])], fn_to_name)
+    name_registry = {"zero3": zero3_fn, "prefetch": prefetch_fn}
+    validate_schedule([(0, [zero3_fn]), (10, [zero3_fn, prefetch_fn])], name_registry)
     with pytest.raises(PassContractError, match="requires"):
-        validate_schedule([(0, [prefetch_fn])], fn_to_name)
+        validate_schedule([(0, [prefetch_fn])], name_registry)
+
+
+def test_ambiguous_callable_requires_explicit_name(clean_registry):
+    register_pass_contract("zero3", PassContract(provides=frozenset({"z3"})))
+
+    def shared_fn():
+        pass
+
+    # The same callable registered under two names cannot be resolved to a single contract.
+    name_registry = {"zero3": shared_fn, "zero3_alias": shared_fn}
+    with pytest.raises(PassContractError, match="multiple names"):
+        validate_schedule([(0, [shared_fn])], name_registry)

--- a/tests/unit/compile/test_pass_contract.py
+++ b/tests/unit/compile/test_pass_contract.py
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+
+from deepspeed.compile.passes import contract as contract_mod
+from deepspeed.compile.passes.contract import (PassContract, PassContractError, register_pass_contract,
+                                               get_pass_contract, validate_schedule)
+
+
+@pytest.fixture
+def clean_registry():
+    # validate_schedule reads a module-level registry, so isolate each test from the built-in
+    # contracts and from one another by snapshotting and restoring it.
+    saved = dict(contract_mod._pass_contracts)
+    contract_mod._pass_contracts.clear()
+    yield
+    contract_mod._pass_contracts.clear()
+    contract_mod._pass_contracts.update(saved)
+
+
+def _register_zero3_and_prefetch():
+    register_pass_contract(PassContract(name="zero3", provides=frozenset({"z3"})))
+    register_pass_contract(PassContract(name="prefetch", requires=frozenset({"z3"})))
+
+
+def test_register_and_get(clean_registry):
+    contract = PassContract(name="zero3", provides=frozenset({"z3"}))
+    register_pass_contract(contract)
+    assert get_pass_contract("zero3") is contract
+    assert get_pass_contract("missing") is None
+
+
+def test_valid_order_passes(clean_registry):
+    _register_zero3_and_prefetch()
+    validate_schedule([(0, ["zero3"]), (10, ["zero3", "prefetch"])])
+
+
+def test_missing_requirement_raises(clean_registry):
+    _register_zero3_and_prefetch()
+    with pytest.raises(PassContractError, match="requires"):
+        validate_schedule([(0, ["prefetch"])])
+
+
+def test_requirement_within_same_step(clean_registry):
+    # Passes in the same step run left to right, so a provider earlier in the list satisfies a
+    # later consumer.
+    _register_zero3_and_prefetch()
+    validate_schedule([(0, ["zero3", "prefetch"])])
+
+
+def test_requirement_does_not_carry_across_steps(clean_registry):
+    # DeepCompile recompiles from the original graph at each step, so a provider in an earlier
+    # step does not satisfy a consumer in a later step; the requirement must be met per step.
+    _register_zero3_and_prefetch()
+    with pytest.raises(PassContractError, match="requires"):
+        validate_schedule([(0, ["zero3"]), (10, ["prefetch"])])
+
+
+def test_conflict_is_symmetric(clean_registry):
+    register_pass_contract(PassContract(name="a", conflicts_with=frozenset({"b"})))
+    register_pass_contract(PassContract(name="b"))
+    # "b" declares nothing, but "a" lists it as a conflict; either ordering must be rejected.
+    with pytest.raises(PassContractError, match="conflicts"):
+        validate_schedule([(0, ["a", "b"])])
+    with pytest.raises(PassContractError, match="conflicts"):
+        validate_schedule([(0, ["b", "a"])])
+
+
+def test_uncontracted_passes_are_skipped(clean_registry):
+    _register_zero3_and_prefetch()
+    # An ad-hoc pass with no registered contract must not break validation of the rest.
+    validate_schedule([(0, ["zero3", "ad_hoc_pass", "prefetch"])])
+
+
+def test_callables_resolved_via_fn_to_name(clean_registry):
+    _register_zero3_and_prefetch()
+
+    def zero3_fn():
+        pass
+
+    def prefetch_fn():
+        pass
+
+    fn_to_name = {zero3_fn: "zero3", prefetch_fn: "prefetch"}
+    validate_schedule([(0, [zero3_fn]), (10, [prefetch_fn])], fn_to_name)
+    with pytest.raises(PassContractError, match="requires"):
+        validate_schedule([(0, [prefetch_fn])], fn_to_name)


### PR DESCRIPTION
### Summary
Based on the DeepCompile efficiency and robustness track in the Q3 2026 roadmap #8104 , this PR implements: _Formal pass contracts and validation of optimization passes: Add lightweight optimization pass contracts for automatic compatibility validation and ordering_

### Motivation
DeepCompile passes execute in the order given by the schedule (`init_schedule`, `backend.py`), with no validation of that order. Inter-pass dependencies are implicit: `prefetch` and `selective_gather` rewrite the all-gather/release ops inserted by `zero3_compile` and require it to run first (cf. the default schedule in `init_z3.py`). An invalid order currently surfaces as a downstream failure rather than a diagnostic at schedule time.

### Changes
- `deepspeed/compile/passes/contract.py`: `PassContract` dataclass (`provides` / `requires` / `conflicts_with` / `phase`), a contract registry, and `validate_schedule()`, which raises `PassContractError` on the first unmet requirement or conflict. No torch dependency.
- Contracts declared for the four built-in passes: `zero3_compile` provides `z3_gather_release`; `prefetch` and `selective_gather` require it.
- `register_compile_pass(name, fn, contract=None)`: optional `contract` argument, backward compatible.
- `validate_schedule()` invoked on user-supplied schedules in the compile path (`engine.py`).

### Design
- Passes without a contract are unconstrained; existing and custom passes are unaffected. Internal default schedules are not validated, only user-supplied ones.
- Dependencies are expressed as capability tags (`z3_gather_release`) rather than pass names, so passes can be added or swapped without editing dependents.
- Conflicts are symmetric: either pass may declare the incompatibility, and both orderings are rejected.
- Scope is limited to metadata and validation, not dependency resolution or automatic reordering.

### Testing
- `tests/unit/compile/test_pass_contract.py`: unit tests for valid ordering, missing requirements, same-step providers, symmetric conflicts, uncontracted-pass pass-through, and callable resolution.