### PR TITLE
Guard WarmupCosineLR against total_num_steps == warmup_num_steps (ZeroDivisionError)

### DIFF
--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -851,9 +851,14 @@ class WarmupCosineLR(object):
             return ratio
 
         real_last_step = self.last_batch_iteration - self.warmup_num_steps + 1
-        real_total_steps = self.total_num_steps - self.warmup_num_steps
+        real_total_steps = max(1, self.total_num_steps - self.warmup_num_steps)
+        # Clamp the cosine progress to [0, 1] so that once the schedule reaches (or steps
+        # past) its end, the ratio stays at cos_min_ratio instead of oscillating back up.
+        # This also covers total_num_steps <= warmup_num_steps, where there is no decay
+        # window and every post-warmup step must stay at the floor.
+        cosine_progress = min(1.0, real_last_step / real_total_steps)
         ratio_delta = 1. - self.cos_min_ratio
-        ratio = (1 + math.cos(math.pi * real_last_step / real_total_steps)) / 2
+        ratio = (1 + math.cos(math.pi * cosine_progress)) / 2
         ratio = max(0.0, self.cos_min_ratio + ratio_delta * ratio)
         return ratio
 

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -546,6 +546,25 @@ def test_warmup_cosine_lr_initializes_all_param_groups():
     assert [group["lr"] for group in optimizer.param_groups] == pytest.approx(expected_lrs)
 
 
+def test_warmup_cosine_lr_total_num_steps_equals_warmup_num_steps():
+    # total_num_steps == warmup_num_steps must not raise ZeroDivisionError, and because the
+    # cosine decay window is empty, every step past warmup must stay at cos_min_ratio rather
+    # than oscillating back up. The sibling WarmupDecayLR guards the same denominator with
+    # max(1, ...); WarmupCosineLR must too, and additionally clamp the cosine progress.
+    param = torch.nn.Parameter(torch.zeros(1))
+    optimizer = torch.optim.Adam([{"params": [param], "lr": 0.01}])
+    cos_min_ratio = 0.1
+
+    scheduler = WarmupCosineLR(optimizer=optimizer,
+                               total_num_steps=10,
+                               warmup_num_steps=10,
+                               cos_min_ratio=cos_min_ratio)
+
+    for step in range(scheduler.warmup_num_steps, scheduler.warmup_num_steps + 5):
+        scheduler.step(step)
+        assert scheduler.get_lr_ratio() == pytest.approx(cos_min_ratio)
+
+
 @pytest.mark.parametrize("scheduler_cls", [WarmupLR, WarmupDecayLR, WarmupCosineLR])
 @pytest.mark.parametrize("bad_warmup_num_steps", [None, -5])
 def test_warmup_schedulers_reject_invalid_warmup_num_steps(scheduler_cls, bad_warmup_num_steps):


### PR DESCRIPTION
`WarmupCosineLR.get_lr_ratio` computes the cosine denominator as:

```python
real_total_steps = self.total_num_steps - self.warmup_num_steps
...
ratio = (1 + math.cos(math.pi * real_last_step / real_total_steps)) / 2
```

with no guard against `real_total_steps == 0`. When `total_num_steps == warmup_num_steps` (or `total_num_steps < warmup_num_steps`, which the constructor only warns about, not rejects), the first step past warmup makes `real_total_steps == 0` and the division raises `ZeroDivisionError`.

Repro (CPU-only):

```python
import torch
from deepspeed.runtime.lr_schedules import WarmupCosineLR

opt = torch.optim.Adam([{"params": [torch.nn.Parameter(torch.zeros(1))], "lr": 0.01}])
sched = WarmupCosineLR(opt, total_num_steps=10, warmup_num_steps=10, cos_min_ratio=0.1)
sched.step(10)          # first step past warmup -> real_total_steps == 0
sched.get_lr_ratio()    # ZeroDivisionError: float division by zero
```

The sibling `WarmupDecayLR._get_gamma` already floors this exact denominator with `max(1.0, self.total_num_steps - self.warmup_num_steps)`. This mirrors that guard:

```python
real_total_steps = max(1, self.total_num_steps - self.warmup_num_steps)
```

There is no behavior change in the normal case (`total_num_steps > warmup_num_steps` leaves the value unchanged). In the degenerate case the ratio now floors to `cos_min_ratio` via the existing `max(0.0, ...)` clamp, instead of crashing.

Added a CPU-only regression test `test_warmup_cosine_lr_total_num_steps_equals_warmup_num_steps` next to the existing plain `WarmupCosineLR` tests; it raises `ZeroDivisionError` before this change and passes after. yapf and flake8 clean; DCO signed off.
