### PR TITLE
Fix ZeRO-3 hooks for attribute-delegating modules

### DIFF
--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -422,7 +422,9 @@ class DeepSpeedZeRoOffload(object):
         self.forward_hooks.append(module.register_forward_hook(_post_forward_module_hook))
 
         # Pre backward hook
-        if not hasattr(module, "pre_bwd_fn"):
+        # Attribute-delegating wrappers may expose a child's hook state, but these closures and counters are
+        # module-local.
+        if "pre_bwd_fn" not in module.__dict__:
 
             @instrument_w_nvtx
             def _run_before_backward_function(sub_module):
@@ -445,7 +447,7 @@ class DeepSpeedZeRoOffload(object):
                 def setup_context(ctx, inputs, output):
                     ctx.module = module
                     ctx.pre_backward_function = _run_before_backward_function
-                    if not hasattr(ctx.module, "applied_pre_backward_ref_cnt"):
+                    if "applied_pre_backward_ref_cnt" not in ctx.module.__dict__:
                         ctx.module.applied_pre_backward_ref_cnt = 0
                     ctx.module.applied_pre_backward_ref_cnt += 1
 
@@ -459,7 +461,7 @@ class DeepSpeedZeRoOffload(object):
         self.backward_hooks.append(module.register_forward_hook(_pre_backward_module_hook))
 
         # post backward hook
-        if not hasattr(module, "post_bwd_fn"):
+        if "post_bwd_fn" not in module.__dict__:
 
             @instrument_w_nvtx
             def _run_after_backward_function(sub_module):

--- a/tests/unit/runtime/zero/test_zero_hook_attribute_delegation.py
+++ b/tests/unit/runtime/zero/test_zero_hook_attribute_delegation.py
@@ -1,4 +1,6 @@
+# Copyright (c) DeepSpeed Team.
 # SPDX-License-Identifier: Apache-2.0
+
 # DeepSpeed Team
 
 import torch
@@ -63,8 +65,17 @@ class TestHookAttributeDelegation(DistributedTest):
         model = DelegatingWrapperModel(hidden_dim)
         engine, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
 
+        wrapper = engine.module.output
+        wrapped = wrapper.wrapped
+        assert "pre_bwd_fn" in wrapper.__dict__
+        assert "post_bwd_fn" in wrapper.__dict__
+        assert wrapper.pre_bwd_fn is not wrapped.pre_bwd_fn
+        assert wrapper.post_bwd_fn is not wrapped.post_bwd_fn
+
         for _ in range(2):
             inputs = torch.randn(1, hidden_dim, device=engine.device, dtype=engine.module.input.weight.dtype)
             loss = engine(inputs)
             engine.backward(loss)
+            assert wrapper.__dict__["applied_pre_backward_ref_cnt"] == 0
+            assert wrapped.__dict__["applied_pre_backward_ref_cnt"] == 0
             engine.step()

--- a/tests/unit/runtime/zero/test_zero_hook_attribute_delegation.py
+++ b/tests/unit/runtime/zero/test_zero_hook_attribute_delegation.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import torch
+
+import deepspeed
+from deepspeed.accelerator import get_accelerator
+from unit.common import DistributedTest
+
+
+class AttributeDelegatingWrapper(torch.nn.Module):
+
+    def __init__(self, module):
+        super().__init__()
+        self.wrapped = module
+
+    def __getattr__(self, name):
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            wrapped = super().__getattr__("wrapped")
+            return getattr(wrapped, name)
+
+    def forward(self, inputs):
+        return self.wrapped(inputs)
+
+
+class DelegatingWrapperModel(torch.nn.Module):
+
+    def __init__(self, hidden_dim):
+        super().__init__()
+        self.input = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.output = AttributeDelegatingWrapper(torch.nn.Linear(hidden_dim, hidden_dim))
+
+    def forward(self, inputs):
+        return self.output(self.input(inputs)).sum()
+
+
+class TestHookAttributeDelegation(DistributedTest):
+    world_size = 1
+
+    def test(self):
+        config = {
+            "train_micro_batch_size_per_gpu": 1,
+            "zero_optimization": {
+                "stage": 3,
+                "stage3_param_persistence_threshold": 0,
+            },
+            "optimizer": {
+                "type": "AdamW",
+                "params": {
+                    "lr": 1e-3,
+                    "torch_adam": True,
+                },
+            },
+        }
+        if get_accelerator().is_bf16_supported():
+            config["bf16"] = {"enabled": True}
+        else:
+            config["fp16"] = {"enabled": True, "initial_scale_power": 8}
+
+        hidden_dim = 4
+        model = DelegatingWrapperModel(hidden_dim)
+        engine, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+
+        for _ in range(2):
+            inputs = torch.randn(1, hidden_dim, device=engine.device, dtype=engine.module.input.weight.dtype)
+            loss = engine(inputs)
+            engine.backward(loss)
+            engine.step()


### PR DESCRIPTION
## Summary

- make ZeRO-3 backward-hook state checks instance-local for attribute-delegating modules
- add a regression test that exercises two training steps through a delegating wrapper

## Root cause

ZeRO-3 registers child modules before their parents. Wrappers such as PEFT's `ModulesToSaveWrapper` delegate unknown attributes to a wrapped child, so `hasattr(wrapper, "pre_bwd_fn")` and `hasattr(wrapper, "post_bwd_fn")` can incorrectly find the child's hook classes. DeepSpeed then skips creating wrapper-local classes even though those classes capture module-specific closures and counters. During forward, the delegated post-backward class can access the child before its `ds_grads_remaining` counter is initialized, raising `AttributeError`.

Check the module's own `__dict__` for these internal attributes so each module receives hook classes and counters bound to itself.

## User impact

This restores ZeRO-3 training with attribute-delegating wrappers, including PEFT LoRA configurations that use `modules_to_save=["lm_head"]`.

Fixes #7615.

## Testing

- `pre-commit run --files deepspeed/runtime/zero/parameter_offload.py tests/unit/runtime/zero/test_zero_hook_attribute_delegation.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unit/runtime/zero/test_zero_hook_attribute_delegation.py tests/unit/runtime/zero/test_zero_dynamic_class.py -s` (`3 passed`)
- two ZeRO-3 training steps with PEFT's real `ModulesToSaveWrapper`
