### PR TITLE
Fix DeepSpeedInferenceConfig crash on bool moe backward-compat value

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -313,7 +313,7 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
     @field_validator("moe")
     def moe_backward_compat(cls, field_value, values):
         if isinstance(field_value, bool):
-            return DeepSpeedMoEConfig(moe=field_value)
+            return DeepSpeedMoEConfig(enabled=field_value)
         return field_value
 
     @field_validator("use_triton")

--- a/tests/unit/inference/test_inference_config.py
+++ b/tests/unit/inference/test_inference_config.py
@@ -42,3 +42,13 @@ class TestInferenceConfig(DistributedTest):
 
         engine = deepspeed.init_inference(torch.nn.Module(), config=config_json)
         assert engine._config.replace_with_kernel_inject
+
+    def test_moe_backward_compat_bool(self):
+        # `moe` accepts a bool for backward compatibility (moe: Union[bool, DeepSpeedMoEConfig]);
+        # it should build a DeepSpeedMoEConfig rather than raising a validation error.
+        from deepspeed.inference.config import DeepSpeedInferenceConfig, DeepSpeedMoEConfig
+
+        for value in (True, False):
+            config = DeepSpeedInferenceConfig(moe=value)
+            assert isinstance(config.moe, DeepSpeedMoEConfig)
+            assert config.moe.enabled == value


### PR DESCRIPTION
`DeepSpeedInferenceConfig.moe` is typed `Union[bool, DeepSpeedMoEConfig]`, and the `moe_backward_compat` validator explicitly handles the bool form (the old `init_inference(..., moe=<bool>)` interface). But it builds `DeepSpeedMoEConfig(moe=field_value)` — and `DeepSpeedMoEConfig` has no `moe` field (it has `enabled`). Since `DeepSpeedConfigModel` sets `extra="forbid"`, every bool `moe` raises a `ValidationError` instead of building the config:

```python
>>> from deepspeed.inference.config import DeepSpeedInferenceConfig
>>> DeepSpeedInferenceConfig(moe=True)
pydantic_core._pydantic_core.ValidationError: 1 validation error for DeepSpeedMoEConfig
moe
  Extra inputs are not permitted [type=extra_forbidden, ...]
```

Both `moe=True` and `moe=False` crash, so the documented backward-compat path is unusable. The fix passes `enabled=field_value` (the actual field) so the bool is turned into a `DeepSpeedMoEConfig` as intended.

The line dates back to #2516 and survived the pydantic-v2 migration (#5167) unchanged.

Added a regression test (`test_moe_backward_compat_bool`) asserting the bool form builds a `DeepSpeedMoEConfig` with the matching `enabled`. `yapf` and `flake8` clean.
