### PR TITLE
Fix DeepCompile fallback handling for scalar outputs

### DIFF
--- a/deepspeed/compile/inductor.py
+++ b/deepspeed/compile/inductor.py
@@ -39,6 +39,12 @@ def _register_graphsafe_rng_state_no_reuse(register_fallback_no_reuse):
     return True
 
 
+def _mark_output_never_reuse(out, *, enabled):
+    if enabled and isinstance(out, IRNode):
+        V.graph.never_reuse_buffers.add(out.get_name())
+    return out
+
+
 def patch_compiler(original_compiler, dc_compiler, z3_partition: bool, graph_id, graph_param_manager, bwd: bool):
 
     def wrapped_compiler(gm, fake_inputs):
@@ -184,9 +190,7 @@ def register_custom_ops():
 
             def wrap_tensors(x):
                 out = TensorBox.create(x) if isinstance(x, torch._inductor.ir.IRNode) else x
-                if out is not None and never_reuse_output:
-                    V.graph.never_reuse_buffers.add(out.get_name())
-                return out
+                return _mark_output_never_reuse(out, enabled=never_reuse_output)
 
             class CustomDCKernel(FallbackKernel):
 

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -377,6 +377,29 @@ def test_graphsafe_rng_state_outputs_are_registered_no_reuse():
     assert calls == [(graphsafe_run_with_rng_state, {"never_reuse_output": True})]
 
 
+def test_mark_output_never_reuse_mixed_pytree():
+
+    class FakeIRNode(inductor_mod.IRNode):
+
+        def get_name(self):
+            return "tensor_buffer"
+
+    class NonIRLeaf:
+
+        def get_name(self):
+            raise AssertionError("get_name must not be called for non-IR outputs")
+
+    graph = SimpleNamespace(never_reuse_buffers=set())
+    outputs = (FakeIRNode(), 1, None, NonIRLeaf())
+
+    with inductor_mod.V.set_graph_handler(graph):
+        wrapped = torch.utils._pytree.tree_map(lambda out: inductor_mod._mark_output_never_reuse(out, enabled=True),
+                                               outputs)
+
+    assert wrapped == outputs
+    assert graph.never_reuse_buffers == {"tensor_buffer"}
+
+
 def test_register_custom_ops_includes_graphsafe_rng_state_no_reuse(monkeypatch):
     graphsafe_run_with_rng_state = inductor_mod._get_graphsafe_run_with_rng_state()
     if graphsafe_run_with_rng_state is None:


### PR DESCRIPTION
When DeepCompile lowered the graph-safe RNG wrapper around this operator, the fallback handler treated every non-`None` output as an Inductor buffer for never-reuse registration and called `get_name()` unconditionally. 
The scalar output therefore raised `AttributeError: 'int' object has no attribute 'get_name'` before the first compiled forward could run (See the following definition of `_scaled_dot_product_flash_attention`).

```
aten::_scaled_dot_product_flash_attention(
    Tensor query,
    Tensor key,
    Tensor value,
    float dropout_p=0.0,
    bool is_causal=False,
    bool return_debug_mask=False,
    *,
    float? scale=None
)
->
(
    Tensor output,
    Tensor logsumexp,
    Tensor cum_seq_q,
    Tensor cum_seq_k,
    SymInt max_q,
    SymInt max_k,
    Tensor rng_state,
    Tensor unused,
    Tensor debug_attn_mask
```

This PR limits "never-reuse" registration to Inductor IR outputs. This is applied to tensor buffers, while scalar and `None` leaves pass through without tensor-only method calls.