### PR TITLE
Update Zhipeng Wang affiliation to Google in COMMITTERS.md

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -9,5 +9,5 @@
 | Minjia Zhang    | [minjiazhang](https://github.com/minjiazhang)  | UIUC  |
 | Ashwin Aji      | [ashwinma](https://github.com/ashwinma)        | AMD   |
 | Sam Foreman     | [saforem2](https://github.com/saforem2)        | Argonne National Laboratory |
-| Zhipeng Wang    | [PKUWZP](https://github.com/PKUWZP)       | LinkedIn  |
+| Zhipeng Wang    | [PKUWZP](https://github.com/PKUWZP)       | Google  |
 | Guokai Ma       | [delock](https://github.com/delock)       | Intel  |


### PR DESCRIPTION
Updates Zhipeng Wang's affiliation from LinkedIn to Google in COMMITTERS.md.