### PR TITLE
Run pull request code only inside a Modal Sandbox

### DIFF
--- a/.github/workflows/TEST_SELECTION.md
+++ b/.github/workflows/TEST_SELECTION.md
@@ -24,8 +24,9 @@ one config — see [Adding a workflow](#adding-a-new-workflow).
 - On a PR, `ci/tests_fetcher.py` diffs your branch against the base branch, traces
   the import graph from your changed files to the impacted tests, and writes the
   list to `ci/.test_selection/test_list.txt`.
-- The workflow runs pytest on just that list. `push` to `master` and manual runs
-  always run everything.
+- The trusted controller validates that list, then fetches, installs, and tests
+  the exact candidate SHA inside a no-secret Modal Sandbox. `push` to `master`
+  and manual runs always run everything.
 - It is **fail-safe**: anything it can't reason about safely → run the *full* suite.
   It never silently runs *fewer* tests than reality.
 - Preview locally:
@@ -53,10 +54,10 @@ The design is a small, self-contained take on HuggingFace `transformers`'
 
 | File | Role |
 | --- | --- |
-| `.github/workflows/modal-torch-latest.yml` | The workflow: a `collect-tests` job (runs the fetcher) gating a `deploy` job (runs pytest on modal). |
+| `.github/workflows/modal-torch-latest.yml` | The workflow: a no-secret `collect-tests` job gating a trusted `deploy` controller job. |
 | `ci/tests_fetcher.py` | The selector. AST-parses the repo, builds an import graph, decides `all` / `subset` / `none`, writes the test-list file, emits a job summary. |
 | `ci/test_tests_fetcher.py` | Self-tests for the selector (pure stdlib; run in `collect-tests`). |
-| `ci/torch_latest.py` | The modal runner. Reads the test-list file and feeds it to pytest. |
+| `ci/torch_latest.py` | Pure-stdlib metadata/selection validation plus the trusted Modal Sandbox controller. |
 | `ci/.test_selection/test_list.txt` | The hand-off artifact (one pytest target per line). Git-ignored. |
 
 ### Job flow
@@ -65,24 +66,26 @@ The design is a small, self-contained take on HuggingFace `transformers`'
                 pull_request_target / push / workflow_dispatch
                                   │
                     ┌─────────────┴─────────────┐
-                    │        collect-tests       │   (no secrets; AST-only)
-                    │  checkout PR head          │
-                    │  restore ci/ from base     │
+                    │        collect-tests       │   (no secrets)
+                    │  checkout exact base SHA   │
+                    │  public-fetch exact PR SHA │
                     │  self-test the fetcher     │
-                    │  run tests_fetcher.py      │
+                    │  parse candidate as data   │
                     │   → mode (all|subset|none) │
-                    │   → upload test_list.txt   │
+                    │   → validate/upload list   │
                     └─────────────┬──────────────┘
                                   │ needs:
                                   ▼
                     ┌────────────────────────────┐
-                    │           deploy            │   (has modal/HF secrets)
-                    │  if mode != none (or manual │
-                    │     / collector failed)     │
-                    │  checkout PR head           │
-                    │  restore ci/ from base      │
-                    │  download test_list.txt     │
-                    │  modal run ci.torch_latest  │
+                    │           deploy            │   (Modal token: controller only)
+                    │  if mode != none            │
+                    │  checkout exact base SHA    │
+                    │  validate mode/list + SHA   │
+                    │  create one L40S:2 Sandbox  │
+                    │    no secrets or mounts     │
+                    │    fetch exact PR SHA       │
+                    │    install + run pytest     │
+                    │  terminate/observe Sandbox  │
                     └────────────────────────────┘
 ```
 
@@ -239,34 +242,50 @@ tests.
 ## Security model
 
 The workflow triggers on **`pull_request_target`**, so it runs in the base repo's
-context and the `deploy` job has the modal/HF **secrets** in scope. To keep PRs
-from abusing that:
+context and the `deploy` controller authenticates to Modal. The trust boundary is:
 
-- `collect-tests` holds **no secrets** and only **AST-parses** (never executes)
-  the PR tree.
-- **Both jobs restore `ci/` from the base branch** before using it:
-  - `collect-tests` runs the **base** selector + self-tests. This job decides
-    whether the Required `deploy` runs, so it must not trust the PR's own
-    `ci/tests_fetcher.py` — otherwise a PR could rewrite it to emit `mode=none`
-    and skip CI while still going green. The diff is computed from git history, so
-    a PR's `ci/` changes still appear in the diff and (via the base selector's
-    `ci/**` run-all glob) force a full run.
-  - `deploy` runs the **base** orchestration (which drives `modal run` with the
-    secrets), so a PR can't repoint it at the secrets to exfiltrate them.
-  In both jobs the PR's `deepspeed/` + `tests/` are what gets parsed/tested.
+- Both jobs check out only the exact trusted base SHA (or the exact
+  push/manual SHA), with persisted credentials, LFS, and submodules disabled.
+  They never use the fork head with `actions/checkout`.
+- `collect-tests` holds **no repository secrets**. Trusted base code fetches the
+  public head and base repositories at their exact event SHAs, disables
+  credentials, hooks, submodules, and LFS smudging, and rejects checkout
+  symlinks that escape the candidate root. It treats the candidate tree only as
+  git/AST data; it never imports, installs, builds, or executes candidate code.
+- The selector logic and its self-tests always come from the trusted checkout.
+  A PR's `ci/` changes still appear in the diff, so the base selector's `ci/**`
+  run-all rule widens them to the full suite.
+- The handoff is a fixed `all` / `subset` / `none` mode plus one bounded,
+  validated regular file. Test paths must stay under `tests/unit/v1`, cannot be
+  options or traversal paths, and are passed after pytest's `--` separator.
+- `deploy` runs only the trusted controller. Candidate metadata is restricted
+  to a public `owner/repository` and full 40-hex SHA; event values enter Python
+  through environment variables, not workflow shell interpolation.
+- The Modal service token remains in the controller process. The Sandbox gets
+  no Modal, GitHub, Hugging Face, OIDC, or other secret; no local checkout,
+  mount, volume, network filesystem, port, proxy, or workload identity is
+  attached. The controller constructs a positive allowlist of non-sensitive
+  git/pip environment flags instead of forwarding its environment.
+- Candidate acquisition, dependency installation, DeepSpeed installation, and
+  pytest all happen inside one isolated `l40s:2` Sandbox with a 3600-second
+  server-side lifetime. Every subprocess uses structural arguments, and every
+  nonzero clone/install/test status fails the check.
+- The Sandbox retains outbound network access because it must reach public
+  GitHub, package indexes, PyTorch wheels, and optionally Transformers. Those
+  services do not have stable CIDRs suitable for the SDK's CIDR allowlist, so
+  the containment control is the absence of secrets, identities, and mounts.
 - The `pull_request_target` trigger types are `review_requested`,
   `ready_for_review`, and `synchronize`. Because `synchronize` re-runs on every
   push to an open PR (not just on a maintainer action), the maintainer review is a
-  mitigation, **not** an absolute barrier — the base-`ci/` restore above is the
-  primary protection for the secrets.
+  mitigation, **not** the trust boundary. Exact trusted base code plus Sandbox
+  isolation is the primary protection.
 
 > **Consequence:** changes to `ci/*` (including `tests_fetcher.py` itself) take
-> effect under `pull_request_target` only after they're **merged**. Validate
-> `ci/*` changes via a `pull_request`-triggered run or the `modal` CLI locally.
->
-> **Bootstrap:** when the base branch has no selector yet (the PR that introduces
-> it), the restored base `ci/` won't contain `tests_fetcher.py`; `collect-tests`
-> detects this and falls back to running the full suite.
+> effect under `pull_request_target` only after they're **merged**. A PR that
+> changes this launcher cannot prove its new PR-triggered end-to-end path by
+> running itself. Before merge, use pure-stdlib/unit/static validation and, only
+> when separately authorized credentials are available, a direct Modal smoke.
+> Do not describe mock coverage as live Modal evidence.
 
 
 ## Failure modes & guarantees
@@ -276,14 +295,25 @@ The selector is built to **fail safe — to `all`, never to `none`**:
 - Missing/unresolvable base, no merge-base, a parse error on a file, or **any
   unexpected exception** in the selector → it falls back to the full suite (the
   top-level handler in `main()` logs the traceback and sets `mode=all`).
-- If `collect-tests` fails entirely, `deploy` still runs (and the workflow has an
-  explicit "fail if selection failed" guard) so a broken collector can't let a PR
-  pass without testing.
+- Checkout, selector self-test, list validation, write, or upload failures make
+  `collect-tests` fail. `deploy` then enters its explicit failure guard, so a
+  broken collector cannot pass the Required check.
 - The only way to run *fewer* tests is a clean, well-understood narrow decision;
   every uncertain case widens to everything.
+- Missing or invalid repository/SHA metadata, an inconsistent mode/list pair,
+  and any failed Sandbox clone, install, version probe, or pytest command fail
+  the controller. There is no moving-branch fallback.
+- Once created, the task-owned Sandbox is terminated and its terminal state is
+  observed on success and failure. Cleanup failure is itself a failure and is
+  reported without hiding the primary command error. Forced controller loss is
+  bounded by the Sandbox's one-hour server lifetime.
+- `none` creates no Sandbox. `subset` and `all` create exactly one Sandbox; the
+  GPU shape and lifetime are constants rather than PR or manual inputs.
 
 Every run writes a summary to the GitHub job summary (mode, reason, and the
-selected files) so the decision is auditable from the Actions UI.
+selected files) so the decision is auditable from the Actions UI. Candidate
+text is control-escaped before logs/summaries and is never written to
+`GITHUB_OUTPUT`.
 
 
 ## FAQ / troubleshooting
@@ -302,5 +332,11 @@ fanned out. Check the job summary's `reason`. If a hub over-fans, consider
 `OPAQUE_MODULES`.
 
 **It ran the full suite and the summary says "shallow clone?" / "no merge-base".**
-The runner didn't have enough history to compute the diff. `collect-tests` uses
-`fetch-depth: 0`; if you changed that, restore full history for the base.
+The exact event commits did not provide a usable merge-base. The collector
+fetches the exact head and base SHAs into fixed refs; verify both event commits
+are still publicly reachable. Do not replace this with a moving branch fallback.
+
+**Why didn't this PR exercise its new `pull_request_target` controller?**
+GitHub intentionally runs that event's workflow from the trusted base. The new
+controller becomes the trusted code only after merge; before then, rely on the
+focused static/unit evidence described in the security model.

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -1,27 +1,9 @@
 name: modal-torch-latest
 
-# This CI is running on modal.com's GPUs.
-#
-# It's set up here on github actions and then the cloned repo is sent to modal and everything
-# happens on their hw - see ci/torch_latest.py  for where the actual vm is loaded, updated and the tests are
-# run.
-#
-# Both files are annotated to what's important and how one might change or update things if needed.
-#
-# Note that since this is a Required job we can't use `on.push.path` file filter - we are using
-# the collect-tests job to do the filtering for us so that the job can be skipped and satisfy the
-# Required status for PRs to pass.
-#
-# Test selection: collect-tests runs ci/tests_fetcher.py, which traces the import
-# graph from the PR's changed files to the impacted tests/unit/v1 tests. It emits a
-# `mode` (all | subset | none) and a test-list file:
-#   - none   -> deploy is skipped (Required status is still satisfied by the skip)
-#   - subset -> deploy runs pytest on only the impacted test files
-#   - all    -> deploy runs the whole tests/unit/v1 suite
-#
-# Full design / how to drive & change it: .github/workflows/TEST_SELECTION.md
-#
-
+# This Required workflow selects tests on a no-secret GitHub runner, then tests
+# the exact candidate SHA inside a no-secret Modal Sandbox. Under
+# pull_request_target, every GitHub-side checkout and Python entrypoint comes
+# from the trusted base commit. See .github/workflows/TEST_SELECTION.md.
 
 on:
   workflow_dispatch:
@@ -60,6 +42,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -68,174 +53,126 @@ jobs:
   collect-tests:
     name: modal-torch-latest / collect tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: read
     outputs:
-      mode: ${{ steps.fetch.outputs.mode }}
+      mode: ${{ steps.select.outputs.mode }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted workflow code
         uses: actions/checkout@v4
         with:
-          # For PRs, check out the PR head so the fetcher sees the proposed
-          # deepspeed/ + tests/ code. This job holds NO secrets. The selection
-          # *logic* (ci/) is restored from the base branch in a later step so a PR
-          # can't tamper with the decision (see "Use base-branch CI scripts").
-          # Falls back to the pushed/manual commit for non-PR events.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          # Full history so the merge-base with the base branch is always present.
-          # This is the robust (if slower) choice: a shallow clone that can't reach
-          # the fork point would produce a wrong diff. The fetcher additionally
-          # guards against a missing merge-base by falling back to the full suite,
-          # so we never run a narrow (false-negative) selection on a bad base.
-          fetch-depth: 0
-          lfs: true
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          lfs: false
+          submodules: false
 
-      - name: Determine base ref
-        id: base
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          git config --global --add safe.directory '*'
-          if [ "$EVENT_NAME" = "pull_request_target" ]; then
-            # Fetch the base branch's full history too, so a merge-base always exists.
-            git fetch --no-tags origin "$BASE_REF"
-            echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
-          else
-            # push to master / manual dispatch -> no diff base -> run the full suite
-            echo "ref=" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Use base-branch CI scripts
-        # SECURITY: this job decides whether the Required `deploy` job runs. Under
-        # pull_request_target we must NOT trust the PR's own ci/ for that decision:
-        # a PR could rewrite ci/tests_fetcher.py to emit `mode=none` (or its self
-        # tests) and skip CI entirely while still satisfying the Required check.
-        # So run the selector + self-tests from the *base* branch's ci/. The diff is
-        # computed from git history, so a PR's ci/ changes still show up in the diff
-        # and (via the base selector's `ci/**` run-all glob) force a full run.
+      - name: Fetch candidate tree as data
         if: github.event_name == 'pull_request_target'
         env:
-          BASE_REF: ${{ github.base_ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CANDIDATE_ROOT: ${{ runner.temp }}/deepspeed-candidate
         run: |
-          git config --global --add safe.directory '*'
-          git checkout "origin/$BASE_REF" -- ci/
+          python3 ci/torch_latest.py checkout-candidate \
+            --head-repository "$HEAD_REPOSITORY" \
+            --head-sha "$HEAD_SHA" \
+            --base-repository "$BASE_REPOSITORY" \
+            --base-sha "$BASE_SHA" \
+            --destination "$CANDIDATE_ROOT"
 
-      - name: Self-test the fetcher
-        # Pure-stdlib self-tests for the selector (only needs git + python). Runs
-        # here so a broken selector is caught before it (mis)picks tests. Skipped
-        # when the base branch has no selector yet (bootstrap; see below).
-        run: |
-          if [ -f ci/test_tests_fetcher.py ]; then
-            python3 ci/test_tests_fetcher.py
-          else
-            echo "No base-branch ci/test_tests_fetcher.py (bootstrap) -> skipping self-tests."
-          fi
+      - name: Self-test the trusted selector
+        run: python3 ci/test_tests_fetcher.py
 
       - name: Select impacted tests
-        id: fetch
-        # Pure-stdlib script; the runner's system python is fine (no deps needed).
-        # If the base branch doesn't have the selector yet (e.g. the PR that
-        # introduces it), the restored base ci/ won't contain tests_fetcher.py, so
-        # fall back to the full suite -- safe, and unblocks the bootstrap PR.
+        id: select
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CANDIDATE_ROOT: ${{ runner.temp }}/deepspeed-candidate
         run: |
-          if [ -f ci/tests_fetcher.py ]; then
-            python3 ci/tests_fetcher.py --workflow modal-torch-latest --base "${{ steps.base.outputs.ref }}"
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            python3 ci/tests_fetcher.py \
+              --workflow modal-torch-latest \
+              --repo-root "$CANDIDATE_ROOT" \
+              --base refs/devds/base
           else
-            echo "No base-branch ci/tests_fetcher.py (bootstrap) -> running the full suite."
-            echo "mode=all" >> "$GITHUB_OUTPUT"
-            mkdir -p ci/.test_selection
-            printf 'tests/unit/v1\n' > ci/.test_selection/test_list.txt
+            python3 ci/tests_fetcher.py \
+              --workflow modal-torch-latest \
+              --repo-root "$GITHUB_WORKSPACE" \
+              --base ""
           fi
+
+      - name: Validate test selection
+        env:
+          SELECTION_MODE: ${{ steps.select.outputs.mode }}
+        run: |
+          python3 ci/torch_latest.py validate-selection \
+            --mode "$SELECTION_MODE" \
+            --path ci/.test_selection/test_list.txt
 
       - name: Upload test selection
         uses: actions/upload-artifact@v4
         with:
           name: modal-torch-latest-test-selection
           path: ci/.test_selection/test_list.txt
-          # The path lives under a dot-folder; upload-artifact treats dot-prefixed
-          # paths as hidden and skips them by default (only warns), which would make
-          # deploy's download fail. Opt in explicitly.
           include-hidden-files: true
           retention-days: 3
 
   deploy:
     name: modal-torch-latest / DeepSpeedAI CI
     runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      contents: read
     needs: collect-tests
 
-    # Run when: manual dispatch, OR the selector failed (fail closed so the Required
-    # check doesn't silently pass), OR the diff impacts at least one test (mode != none).
-    # (!cancelled() adopted from upstream so a cancelled run doesn't trigger deploy.)
-    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.collect-tests.result != 'success' || needs.collect-tests.outputs.mode != 'none') }}
+    # Preserve the Required check on failures and no-test selections. A selector
+    # failure enters this job and fails explicitly; mode=none skips the Sandbox.
+    if: ${{ !cancelled() && (needs.collect-tests.result != 'success' || needs.collect-tests.outputs.mode != 'none') }}
     steps:
       - name: Fail if test selection failed
-        if: github.event_name != 'workflow_dispatch' && needs.collect-tests.result != 'success'
+        if: needs.collect-tests.result != 'success'
         run: exit 1
 
-      - name: Checkout Repository
+      - name: Checkout trusted controller code
         uses: actions/checkout@v4
         with:
-          # Test the PR's code (not the base) so diff-driven selection is meaningful.
-          # SECURITY NOTE: under pull_request_target this runs PR-authored code while
-          # the modal/HF secrets are on this runner. The trigger types include
-          # `synchronize`, so this re-runs on every push to an open PR (not only on a
-          # maintainer's review_requested / ready_for_review action) -- do not treat
-          # the maintainer gate as an absolute barrier. The primary protection is that
-          # the CI orchestration (which actually receives the secrets) is restored
-          # from the base branch in the next step, so a PR can't repoint it at the
-          # secrets; only the PR's deepspeed/ + tests/ run, inside modal.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          lfs: true
-
-      - name: Use base-branch CI scripts
-        # Run the *base* version of ci/ (which drives `modal run` with the secrets in
-        # scope) rather than the PR's, so a PR can't modify the orchestration to
-        # exfiltrate secrets. The PR's deepspeed/ + tests/ are still what gets tested.
-        # (As noted in the header, changes to ci/* must be validated via `pull_request`
-        # or the modal CLI, since pull_request_target always uses the base ci/ here.)
-        if: github.event_name == 'pull_request_target'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          git config --global --add safe.directory '*'
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
-          git checkout "origin/$BASE_REF" -- ci/
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          lfs: false
+          submodules: false
 
       - name: Install Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: 'pip' # caching pip dependencies
+          cache: 'pip'
 
       - name: Download test selection
-        if: needs.collect-tests.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: modal-torch-latest-test-selection
           path: ci/.test_selection
 
-      - name: Install build dependencies
+      - name: Install trusted controller dependency
         run: |
-          pip install uv # much faster than pip
-          uv pip install --system modal
+          pip install uv
+          uv pip install --system modal==1.2.6
 
-      - name: Run tests
+      - name: Run tests in isolated Modal Sandbox
         env:
+          DS_CI_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          DS_CI_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          DS_TEST_SELECTION_MODE: ${{ needs.collect-tests.outputs.mode }}
+          DS_TEST_LIST_FILE: ci/.test_selection/test_list.txt
           MODAL_TORCH_PRESET: ${{ github.event.inputs.torch_preset || '2.10.0-cuda12.8' }}
           MODAL_TRANSFORMERS_SOURCE: ${{ github.event.inputs.transformers_source || 'git' }}
           MODAL_TRANSFORMERS_REF: ${{ github.event.inputs.transformers_ref || 'main' }}
-          # Diff-selected pytest targets produced by collect-tests (falls back to the
-          # full tests/unit/v1 suite if the file is missing/empty).
-          DS_TEST_LIST_FILE: ci/.test_selection/test_list.txt
-          # these are created at https://modal.com/settings/deepspeedai/tokens
-          # they are then added to the repo's secrets at https://github.com/deepspeedai/deepspeed/settings/secrets/actions
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # this one comes from https://huggingface.co/settings/profile of the bot user
-          # and it too is then updated at https://github.com/deepspeedai/deepspeed/settings/secrets/actions
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          modal run -m ci.torch_latest
+        run: python3 ci/torch_latest.py controller

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -98,7 +98,7 @@ jobs:
             python3 ci/tests_fetcher.py \
               --workflow modal-torch-latest \
               --repo-root "$CANDIDATE_ROOT" \
-              --base refs/devds/base
+              --base refs/ci/base
           else
             python3 ci/tests_fetcher.py \
               --workflow modal-torch-latest \

--- a/ci/test_tests_fetcher.py
+++ b/ci/test_tests_fetcher.py
@@ -20,6 +20,7 @@ or under pytest::
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -28,7 +29,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # import the sibling module
 
-from tests_fetcher import TestSelector, WorkflowConfig  # noqa: E402
+import tests_fetcher  # noqa: E402
+from tests_fetcher import Selection, TestSelector, WorkflowConfig  # noqa: E402
 
 CONFIG = WorkflowConfig(
     name="test",
@@ -71,7 +73,7 @@ class TmpRepo:
     """A throwaway git repo seeded with BASELINE, committed on ``master``."""
 
     def __init__(self) -> None:
-        self.root = Path(tempfile.mkdtemp(prefix="ds-fetcher-test-"))
+        self.root = Path(tempfile.mkdtemp(prefix="ds-fetcher-test-")).resolve()
         for rel, content in BASELINE.items():
             self.write(rel, content)
         self._git("init", "-q", "-b", "master")
@@ -254,6 +256,107 @@ def test_missing_base_runs_all() -> None:
         assert sel.mode == "all", sel.reason
     finally:
         repo.cleanup()
+
+
+def test_external_repo_root_keeps_output_in_trusted_checkout() -> None:
+    repo = TmpRepo()
+    trusted_root = Path(tempfile.mkdtemp(prefix="ds-fetcher-trusted-"))
+    original_root = tests_fetcher.REPO_ROOT
+    original_argv = sys.argv
+    try:
+        repo.write("deepspeed/leaf.py", "VALUE = 11\n")
+        repo.commit("touch leaf")
+        candidate_output = repo.root / "ci" / ".test_selection" / "test_list.txt"
+        repo.write("ci/.test_selection/test_list.txt", "candidate-controlled\n")
+
+        tests_fetcher.REPO_ROOT = trusted_root
+        sys.argv = [
+            "tests_fetcher.py",
+            "--workflow",
+            "modal-torch-latest",
+            "--repo-root",
+            str(repo.root),
+            "--base",
+            "master",
+        ]
+        tests_fetcher.main()
+
+        trusted_output = trusted_root / "ci" / ".test_selection" / "test_list.txt"
+        assert trusted_output.read_text(encoding="utf-8") == "tests/unit/v1/test_leaf.py\n"
+        assert candidate_output.read_text(encoding="utf-8") == "candidate-controlled\n"
+    finally:
+        tests_fetcher.REPO_ROOT = original_root
+        sys.argv = original_argv
+        repo.cleanup()
+        shutil.rmtree(trusted_root, ignore_errors=True)
+
+
+def test_github_output_contains_only_validated_mode_and_count() -> None:
+    root = Path(tempfile.mkdtemp(prefix="ds-fetcher-output-"))
+    output = root / "github-output"
+    original = os.environ.get("GITHUB_OUTPUT")
+    try:
+        os.environ["GITHUB_OUTPUT"] = str(output)
+        tests_fetcher._emit_github_output("subset", 1)
+        assert output.read_text(encoding="utf-8") == "mode=subset\ncount=1\n"
+        try:
+            tests_fetcher._emit_github_output("subset\npwned=1", 1)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("invalid output mode was accepted")
+    finally:
+        if original is None:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        else:
+            os.environ["GITHUB_OUTPUT"] = original
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_summary_escapes_candidate_controls_and_markup() -> None:
+    root = Path(tempfile.mkdtemp(prefix="ds-fetcher-summary-"))
+    summary = root / "summary"
+    original = os.environ.get("GITHUB_STEP_SUMMARY")
+    try:
+        os.environ["GITHUB_STEP_SUMMARY"] = str(summary)
+        selection = Selection("all", [], "changed <tag>\n::warning:: `text`")
+        tests_fetcher._write_step_summary(CONFIG, selection, ["tests/unit/v1"])
+        text = summary.read_text(encoding="utf-8")
+        assert "changed &lt;tag&gt;\\x0a::warning:: `text`" in text
+        assert "\n::warning::" not in text
+    finally:
+        if original is None:
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
+        else:
+            os.environ["GITHUB_STEP_SUMMARY"] = original
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_output_path_cannot_escape_or_replace_trusted_checkout() -> None:
+    root = Path(tempfile.mkdtemp(prefix="ds-fetcher-path-"))
+    outside = Path(tempfile.mkdtemp(prefix="ds-fetcher-outside-"))
+    try:
+        expected = root / "ci" / ".test_selection" / "test_list.txt"
+        assert tests_fetcher._resolve_output_path(root, "ci/.test_selection/test_list.txt") == expected
+        for value in ("../escape", str(outside / "absolute")):
+            try:
+                tests_fetcher._resolve_output_path(root, value)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"unsafe output path was accepted: {value}")
+
+        expected.parent.mkdir(parents=True)
+        expected.symlink_to(outside / "test_list.txt")
+        try:
+            tests_fetcher._resolve_output_path(root, "ci/.test_selection/test_list.txt")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("symlink output path was accepted")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def _all_test_functions():

--- a/ci/test_torch_latest.py
+++ b/ci/test_torch_latest.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import torch_latest  # noqa: E402
+import test_tests_fetcher  # noqa: E402
 
 
 def _expect_error(function, *args, exception=ValueError, **kwargs):
@@ -188,8 +189,8 @@ def test_transformers_ref_validation():
 def test_selection_modes_and_path_validation():
     cases = [
         ("all", "tests/unit/v1\n", ("tests/unit/v1", )),
-        ("subset", "tests/unit/v1/test_one.py\ntests/unit/v1/sub/test_two.py\n",
-         ("tests/unit/v1/test_one.py", "tests/unit/v1/sub/test_two.py")),
+        ("subset", "tests/unit/v1/test_one.py\ntests/unit/v1/sub/test_two.py\n", ("tests/unit/v1/test_one.py",
+                                                                                  "tests/unit/v1/sub/test_two.py")),
         ("none", "", ()),
     ]
     for mode, content, expected in cases:
@@ -272,6 +273,23 @@ def test_exact_checkout_uses_requested_commits_and_detached_head():
         history.cleanup()
 
 
+def test_collector_checkout_preserves_merge_base_for_subset_selection():
+    repo = test_tests_fetcher.TmpRepo()
+    destination = repo.root.parent / f"{repo.root.name}-collector"
+    try:
+        repo.write("deepspeed/leaf.py", "VALUE = 11\n")
+        repo.commit("touch leaf")
+        head = repo._git("rev-parse", "HEAD").strip()
+        base = repo._git("rev-parse", "master").strip()
+        torch_latest._checkout_exact(str(repo.root), head, str(repo.root), base, destination)
+        selection = test_tests_fetcher.TestSelector(destination, test_tests_fetcher.CONFIG).select("refs/ci/base")
+        assert selection.mode == "subset", selection.reason
+        assert {path.relative_to(destination).as_posix() for path in selection.tests} == {"tests/unit/v1/test_leaf.py"}
+    finally:
+        shutil.rmtree(destination, ignore_errors=True)
+        repo.cleanup()
+
+
 def test_exact_checkout_rejects_escaping_symlink_and_cleans_destination():
     history = LocalHistory(escaping_symlink=True)
     destination = history.root.parent / f"{history.root.name}-checkout"
@@ -347,6 +365,17 @@ def test_controller_inputs_and_push_manual_fallback():
         assert resolved.repository == "deepspeedai/DeepSpeed"
         assert resolved.sha == "b" * 40
 
+        requirements = torch_latest.resolve_controller_inputs(
+            _valid_env(
+                path,
+                GITHUB_EVENT_NAME="workflow_dispatch",
+                MODAL_TRANSFORMERS_SOURCE="requirements",
+                MODAL_TRANSFORMERS_REF="main",
+            ))
+        assert requirements.transformers_source == "requirements"
+        assert requirements.transformers_ref == ""
+        assert not any("Transformers" in command.label for command in torch_latest.build_remote_commands(requirements))
+
         missing_pr = dict(fallback)
         missing_pr["GITHUB_EVENT_NAME"] = "pull_request_target"
         _expect_error(torch_latest.resolve_controller_inputs, missing_pr)
@@ -369,7 +398,7 @@ def test_remote_plan_is_structural_and_preserves_order_and_scope():
         assert pytest_command.argv[separator + 1:] == ("tests/unit/v1/test_one.py", )
         fetch = next(command for command in commands if command.label == "fetch candidate SHA")
         assert "https://github.com/example/DeepSpeed.git" in fetch.argv
-        assert f"{'c' * 40}:refs/devds/candidate" in fetch.argv
+        assert f"{'c' * 40}:refs/ci/candidate" in fetch.argv
         assert not any("sh" == argument or "bash" == argument for command in commands for argument in command.argv)
     finally:
         shutil.rmtree(root, ignore_errors=True)
@@ -470,15 +499,18 @@ def test_remote_output_is_prefixed_escaped_capped_and_drained():
     original_limit = torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND
     output = io.StringIO()
     try:
-        torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND = 20
+        torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND = 40
         with contextlib.redirect_stdout(output):
-            torch_latest.run_sandbox_command(Sandbox(), modal, torch_latest.RemoteCommand("test", ("command", )))
+            last_line = torch_latest.run_sandbox_command(Sandbox(), modal,
+                                                         torch_latest.RemoteCommand("test", ("command", )))
     finally:
         torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND = original_limit
     text = output.getvalue()
     assert "\n::warning::" not in text
     assert "[sandbox:test] ::warning:: first" in text
+    assert "[sandbox:test] second" not in text
     assert "output truncated" in text
+    assert last_line == "third"
     assert process.waited
 
 
@@ -491,7 +523,8 @@ def test_validate_selection_cli_needs_no_modal_install():
             "PYTHONPATH": "",
         }
         result = subprocess.run(
-            [sys.executable, str(script), "validate-selection", "--mode", "all", "--path", str(path)],
+            [sys.executable, str(script), "validate-selection", "--mode", "all", "--path",
+             str(path)],
             check=False,
             capture_output=True,
             text=True,
@@ -522,6 +555,8 @@ def test_workflow_keeps_github_execution_trusted_and_preserves_modes():
     assert "github.event.pull_request.head.sha" in text
     assert "github.event.pull_request.base.repo.full_name" in text
     assert "github.event.pull_request.base.sha" in text
+    assert "refs/ci/base" in text
+    assert "refs/" + "dev" + "ds" not in text
     assert text.count("modal-torch-latest-test-selection") == 2
     assert "needs.collect-tests.outputs.mode != 'none'" in text
     assert "needs.collect-tests.result != 'success'" in text

--- a/ci/test_torch_latest.py
+++ b/ci/test_torch_latest.py
@@ -1,0 +1,565 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Pure-stdlib security tests for ci/torch_latest.py."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import torch_latest  # noqa: E402
+
+
+def _expect_error(function, *args, exception=ValueError, **kwargs):
+    try:
+        function(*args, **kwargs)
+    except exception as exc:
+        return exc
+    raise AssertionError(f"{function.__name__} unexpectedly succeeded")
+
+
+def _selection_file(content: str) -> tuple[Path, Path]:
+    root = Path(tempfile.mkdtemp(prefix="ds-modal-selection-")).resolve()
+    path = root / "test_list.txt"
+    path.write_text(content, encoding="utf-8")
+    return root, path
+
+
+def _valid_env(path: Path, **overrides: str) -> dict[str, str]:
+    values = {
+        "GITHUB_EVENT_NAME": "pull_request_target",
+        "DS_CI_REPOSITORY": "example/DeepSpeed",
+        "DS_CI_SHA": "a" * 40,
+        "DS_TEST_SELECTION_MODE": "all",
+        "DS_TEST_LIST_FILE": str(path),
+        "MODAL_TORCH_PRESET": "2.10.0-cuda12.8",
+        "MODAL_TRANSFORMERS_SOURCE": "git",
+        "MODAL_TRANSFORMERS_REF": "main",
+    }
+    values.update(overrides)
+    return values
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
+
+
+class LocalHistory:
+
+    def __init__(self, *, escaping_symlink: bool = False):
+        self.root = Path(tempfile.mkdtemp(prefix="ds-modal-git-")).resolve()
+        _git(self.root, "init", "-q", "-b", "master")
+        _git(self.root, "config", "user.email", "ci@example.com")
+        _git(self.root, "config", "user.name", "ci")
+        (self.root / "README.md").write_text("base\n", encoding="utf-8")
+        _git(self.root, "add", "README.md")
+        _git(self.root, "commit", "-q", "-m", "base")
+        self.base = _git(self.root, "rev-parse", "HEAD")
+        if escaping_symlink:
+            (self.root / "unsafe-link").symlink_to("../../outside")
+            _git(self.root, "add", "unsafe-link")
+        else:
+            (self.root / "README.md").write_text("head\n", encoding="utf-8")
+            _git(self.root, "add", "README.md")
+        _git(self.root, "commit", "-q", "-m", "head")
+        self.head = _git(self.root, "rev-parse", "HEAD")
+
+    def cleanup(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+class FakeProcess:
+
+    def __init__(self, lines=None, return_code=0):
+        self.stdout = list(lines or [])
+        self.return_code = return_code
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+        return self.return_code
+
+
+class FakeSandbox:
+
+    def __init__(
+        self,
+        candidate_sha: str,
+        fail_label: str | None = None,
+        cleanup_failure: bool = False,
+        wait_failure: bool = False,
+    ):
+        self.candidate_sha = candidate_sha
+        self.fail_label = fail_label
+        self.cleanup_failure = cleanup_failure
+        self.wait_failure = wait_failure
+        self.exec_calls = []
+        self.processes = []
+        self.terminated = False
+        self.wait_calls = []
+
+    def exec(self, *args, **kwargs):
+        self.exec_calls.append((args, kwargs))
+        lines = [self.candidate_sha + "\n"] if "rev-parse" in args and "HEAD^{commit}" in args else ["ok\n"]
+        label_failure = self.fail_label and self.fail_label in " ".join(args)
+        process = FakeProcess(lines, return_code=9 if label_failure else 0)
+        self.processes.append(process)
+        return process
+
+    def terminate(self):
+        self.terminated = True
+        if self.cleanup_failure:
+            raise RuntimeError("terminate failed")
+
+    def wait(self, raise_on_termination=True):
+        self.wait_calls.append(raise_on_termination)
+        if self.wait_failure:
+            raise RuntimeError("wait failed")
+
+
+def _fake_modal(
+    candidate_sha: str,
+    fail_label: str | None = None,
+    cleanup_failure: bool = False,
+    wait_failure: bool = False,
+    create_failure: bool = False,
+):
+    state = SimpleNamespace(image_calls=[], app_calls=[], create_calls=[])
+    sandbox = FakeSandbox(candidate_sha, fail_label, cleanup_failure, wait_failure)
+
+    class Image:
+
+        @staticmethod
+        def from_registry(image, add_python=None):
+            state.image_calls.append((image, add_python))
+            return ("image", image, add_python)
+
+    class App:
+
+        @staticmethod
+        def lookup(name, create_if_missing=False):
+            state.app_calls.append((name, create_if_missing))
+            return ("app", name)
+
+    class Sandbox:
+
+        @staticmethod
+        def create(*args, **kwargs):
+            state.create_calls.append((args, kwargs))
+            if create_failure:
+                raise RuntimeError("create failed")
+            return sandbox
+
+    stream_type = SimpleNamespace(StreamType=SimpleNamespace(STDOUT=object()))
+    return SimpleNamespace(Image=Image, App=App, Sandbox=Sandbox, stream_type=stream_type), state, sandbox
+
+
+def test_module_import_is_modal_free():
+    assert "modal" not in torch_latest.__dict__, "Modal was imported at module load time"
+
+
+def test_repository_and_sha_validation():
+    assert torch_latest.validate_repository("owner/repo.name-1") == "owner/repo.name-1"
+    assert torch_latest.validate_sha("A" * 40) == "a" * 40
+    for value in ("owner", "https://github.com/owner/repo", "../repo", "-owner/repo", "owner/repo/sub"):
+        _expect_error(torch_latest.validate_repository, value)
+    for value in ("a" * 39, "g" * 40, "-a" * 20, "a" * 40 + "\n"):
+        _expect_error(torch_latest.validate_sha, value)
+
+
+def test_transformers_ref_validation():
+    assert torch_latest.validate_transformers_ref("main") == "main"
+    assert torch_latest.validate_transformers_ref("A" * 40) == "a" * 40
+    for value in ("-main", "https://example.test/repo", "bad ref", "bad\nref", "branch..name"):
+        _expect_error(torch_latest.validate_transformers_ref, value)
+
+
+def test_selection_modes_and_path_validation():
+    cases = [
+        ("all", "tests/unit/v1\n", ("tests/unit/v1", )),
+        ("subset", "tests/unit/v1/test_one.py\ntests/unit/v1/sub/test_two.py\n",
+         ("tests/unit/v1/test_one.py", "tests/unit/v1/sub/test_two.py")),
+        ("none", "", ()),
+    ]
+    for mode, content, expected in cases:
+        root, path = _selection_file(content)
+        try:
+            assert torch_latest.load_test_selection(path, mode) == expected
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    invalid = [
+        ("all", ""),
+        ("all", "tests/unit/v1/test_one.py\n"),
+        ("subset", ""),
+        ("subset", "tests/unit/v1/../test_bad.py\n"),
+        ("subset", "/tests/unit/v1/test_bad.py\n"),
+        ("subset", "tests\\unit\\v1\\test_bad.py\n"),
+        ("subset", "--collect-only\n"),
+        ("subset", "tests/unit/v1/helper.py\n"),
+        ("none", "tests/unit/v1\n"),
+        ("bogus", ""),
+    ]
+    for mode, content in invalid:
+        root, path = _selection_file(content)
+        try:
+            _expect_error(torch_latest.load_test_selection, path, mode)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+def test_selection_rejects_duplicate_symlink_size_count_and_controls():
+    invalid_contents = [
+        "tests/unit/v1/test_one.py\ntests/unit/v1/test_one.py\n",
+        "tests/unit/v1/test_\x01bad.py\n",
+        "\n",
+    ]
+    for content in invalid_contents:
+        root, path = _selection_file(content)
+        try:
+            _expect_error(torch_latest.load_test_selection, path, "subset")
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    root, path = _selection_file("tests/unit/v1/test_one.py\n")
+    link = root / "link"
+    link.symlink_to(path)
+    try:
+        _expect_error(torch_latest.load_test_selection, link, "subset")
+        path.write_text("x" * (torch_latest.MAX_TEST_LIST_BYTES + 1), encoding="utf-8")
+        _expect_error(torch_latest.load_test_selection, path, "subset")
+        path.write_text("\n".join(f"tests/unit/v1/test_{index}.py" for index in range(1025)), encoding="utf-8")
+        _expect_error(torch_latest.load_test_selection, path, "subset")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_exact_checkout_uses_requested_commits_and_detached_head():
+    history = LocalHistory()
+    destination = history.root.parent / f"{history.root.name}-checkout"
+    try:
+        torch_latest._checkout_exact(str(history.root), history.head, str(history.root), history.base, destination)
+        assert _git(destination, "rev-parse", "HEAD") == history.head
+        detached = subprocess.run(
+            ["git", "symbolic-ref", "-q", "HEAD"],
+            cwd=destination,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert detached.returncode == 1
+        _expect_error(
+            torch_latest._checkout_exact,
+            str(history.root),
+            history.head,
+            str(history.root),
+            history.base,
+            destination,
+        )
+    finally:
+        shutil.rmtree(destination, ignore_errors=True)
+        history.cleanup()
+
+
+def test_exact_checkout_rejects_escaping_symlink_and_cleans_destination():
+    history = LocalHistory(escaping_symlink=True)
+    destination = history.root.parent / f"{history.root.name}-checkout"
+    try:
+        _expect_error(
+            torch_latest._checkout_exact,
+            str(history.root),
+            history.head,
+            str(history.root),
+            history.base,
+            destination,
+        )
+        assert not destination.exists()
+    finally:
+        shutil.rmtree(destination, ignore_errors=True)
+        history.cleanup()
+
+
+def test_candidate_checkout_builds_public_urls_from_validated_metadata():
+    captured = []
+    original = torch_latest._checkout_exact
+    try:
+        torch_latest._checkout_exact = lambda *args: captured.append(args)
+        destination = Path("fixed-candidate")
+        torch_latest.checkout_candidate(
+            "fork-owner/DeepSpeed",
+            "A" * 40,
+            "deepspeedai/DeepSpeed",
+            "B" * 40,
+            destination,
+        )
+    finally:
+        torch_latest._checkout_exact = original
+    assert captured == [(
+        "https://github.com/fork-owner/DeepSpeed.git",
+        "a" * 40,
+        "https://github.com/deepspeedai/DeepSpeed.git",
+        "b" * 40,
+        destination,
+    )]
+
+
+def test_git_environment_is_positive_allowlist():
+    env = torch_latest.build_git_env({
+        "PATH": "/safe/path",
+        "MODAL_TOKEN_SECRET": "secret",
+        "GITHUB_TOKEN": "token",
+        "HF_TOKEN": "hf",
+        "HOME": "/untrusted",
+    })
+    assert env["PATH"] == "/safe/path"
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    for key in ("MODAL_TOKEN_SECRET", "GITHUB_TOKEN", "HF_TOKEN", "HOME"):
+        assert key not in env
+
+
+def test_controller_inputs_and_push_manual_fallback():
+    root, path = _selection_file("tests/unit/v1\n")
+    try:
+        explicit = torch_latest.resolve_controller_inputs(_valid_env(path))
+        assert explicit.repository == "example/DeepSpeed"
+        assert explicit.sha == "a" * 40
+
+        fallback = _valid_env(path)
+        fallback.update({
+            "GITHUB_EVENT_NAME": "push",
+            "DS_CI_REPOSITORY": "",
+            "DS_CI_SHA": "",
+            "GITHUB_REPOSITORY": "deepspeedai/DeepSpeed",
+            "GITHUB_SHA": "B" * 40,
+        })
+        resolved = torch_latest.resolve_controller_inputs(fallback)
+        assert resolved.repository == "deepspeedai/DeepSpeed"
+        assert resolved.sha == "b" * 40
+
+        missing_pr = dict(fallback)
+        missing_pr["GITHUB_EVENT_NAME"] = "pull_request_target"
+        _expect_error(torch_latest.resolve_controller_inputs, missing_pr)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_remote_plan_is_structural_and_preserves_order_and_scope():
+    root, path = _selection_file("tests/unit/v1/test_one.py\n")
+    try:
+        inputs = torch_latest.resolve_controller_inputs(
+            _valid_env(path, DS_TEST_SELECTION_MODE="subset", DS_CI_SHA="C" * 40))
+        commands = torch_latest.build_remote_commands(inputs)
+        assert all(isinstance(command.argv, tuple) for command in commands)
+        labels = [command.label for command in commands]
+        assert labels.index("install runtime requirements") < labels.index("reinstall Torch packages")
+        assert labels.index("reinstall Torch packages") < labels.index("install candidate DeepSpeed")
+        pytest_command = next(command for command in commands if command.label == "run pytest")
+        separator = pytest_command.argv.index("--")
+        assert pytest_command.argv[separator + 1:] == ("tests/unit/v1/test_one.py", )
+        fetch = next(command for command in commands if command.label == "fetch candidate SHA")
+        assert "https://github.com/example/DeepSpeed.git" in fetch.argv
+        assert f"{'c' * 40}:refs/devds/candidate" in fetch.argv
+        assert not any("sh" == argument or "bash" == argument for command in commands for argument in command.argv)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_sandbox_kwargs_are_fixed_and_secret_free():
+    kwargs = torch_latest.build_sandbox_kwargs("image")
+    assert kwargs["gpu"] == "l40s:2"
+    assert kwargs["timeout"] == 3600
+    assert kwargs["secrets"] == []
+    assert kwargs["network_file_systems"] == {}
+    assert kwargs["volumes"] == {}
+    assert kwargs["encrypted_ports"] == []
+    assert kwargs["unencrypted_ports"] == []
+    assert kwargs["proxy"] is None
+    joined = repr(kwargs).upper()
+    for forbidden in ("MODAL_TOKEN", "GITHUB_TOKEN", "HF_TOKEN", "OIDC", "CONNECT_TOKEN"):
+        assert forbidden not in joined
+
+
+def test_controller_creates_one_sandbox_without_forwarding_secrets_and_cleans_up():
+    root, path = _selection_file("tests/unit/v1\n")
+    try:
+        env = _valid_env(
+            path,
+            MODAL_TOKEN_ID="controller-only",
+            MODAL_TOKEN_SECRET="controller-only",
+            GITHUB_TOKEN="not-forwarded",
+            HF_TOKEN="not-forwarded",
+        )
+        fake, state, sandbox = _fake_modal("a" * 40)
+        assert torch_latest.run_controller(env, fake) == 0
+        assert state.app_calls == [(torch_latest.APP_NAME, True)]
+        assert len(state.create_calls) == 1
+        create_kwargs = state.create_calls[0][1]
+        assert create_kwargs["gpu"] == "l40s:2"
+        assert create_kwargs["secrets"] == []
+        assert set(create_kwargs["env"]) == set(torch_latest.build_sandbox_env())
+        assert sandbox.terminated
+        assert sandbox.wait_calls == [False]
+        assert all(process.waited for process in sandbox.processes)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_controller_propagates_command_and_cleanup_failures():
+    root, path = _selection_file("tests/unit/v1\n")
+    try:
+        env = _valid_env(path)
+        fake, _, sandbox = _fake_modal("a" * 40, fail_label="pytest")
+        _expect_error(torch_latest.run_controller, env, fake, exception=RuntimeError)
+        assert sandbox.terminated
+
+        fake, _, sandbox = _fake_modal("a" * 40, fail_label="pytest", cleanup_failure=True)
+        error = _expect_error(
+            torch_latest.run_controller,
+            env,
+            fake,
+            exception=torch_latest.ControllerCleanupError,
+        )
+        assert isinstance(error.primary, RuntimeError)
+        assert isinstance(error.cleanup, RuntimeError)
+
+        fake, _, sandbox = _fake_modal("a" * 40, wait_failure=True)
+        _expect_error(torch_latest.run_controller, env, fake, exception=RuntimeError)
+        assert sandbox.terminated
+        assert sandbox.wait_calls == [False]
+
+        fake, state, sandbox = _fake_modal("a" * 40, create_failure=True)
+        _expect_error(torch_latest.run_controller, env, fake, exception=RuntimeError)
+        assert len(state.create_calls) == 1
+        assert not sandbox.terminated
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_none_mode_creates_no_modal_resources():
+    root, path = _selection_file("")
+    try:
+        fake, state, _ = _fake_modal("a" * 40)
+        assert torch_latest.run_controller(_valid_env(path, DS_TEST_SELECTION_MODE="none"), fake) == 0
+        assert not state.create_calls
+        assert not state.app_calls
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_remote_output_is_prefixed_escaped_capped_and_drained():
+    process = FakeProcess(["::warning:: first\n", "second\n", "third\n"])
+
+    class Sandbox:
+
+        @staticmethod
+        def exec(*args, **kwargs):
+            return process
+
+    modal = SimpleNamespace(stream_type=SimpleNamespace(StreamType=SimpleNamespace(STDOUT=object())))
+    original_limit = torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND
+    output = io.StringIO()
+    try:
+        torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND = 20
+        with contextlib.redirect_stdout(output):
+            torch_latest.run_sandbox_command(Sandbox(), modal, torch_latest.RemoteCommand("test", ("command", )))
+    finally:
+        torch_latest.MAX_DISPLAY_BYTES_PER_COMMAND = original_limit
+    text = output.getvalue()
+    assert "\n::warning::" not in text
+    assert "[sandbox:test] ::warning:: first" in text
+    assert "output truncated" in text
+    assert process.waited
+
+
+def test_validate_selection_cli_needs_no_modal_install():
+    root, path = _selection_file("tests/unit/v1\n")
+    try:
+        script = Path(torch_latest.__file__).resolve()
+        env = {
+            "PATH": os.environ["PATH"],
+            "PYTHONPATH": "",
+        }
+        result = subprocess.run(
+            [sys.executable, str(script), "validate-selection", "--mode", "all", "--path", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "Validated selection mode=all count=1"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_workflow_keeps_github_execution_trusted_and_preserves_modes():
+    workflow = Path(torch_latest.__file__).resolve().parents[1] / ".github/workflows/modal-torch-latest.yml"
+    text = workflow.read_text(encoding="utf-8")
+    trusted_ref = "ref: ${{ github.event.pull_request.base.sha || github.sha }}"
+    assert text.count(trusted_ref) == 2
+    assert "ref: ${{ github.event.pull_request.head.sha" not in text
+    assert "allow-unsafe-pr-checkout" not in text
+    assert "Use base-branch CI scripts" not in text
+    assert "HF_TOKEN" not in text
+    assert "modal==1.2.6" in text
+    assert "timeout-minutes: 20" in text
+    assert "timeout-minutes: 75" in text
+    assert text.count("persist-credentials: false") == 2
+    assert text.count("lfs: false") == 2
+    assert text.count("submodules: false") == 2
+    assert "github.event.pull_request.head.repo.full_name" in text
+    assert "github.event.pull_request.head.sha" in text
+    assert "github.event.pull_request.base.repo.full_name" in text
+    assert "github.event.pull_request.base.sha" in text
+    assert text.count("modal-torch-latest-test-selection") == 2
+    assert "needs.collect-tests.outputs.mode != 'none'" in text
+    assert "needs.collect-tests.result != 'success'" in text
+    assert 'python3 ci/torch_latest.py controller' in text
+
+    deploy = text.split("\n  deploy:\n", 1)[1]
+    assert "CANDIDATE_ROOT" not in deploy
+    assert "checkout-candidate" not in deploy
+    assert "pull_request.head.sha || github.sha" in deploy
+    assert "pull_request.head.repo.full_name || github.repository" in deploy
+
+
+def test_launcher_source_has_no_local_packaging_or_shell_execution():
+    source = Path(torch_latest.__file__).read_text(encoding="utf-8")
+    for forbidden in ("add_local_dir", "modal.Function", "@app.function", "shell=True", "os.system(", "HF_TOKEN"):
+        assert forbidden not in source
+
+
+def _all_test_functions():
+    return sorted((name, obj) for name, obj in globals().items() if name.startswith("test_") and callable(obj))
+
+
+def main() -> int:
+    failures = 0
+    tests = _all_test_functions()
+    for name, function in tests:
+        try:
+            function()
+            print(f"PASS {name}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"ERROR {name}: {type(exc).__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests_fetcher.py
+++ b/ci/tests_fetcher.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import html
 import os
 import subprocess
 import sys
@@ -618,14 +619,33 @@ class TestSelector:
 # --------------------------------------------------------------------------- #
 # CLI / CI glue.
 # --------------------------------------------------------------------------- #
-def _emit_github_output(mode: str, num_tests: int, reason: str) -> None:
+def _single_line(text: object) -> str:
+    """Render untrusted repository text without controls or extra log lines."""
+    return "".join(char if char.isprintable() else f"\\x{ord(char):02x}" for char in str(text))
+
+
+def _emit_github_output(mode: str, count: int) -> None:
+    if mode not in {"all", "subset", "none"}:
+        raise ValueError(f"invalid selection mode: {mode!r}")
+    if not isinstance(count, int) or count < 0:
+        raise ValueError(f"invalid selection count: {count!r}")
     gh_out = os.environ.get("GITHUB_OUTPUT")
     if not gh_out:
         return
     with open(gh_out, "a", encoding="utf-8") as fh:
         fh.write(f"mode={mode}\n")
-        fh.write(f"num_tests={num_tests}\n")
-        fh.write(f"reason={reason}\n")
+        fh.write(f"count={count}\n")
+
+
+def _resolve_output_path(trusted_root: Path, value: str) -> Path:
+    output_arg = Path(value)
+    if output_arg.is_absolute():
+        raise ValueError("--output-file must be relative to the trusted script checkout")
+    output_path = trusted_root / output_arg
+    resolved_output_path = output_path.resolve()
+    if not resolved_output_path.is_relative_to(trusted_root.resolve()) or output_path.is_symlink():
+        raise ValueError("--output-file must not escape or replace the trusted script checkout")
+    return output_path
 
 
 def _write_step_summary(config: WorkflowConfig, sel: Selection, targets: list[str]) -> None:
@@ -633,18 +653,15 @@ def _write_step_summary(config: WorkflowConfig, sel: Selection, targets: list[st
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
         return
-    # chr(96) is a backtick; kept out of f-string literals so flake8's W604
-    # (Python-2 backtick) check -- which doesn't mute f-string contents -- won't fire.
-    bt = chr(96)
 
     def code(text: object) -> str:
-        return f"{bt}{text}{bt}"
+        return f"<code>{html.escape(_single_line(text), quote=True)}</code>"
 
     lines = [
         f"### Test selection: {code(config.name)}",
         "",
         f"- **decision:** {code(sel.mode)}",
-        f"- **reason:** {sel.reason}",
+        f"- **reason:** {code(sel.reason)}",
         f"- **pytest targets:** {len(targets)}",
         "",
     ]
@@ -679,6 +696,11 @@ def main() -> None:
         "Default: origin/master.",
     )
     parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repository tree to analyze. Output remains anchored in the trusted script checkout.",
+    )
+    parser.add_argument(
         "--output-file",
         default="ci/.test_selection/test_list.txt",
         help="Where to write the test targets to run (one per line). "
@@ -697,7 +719,8 @@ def main() -> None:
     args = parser.parse_args()
 
     config = WORKFLOWS[args.workflow]
-    selector = TestSelector(REPO_ROOT, config)
+    repo_root = Path(args.repo_root).resolve()
+    selector = TestSelector(repo_root, config)
 
     if args.explain:
         try:
@@ -718,18 +741,21 @@ def main() -> None:
     if sel.mode == "all":
         targets = list(config.test_scopes)
     else:
-        targets = [p.relative_to(REPO_ROOT).as_posix() for p in sel.tests]
+        targets = [p.relative_to(repo_root).as_posix() for p in sel.tests]
 
-    out_path = (REPO_ROOT / args.output_file).resolve()
+    try:
+        out_path = _resolve_output_path(REPO_ROOT, args.output_file)
+    except ValueError as exc:
+        parser.error(str(exc))
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text("\n".join(targets) + ("\n" if targets else ""), encoding="utf-8")
 
-    print(f"\n### MODE: {sel.mode} ({sel.reason}) ###")
+    print(f"\n### MODE: {sel.mode} ({_single_line(sel.reason)}) ###")
     print(f"### {len(targets)} pytest target(s) -> {out_path.relative_to(REPO_ROOT)} ###")
     for t in targets:
-        print(f"  {t}")
+        print(f"  {_single_line(t)}")
 
-    _emit_github_output(sel.mode, len(sel.tests), sel.reason)
+    _emit_github_output(sel.mode, len(targets))
     _write_step_summary(config, sel, targets)
 
 

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -2,14 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team
+"""Trusted controller for the modal-torch-latest workflow.
 
+GitHub runs this file from the trusted base revision. Pull-request code is
+identified only by a validated public repository name and exact commit SHA,
+then fetched, installed, and tested inside a no-secret Modal Sandbox.
+
+The ``checkout-candidate`` and ``validate-selection`` subcommands are
+pure-stdlib so the no-secret selection job can use them without importing
+Modal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
 import os
-import shlex
-from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
 
-import modal
-
-ROOT_PATH = Path(__file__).parents[1]
 DEFAULT_MODAL_TORCH_PRESET = "2.10.0-cuda12.8"
 DEFAULT_MODAL_TRANSFORMERS_SOURCE = "git"
 MODAL_TORCH_PRESETS = {
@@ -50,171 +66,587 @@ MODAL_TORCH_PRESETS = {
     },
 }
 PYTORCH_CUDA_128_INDEX_URL = "https://download.pytorch.org/whl/cu128"
+APP_NAME = "deepspeedai-torch-latest-ci"
+SANDBOX_TIMEOUT_SECONDS = 3600
+MAX_TEST_LIST_BYTES = 64 * 1024
+MAX_TEST_TARGETS = 1024
+MAX_DISPLAY_BYTES_PER_COMMAND = 16 * 1024 * 1024
+REMOTE_ROOT = "/workspace"
+REMOTE_REPOSITORY = f"{REMOTE_ROOT}/deepspeed"
+REMOTE_TRANSFORMERS = f"{REMOTE_ROOT}/transformers"
+
+_REPOSITORY_COMPONENT = r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}"
+_REPOSITORY_RE = re.compile(rf"{_REPOSITORY_COMPONENT}/{_REPOSITORY_COMPONENT}\Z")
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
+_TEST_FILE_RE = re.compile(r"tests/unit/v1/(?:[^/\x00-\x1f\x7f]+/)*test_[^/\x00-\x1f\x7f]+\.py\Z")
 
 
-def resolve_modal_torch_config():
-    selected_preset = os.environ.get("MODAL_TORCH_PRESET") or DEFAULT_MODAL_TORCH_PRESET
+@dataclass(frozen=True)
+class ControllerInputs:
+    repository: str
+    sha: str
+    selection_mode: str
+    targets: tuple[str, ...]
+    torch_preset: str
+    transformers_source: str
+    transformers_ref: str
+
+
+@dataclass(frozen=True)
+class RemoteCommand:
+    label: str
+    argv: tuple[str, ...]
+    workdir: str | None = None
+    expected_line: str | None = None
+
+
+class ControllerCleanupError(RuntimeError):
+    """A primary controller failure accompanied by a cleanup failure."""
+
+    def __init__(self, primary: BaseException, cleanup: BaseException):
+        super().__init__(f"controller failed ({primary}); Sandbox cleanup also failed ({cleanup})")
+        self.primary = primary
+        self.cleanup = cleanup
+
+
+def validate_repository(value: str) -> str:
+    if not isinstance(value, str) or not _REPOSITORY_RE.fullmatch(value):
+        raise ValueError("repository must be an ASCII owner/name pair")
+    return value
+
+
+def validate_sha(value: str) -> str:
+    if not isinstance(value, str) or not _SHA_RE.fullmatch(value):
+        raise ValueError("commit SHA must contain exactly 40 hexadecimal characters")
+    return value.lower()
+
+
+def validate_transformers_ref(value: str) -> str:
+    if not isinstance(value, str) or not 1 <= len(value) <= 200:
+        raise ValueError("Transformers ref must contain 1-200 characters")
+    if value.startswith("-") or "://" in value or any(char.isspace() or not char.isprintable() for char in value):
+        raise ValueError("Transformers ref contains unsafe syntax")
+    if _SHA_RE.fullmatch(value):
+        return value.lower()
+    result = subprocess.run(
+        ["git", "check-ref-format", "--branch", value],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=build_git_env(),
+    )
+    if result.returncode:
+        raise ValueError("Transformers ref is not a valid branch-like git ref")
+    return value
+
+
+def _validate_target(value: str) -> str:
+    if not isinstance(value, str) or not value or value.startswith("-") or "\\" in value:
+        raise ValueError(f"invalid pytest target: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"invalid pytest target: {value!r}")
+    if not _TEST_FILE_RE.fullmatch(value):
+        raise ValueError(f"pytest target is outside tests/unit/v1 or is not a test file: {value!r}")
+    return value
+
+
+def load_test_selection(path: Path, mode: str) -> tuple[str, ...]:
+    if mode not in {"all", "subset", "none"}:
+        raise ValueError(f"invalid selection mode: {mode!r}")
     try:
-        preset_config = MODAL_TORCH_PRESETS[selected_preset]
-    except KeyError as exc:
-        supported = ", ".join(sorted(MODAL_TORCH_PRESETS))
-        raise ValueError(f"Unsupported MODAL_TORCH_PRESET={selected_preset!r}; supported values: {supported}") from exc
-
-    return {
-        "preset": selected_preset,
-        **preset_config,
-    }
-
-
-def resolve_modal_transformers_config():
-    transformers_source = os.environ.get("MODAL_TRANSFORMERS_SOURCE") or DEFAULT_MODAL_TRANSFORMERS_SOURCE
-    supported_sources = {"requirements", "git"}
-    if transformers_source not in supported_sources:
-        supported = ", ".join(sorted(supported_sources))
-        raise ValueError(
-            f"Unsupported MODAL_TRANSFORMERS_SOURCE={transformers_source!r}; supported values: {supported}")
-
-    transformers_ref = os.environ.get("MODAL_TRANSFORMERS_REF") or ""
-    if transformers_source == "git" and not transformers_ref:
-        transformers_ref = "main"
-
-    return {
-        "source": transformers_source,
-        "ref": transformers_ref,
-    }
-
-
-def transformers_override_commands():
-    if MODAL_TRANSFORMERS_CONFIG["source"] == "requirements":
+        metadata = path.lstat()
+    except OSError as exc:
+        raise ValueError(f"test selection file is unavailable: {path}") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("test selection must be a non-symlink regular file")
+    if metadata.st_size > MAX_TEST_LIST_BYTES:
+        raise ValueError("test selection exceeds the 64 KiB limit")
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ValueError("test selection is not readable UTF-8") from exc
+    if any((ord(char) < 32 and char != "\n") or ord(char) == 127 for char in raw):
+        raise ValueError("test selection contains control characters")
+    lines = raw.splitlines()
+    if any(not line for line in lines):
+        raise ValueError("test selection contains an empty line")
+    if len(lines) > MAX_TEST_TARGETS:
+        raise ValueError("test selection exceeds the 1024-target limit")
+    if len(lines) != len(set(lines)):
+        raise ValueError("test selection contains duplicate targets")
+    if mode == "all":
+        if lines != ["tests/unit/v1"]:
+            raise ValueError("all mode requires exactly tests/unit/v1")
+        return tuple(lines)
+    if mode == "none":
+        if lines:
+            raise ValueError("none mode requires an empty selection")
         return ()
-
-    transformers_ref = shlex.quote(MODAL_TRANSFORMERS_CONFIG["ref"])
-    return (
-        "rm -rf /tmp/transformers",
-        "git clone --filter=blob:none https://github.com/huggingface/transformers /tmp/transformers",
-        "cd /tmp/transformers && "
-        f"git checkout {transformers_ref} && "
-        "resolved_ref=$(git rev-parse HEAD) && "
-        "echo \"Resolved Transformers git ref: ${resolved_ref}\" && "
-        "pip install .",
-    )
+    if not lines:
+        raise ValueError("subset mode requires at least one test")
+    return tuple(_validate_target(line) for line in lines)
 
 
-def torch_package_reinstall_command():
-    command = [
-        "pip",
-        "install",
-        "--force-reinstall",
-        "--no-cache-dir",
-        "--index-url",
-        PYTORCH_CUDA_128_INDEX_URL,
-        MODAL_TORCH_CONFIG["torch_package"],
-        MODAL_TORCH_CONFIG["torchvision_package"],
+def build_git_env(source: Mapping[str, str] | None = None) -> dict[str, str]:
+    source = source or os.environ
+    result = {
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/bin/false",
+        "SSH_ASKPASS": "/bin/false",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_LFS_SKIP_SMUDGE": "1",
+        "LC_ALL": "C.UTF-8",
+    }
+    for key in ("PATH", "SYSTEMROOT"):
+        if source.get(key):
+            result[key] = source[key]
+    return result
+
+
+def _git_command(*args: str) -> list[str]:
+    return [
+        "git",
+        "-c",
+        "credential.helper=",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "filter.lfs.smudge=",
+        "-c",
+        "filter.lfs.required=false",
+        *args,
     ]
-    return " ".join(shlex.quote(part) for part in command)
 
 
-MODAL_TORCH_CONFIG = resolve_modal_torch_config()
-MODAL_TRANSFORMERS_CONFIG = resolve_modal_transformers_config()
-MODAL_TORCH_IMAGE = MODAL_TORCH_CONFIG["image"]
-MODAL_TORCH_TEST_VERSION = MODAL_TORCH_CONFIG["torch_test_version"]
-MODAL_CUDA_TEST_VERSION = MODAL_TORCH_CONFIG["cuda_test_version"]
+def _run_local(argv: Sequence[str], *, cwd: Path | None = None) -> str:
+    return subprocess.run(
+        list(argv),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=build_git_env(),
+    ).stdout
 
-# Full test sub-tree this workflow runs by default.
-DEFAULT_TEST_TARGET = "tests/unit/v1/"
+
+def _validate_checkout_symlinks(destination: Path) -> None:
+    root = destination.resolve()
+    output = _run_local(_git_command("ls-files", "-z", "-s"), cwd=root)
+    for record in output.split("\0"):
+        if not record:
+            continue
+        metadata, relative = record.split("\t", 1)
+        mode = metadata.split(" ", 1)[0]
+        if mode != "120000":
+            continue
+        link = root / relative
+        target = link.resolve(strict=False)
+        if not target.is_relative_to(root):
+            raise ValueError(f"tracked symlink escapes candidate checkout: {relative!r}")
 
 
-def resolve_selected_tests():
-    """pytest targets selected by the diff-driven fetcher (ci/tests_fetcher.py).
-
-    The fetcher writes one target per line (individual test files for a narrowed
-    run, or just ``tests/unit/v1`` for a full run). The ``collect-tests`` CI job
-    produces this file and the ``deploy`` job downloads it into place before
-    ``modal run``. We read it here on the runner (at image-build time) and bake the
-    targets into the image env so the remote ``pytest`` picks them up.
-
-    Falls back to the whole v1 suite when the file is missing or empty (local runs,
-    or selection skipped), so behavior is unchanged unless a selection is provided.
-    """
-    env_path = os.environ.get("DS_TEST_LIST_FILE", "")
-    list_file = Path(env_path) if env_path else ROOT_PATH / "ci" / ".test_selection" / "test_list.txt"
-    if not list_file.is_absolute():
-        list_file = ROOT_PATH / list_file
+def _checkout_exact(
+    head_url: str,
+    head_sha: str,
+    base_url: str,
+    base_sha: str,
+    destination: Path,
+) -> None:
+    if destination.exists() or destination.is_symlink():
+        raise ValueError(f"checkout destination already exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    created = False
     try:
-        targets = [line.strip() for line in list_file.read_text().splitlines() if line.strip()]
-    except OSError:
-        targets = []
-    return targets or [DEFAULT_TEST_TARGET]
-
-
-SELECTED_TESTS = resolve_selected_tests()
-
-# yapf: disable
-image = (modal.Image
-         .from_registry(MODAL_TORCH_IMAGE, add_python="3.10")
-         .env({
-             "MODAL_TORCH_PRESET": MODAL_TORCH_CONFIG["preset"],
-             "MODAL_TRANSFORMERS_SOURCE": MODAL_TRANSFORMERS_CONFIG["source"],
-             "MODAL_TRANSFORMERS_REF": MODAL_TRANSFORMERS_CONFIG["ref"],
-             "DS_SELECTED_TESTS": " ".join(SELECTED_TESTS),
-         })
-         .run_commands("apt update && apt install -y git libaio-dev")
-         .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
-         .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-dev.txt", gpu="any")
-         .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-deepcompile.txt", gpu="any")
-         .run_commands(torch_package_reinstall_command())
+        _run_local(_git_command("init", str(destination)))
+        created = True
+        fetch_head = _git_command(
+            "-C",
+            str(destination),
+            "fetch",
+            "--no-tags",
+            "--no-recurse-submodules",
+            "--depth=1",
+            head_url,
+            f"{head_sha}:refs/devds/head",
         )
-
-transformers_commands = transformers_override_commands()
-if transformers_commands:
-    image = image.run_commands(*transformers_commands)
-
-image = (image
-         .add_local_dir(ROOT_PATH , remote_path="/root/", copy=True)
-         .run_commands("pip install /root")
-         .add_local_dir(ROOT_PATH / "accelerator", remote_path="/root/deepspeed/accelerator")
-         .add_local_dir(ROOT_PATH / "csrc", remote_path="/root/deepspeed/ops/csrc")
-         .add_local_dir(ROOT_PATH / "op_builder", remote_path="/root/deepspeed/ops/op_builder")
+        _run_local(fetch_head)
+        fetch_base = _git_command(
+            "-C",
+            str(destination),
+            "fetch",
+            "--no-tags",
+            "--no-recurse-submodules",
+            "--depth=1",
+            base_url,
+            f"{base_sha}:refs/devds/base",
         )
+        _run_local(fetch_base)
+        resolved_head = _run_local(
+            _git_command("-C", str(destination), "rev-parse", "--verify", "refs/devds/head^{commit}")).strip()
+        resolved_base = _run_local(
+            _git_command("-C", str(destination), "rev-parse", "--verify", "refs/devds/base^{commit}")).strip()
+        if resolved_head != head_sha or resolved_base != base_sha:
+            raise ValueError("fetched commit did not match requested event SHA")
+        _run_local(_git_command("-C", str(destination), "checkout", "--detach", "refs/devds/head"))
+        checked_out = _run_local(_git_command("-C", str(destination), "rev-parse", "HEAD")).strip()
+        if checked_out != head_sha:
+            raise ValueError("checked-out HEAD did not match requested event SHA")
+        _validate_checkout_symlinks(destination)
+    except BaseException:
+        if created:
+            shutil.rmtree(destination, ignore_errors=True)
+        raise
 
 
-app = modal.App("deepspeedai-torch-latest-ci", image=image)
-
-
-@app.function(
-    gpu="l40s:2",
-    timeout=3600,
-)
-def pytest():
-    import subprocess
-
-    subprocess.run(
-        [
-            "python",
-            "-c",
-            "import json, torch, torchvision, transformers; "
-            "print('Modal Python package versions: ' + json.dumps({"
-            "'torch': torch.__version__, "
-            "'torch_cuda': torch.version.cuda, "
-            "'torchvision': torchvision.__version__, "
-            "'transformers': transformers.__version__"
-            "}, sort_keys=True))",
-        ],
-        check=True,
-        cwd=ROOT_PATH / ".",
+def checkout_candidate(
+    head_repository: str,
+    head_sha: str,
+    base_repository: str,
+    base_sha: str,
+    destination: Path,
+) -> None:
+    head_repository = validate_repository(head_repository)
+    base_repository = validate_repository(base_repository)
+    head_sha = validate_sha(head_sha)
+    base_sha = validate_sha(base_sha)
+    _checkout_exact(
+        f"https://github.com/{head_repository}.git",
+        head_sha,
+        f"https://github.com/{base_repository}.git",
+        base_sha,
+        destination,
     )
-    selected_tests = os.environ.get("DS_SELECTED_TESTS", DEFAULT_TEST_TARGET).split()
-    print(f"Running pytest on diff-selected targets: {selected_tests}")
-    subprocess.run(
-        [
-            "pytest",
-            "-n",
-            "4",
-            "--verbose",
-            *selected_tests,
-            f"--torch_ver={MODAL_TORCH_TEST_VERSION}",
-            f"--cuda_ver={MODAL_CUDA_TEST_VERSION}",
-        ],
-        check=True,
-        cwd=ROOT_PATH / ".",
+
+
+def resolve_controller_inputs(env: Mapping[str, str]) -> ControllerInputs:
+    event_name = env.get("GITHUB_EVENT_NAME", "")
+    repository = env.get("DS_CI_REPOSITORY", "")
+    sha = env.get("DS_CI_SHA", "")
+    if not repository or not sha:
+        if event_name == "pull_request_target":
+            raise ValueError("pull_request_target requires explicit PR repository and SHA metadata")
+        repository = repository or env.get("GITHUB_REPOSITORY", "")
+        sha = sha or env.get("GITHUB_SHA", "")
+    repository = validate_repository(repository)
+    sha = validate_sha(sha)
+
+    selection_mode = env.get("DS_TEST_SELECTION_MODE", "")
+    selection_file = env.get("DS_TEST_LIST_FILE", "")
+    if not selection_file:
+        raise ValueError("DS_TEST_LIST_FILE is required")
+    targets = load_test_selection(Path(selection_file), selection_mode)
+
+    torch_preset = env.get("MODAL_TORCH_PRESET") or DEFAULT_MODAL_TORCH_PRESET
+    if torch_preset not in MODAL_TORCH_PRESETS:
+        supported = ", ".join(sorted(MODAL_TORCH_PRESETS))
+        raise ValueError(f"unsupported MODAL_TORCH_PRESET={torch_preset!r}; supported values: {supported}")
+    transformers_source = env.get("MODAL_TRANSFORMERS_SOURCE") or DEFAULT_MODAL_TRANSFORMERS_SOURCE
+    if transformers_source not in {"requirements", "git"}:
+        raise ValueError("MODAL_TRANSFORMERS_SOURCE must be 'requirements' or 'git'")
+    transformers_ref = env.get("MODAL_TRANSFORMERS_REF", "")
+    if transformers_source == "git":
+        transformers_ref = validate_transformers_ref(transformers_ref or "main")
+    elif transformers_ref:
+        raise ValueError("MODAL_TRANSFORMERS_REF is only valid when source is 'git'")
+
+    return ControllerInputs(
+        repository=repository,
+        sha=sha,
+        selection_mode=selection_mode,
+        targets=targets,
+        torch_preset=torch_preset,
+        transformers_source=transformers_source,
+        transformers_ref=transformers_ref,
     )
+
+
+def build_sandbox_env() -> dict[str, str]:
+    return {
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/bin/false",
+        "SSH_ASKPASS": "/bin/false",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_LFS_SKIP_SMUDGE": "1",
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PIP_NO_INPUT": "1",
+    }
+
+
+def build_sandbox_kwargs(image: Any) -> dict[str, Any]:
+    return {
+        "image": image,
+        "env": build_sandbox_env(),
+        "secrets": [],
+        "network_file_systems": {},
+        "volumes": {},
+        "encrypted_ports": [],
+        "h2_ports": [],
+        "unencrypted_ports": [],
+        "proxy": None,
+        "block_network": False,
+        "gpu": "l40s:2",
+        "timeout": SANDBOX_TIMEOUT_SECONDS,
+    }
+
+
+def _remote_git(*args: str) -> tuple[str, ...]:
+    return tuple(_git_command(*args))
+
+
+def build_remote_commands(inputs: ControllerInputs) -> tuple[RemoteCommand, ...]:
+    preset = MODAL_TORCH_PRESETS[inputs.torch_preset]
+    repository_url = f"https://github.com/{inputs.repository}.git"
+    commands = [
+        RemoteCommand("install system prerequisites", ("apt-get", "update")),
+        RemoteCommand("install system packages", ("apt-get", "install", "-y", "git", "libaio-dev")),
+        RemoteCommand("create work root", ("mkdir", "-p", REMOTE_ROOT)),
+        RemoteCommand("initialize candidate repository", _remote_git("init", REMOTE_REPOSITORY)),
+        RemoteCommand(
+            "fetch candidate SHA",
+            _remote_git(
+                "-C",
+                REMOTE_REPOSITORY,
+                "fetch",
+                "--no-tags",
+                "--no-recurse-submodules",
+                "--depth=1",
+                repository_url,
+                f"{inputs.sha}:refs/devds/candidate",
+            ),
+        ),
+        RemoteCommand(
+            "checkout candidate SHA",
+            _remote_git("-C", REMOTE_REPOSITORY, "checkout", "--detach", "refs/devds/candidate"),
+        ),
+        RemoteCommand(
+            "verify candidate SHA",
+            _remote_git("-C", REMOTE_REPOSITORY, "rev-parse", "--verify", "HEAD^{commit}"),
+            expected_line=inputs.sha,
+        ),
+        RemoteCommand(
+            "install runtime requirements",
+            ("python", "-m", "pip", "install", "-r", "requirements/requirements.txt"),
+            REMOTE_REPOSITORY,
+        ),
+        RemoteCommand(
+            "install development requirements",
+            ("python", "-m", "pip", "install", "-r", "requirements/requirements-dev.txt"),
+            REMOTE_REPOSITORY,
+        ),
+        RemoteCommand(
+            "install DeepCompile requirements",
+            ("python", "-m", "pip", "install", "-r", "requirements/requirements-deepcompile.txt"),
+            REMOTE_REPOSITORY,
+        ),
+        RemoteCommand(
+            "reinstall Torch packages",
+            (
+                "python",
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "--no-cache-dir",
+                "--index-url",
+                PYTORCH_CUDA_128_INDEX_URL,
+                preset["torch_package"],
+                preset["torchvision_package"],
+            ),
+            REMOTE_REPOSITORY,
+        ),
+    ]
+    if inputs.transformers_source == "git":
+        commands.extend([
+            RemoteCommand("initialize Transformers repository", _remote_git("init", REMOTE_TRANSFORMERS)),
+            RemoteCommand(
+                "fetch Transformers ref",
+                _remote_git(
+                    "-C",
+                    REMOTE_TRANSFORMERS,
+                    "fetch",
+                    "--no-tags",
+                    "--no-recurse-submodules",
+                    "--depth=1",
+                    "https://github.com/huggingface/transformers.git",
+                    inputs.transformers_ref,
+                ),
+            ),
+            RemoteCommand(
+                "checkout Transformers ref",
+                _remote_git("-C", REMOTE_TRANSFORMERS, "checkout", "--detach", "FETCH_HEAD"),
+            ),
+            RemoteCommand(
+                "report Transformers commit",
+                _remote_git("-C", REMOTE_TRANSFORMERS, "rev-parse", "HEAD"),
+            ),
+            RemoteCommand(
+                "install Transformers",
+                ("python", "-m", "pip", "install", "."),
+                REMOTE_TRANSFORMERS,
+            ),
+        ])
+    commands.extend([
+        RemoteCommand("install candidate DeepSpeed", ("python", "-m", "pip", "install", "."), REMOTE_REPOSITORY),
+        RemoteCommand(
+            "report package versions",
+            (
+                "python",
+                "-c",
+                "import json, torch, torchvision, transformers; "
+                "print(json.dumps({'torch': torch.__version__, 'torch_cuda': torch.version.cuda, "
+                "'torchvision': torchvision.__version__, 'transformers': transformers.__version__}, "
+                "sort_keys=True))",
+            ),
+            REMOTE_REPOSITORY,
+        ),
+        RemoteCommand(
+            "run pytest",
+            (
+                "pytest",
+                "-n",
+                "4",
+                "--verbose",
+                f"--torch_ver={preset['torch_test_version']}",
+                f"--cuda_ver={preset['cuda_test_version']}",
+                "--",
+                *inputs.targets,
+            ),
+            REMOTE_REPOSITORY,
+        ),
+    ])
+    return tuple(commands)
+
+
+def _single_line(value: object) -> str:
+    return "".join(char if char.isprintable() else f"\\x{ord(char):02x}" for char in str(value))
+
+
+def run_sandbox_command(sandbox: Any, modal_module: Any, command: RemoteCommand) -> str:
+    process = sandbox.exec(
+        *command.argv,
+        stderr=modal_module.stream_type.StreamType.STDOUT,
+        workdir=command.workdir,
+    )
+    displayed = 0
+    captured: list[str] = []
+    truncated = False
+    for raw_line in process.stdout:
+        line = _single_line(raw_line.rstrip("\r\n"))
+        encoded_size = len(line.encode("utf-8", errors="replace")) + 1
+        if displayed + encoded_size <= MAX_DISPLAY_BYTES_PER_COMMAND:
+            print(f"[sandbox:{command.label}] {line}")
+            displayed += encoded_size
+            captured.append(line)
+        else:
+            truncated = True
+    if truncated:
+        print(f"[sandbox:{command.label}] output truncated after {MAX_DISPLAY_BYTES_PER_COMMAND} bytes")
+    return_code = process.wait()
+    if return_code:
+        raise RuntimeError(f"{command.label} failed with exit code {return_code}")
+    if command.expected_line is not None:
+        actual = captured[-1].strip() if captured else ""
+        if actual != command.expected_line:
+            raise RuntimeError(
+                f"{command.label} returned {_single_line(actual)!r}, expected {command.expected_line!r}")
+    return "\n".join(captured)
+
+
+def _cleanup_sandbox(sandbox: Any) -> None:
+    termination_error = None
+    observation_error = None
+    try:
+        sandbox.terminate()
+    except BaseException as exc:
+        termination_error = exc
+    try:
+        sandbox.wait(raise_on_termination=False)
+    except BaseException as exc:
+        observation_error = exc
+    if termination_error is not None and observation_error is not None:
+        raise RuntimeError(f"Sandbox termination failed ({termination_error}); terminal-state observation also failed "
+                           f"({observation_error})") from termination_error
+    if termination_error is not None:
+        raise termination_error.with_traceback(termination_error.__traceback__)
+    if observation_error is not None:
+        raise observation_error.with_traceback(observation_error.__traceback__)
+
+
+def run_controller(env: Mapping[str, str], modal_module: Any | None = None) -> int:
+    inputs = resolve_controller_inputs(env)
+    if inputs.selection_mode == "none":
+        print("No impacted tests; Modal Sandbox was not created.")
+        return 0
+
+    if modal_module is None:
+        modal_module = importlib.import_module("modal")
+    preset = MODAL_TORCH_PRESETS[inputs.torch_preset]
+    image = modal_module.Image.from_registry(preset["image"], add_python="3.10")
+    app = modal_module.App.lookup(APP_NAME, create_if_missing=True)
+    sandbox = None
+    primary_error: BaseException | None = None
+    cleanup_error: BaseException | None = None
+    try:
+        sandbox = modal_module.Sandbox.create(app=app, **build_sandbox_kwargs(image))
+        for command in build_remote_commands(inputs):
+            run_sandbox_command(sandbox, modal_module, command)
+    except BaseException as exc:
+        primary_error = exc
+    finally:
+        if sandbox is not None:
+            try:
+                _cleanup_sandbox(sandbox)
+            except BaseException as exc:
+                cleanup_error = exc
+
+    if primary_error is not None and cleanup_error is not None:
+        raise ControllerCleanupError(primary_error, cleanup_error) from primary_error
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_error.__traceback__)
+    if cleanup_error is not None:
+        raise RuntimeError(f"Sandbox cleanup failed: {cleanup_error}") from cleanup_error
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    checkout = subparsers.add_parser("checkout-candidate", help="Fetch an exact public PR SHA as data")
+    checkout.add_argument("--head-repository", required=True)
+    checkout.add_argument("--head-sha", required=True)
+    checkout.add_argument("--base-repository", required=True)
+    checkout.add_argument("--base-sha", required=True)
+    checkout.add_argument("--destination", type=Path, required=True)
+
+    selection = subparsers.add_parser("validate-selection", help="Validate a mode/list artifact pair")
+    selection.add_argument("--mode", required=True)
+    selection.add_argument("--path", type=Path, required=True)
+
+    subparsers.add_parser("controller", help="Create the no-secret Modal Sandbox and run the selected tests")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "checkout-candidate":
+        checkout_candidate(
+            args.head_repository,
+            args.head_sha,
+            args.base_repository,
+            args.base_sha,
+            args.destination,
+        )
+        return 0
+    if args.command == "validate-selection":
+        targets = load_test_selection(args.path, args.mode)
+        print(f"Validated selection mode={args.mode} count={len(targets)}")
+        return 0
+    return run_controller(os.environ)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -267,9 +267,8 @@ def _checkout_exact(
             "fetch",
             "--no-tags",
             "--no-recurse-submodules",
-            "--depth=1",
             head_url,
-            f"{head_sha}:refs/devds/head",
+            f"{head_sha}:refs/ci/head",
         )
         _run_local(fetch_head)
         fetch_base = _git_command(
@@ -278,18 +277,17 @@ def _checkout_exact(
             "fetch",
             "--no-tags",
             "--no-recurse-submodules",
-            "--depth=1",
             base_url,
-            f"{base_sha}:refs/devds/base",
+            f"{base_sha}:refs/ci/base",
         )
         _run_local(fetch_base)
         resolved_head = _run_local(
-            _git_command("-C", str(destination), "rev-parse", "--verify", "refs/devds/head^{commit}")).strip()
+            _git_command("-C", str(destination), "rev-parse", "--verify", "refs/ci/head^{commit}")).strip()
         resolved_base = _run_local(
-            _git_command("-C", str(destination), "rev-parse", "--verify", "refs/devds/base^{commit}")).strip()
+            _git_command("-C", str(destination), "rev-parse", "--verify", "refs/ci/base^{commit}")).strip()
         if resolved_head != head_sha or resolved_base != base_sha:
             raise ValueError("fetched commit did not match requested event SHA")
-        _run_local(_git_command("-C", str(destination), "checkout", "--detach", "refs/devds/head"))
+        _run_local(_git_command("-C", str(destination), "checkout", "--detach", "refs/ci/head"))
         checked_out = _run_local(_git_command("-C", str(destination), "rev-parse", "HEAD")).strip()
         if checked_out != head_sha:
             raise ValueError("checked-out HEAD did not match requested event SHA")
@@ -348,8 +346,8 @@ def resolve_controller_inputs(env: Mapping[str, str]) -> ControllerInputs:
     transformers_ref = env.get("MODAL_TRANSFORMERS_REF", "")
     if transformers_source == "git":
         transformers_ref = validate_transformers_ref(transformers_ref or "main")
-    elif transformers_ref:
-        raise ValueError("MODAL_TRANSFORMERS_REF is only valid when source is 'git'")
+    else:
+        transformers_ref = ""
 
     return ControllerInputs(
         repository=repository,
@@ -414,12 +412,12 @@ def build_remote_commands(inputs: ControllerInputs) -> tuple[RemoteCommand, ...]
                 "--no-recurse-submodules",
                 "--depth=1",
                 repository_url,
-                f"{inputs.sha}:refs/devds/candidate",
+                f"{inputs.sha}:refs/ci/candidate",
             ),
         ),
         RemoteCommand(
             "checkout candidate SHA",
-            _remote_git("-C", REMOTE_REPOSITORY, "checkout", "--detach", "refs/devds/candidate"),
+            _remote_git("-C", REMOTE_REPOSITORY, "checkout", "--detach", "refs/ci/candidate"),
         ),
         RemoteCommand(
             "verify candidate SHA",
@@ -531,15 +529,16 @@ def run_sandbox_command(sandbox: Any, modal_module: Any, command: RemoteCommand)
         workdir=command.workdir,
     )
     displayed = 0
-    captured: list[str] = []
+    last_line = ""
     truncated = False
     for raw_line in process.stdout:
         line = _single_line(raw_line.rstrip("\r\n"))
-        encoded_size = len(line.encode("utf-8", errors="replace")) + 1
+        last_line = line
+        rendered = f"[sandbox:{command.label}] {line}"
+        encoded_size = len(rendered.encode("utf-8", errors="replace")) + 1
         if displayed + encoded_size <= MAX_DISPLAY_BYTES_PER_COMMAND:
-            print(f"[sandbox:{command.label}] {line}")
+            print(rendered)
             displayed += encoded_size
-            captured.append(line)
         else:
             truncated = True
     if truncated:
@@ -548,11 +547,11 @@ def run_sandbox_command(sandbox: Any, modal_module: Any, command: RemoteCommand)
     if return_code:
         raise RuntimeError(f"{command.label} failed with exit code {return_code}")
     if command.expected_line is not None:
-        actual = captured[-1].strip() if captured else ""
+        actual = last_line.strip()
         if actual != command.expected_line:
             raise RuntimeError(
                 f"{command.label} returned {_single_line(actual)!r}, expected {command.expected_line!r}")
-    return "\n".join(captured)
+    return last_line
 
 
 def _cleanup_sandbox(sandbox: Any) -> None:


### PR DESCRIPTION
GitHub recently changed `actions/checkout` to reject fork pull request checkouts by default in privileged `pull_request_target` workflows. This protection was introduced in `actions/checkout` v7 and backported to supported floating major versions, including `actions/checkout@v4`. As a result, the current workflow's checkout of `${{ github.event.pull_request.head.sha }}` is now rejected for fork pull requests.

Setting `allow-unsafe-pr-checkout: true` would restore the previous behavior, but it would deliberately bypass this protection. A `pull_request_target` workflow runs trusted default-branch code with access to the base repository's token and secrets. Because this workflow needs `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` to start GPU CI, the code that handles those credentials must remain trusted code from `master`; pull request code must not execute in the same GitHub runner context.

Modal documents Sandboxes as secure containers for executing untrusted code, including checking out a repository and running its test suite. This change follows that model: GitHub runs only the trusted selector and Modal controller, while the pull request is treated as data during test selection. The controller passes only a validated public repository name, exact commit SHA, and validated test selection to a Modal Sandbox. The Sandbox receives no GitHub, Modal, or Hugging Face credentials, and performs the candidate checkout, dependency installation, DeepSpeed installation, and pytest execution itself.