### PR TITLE
Fix WarmupLR collapsing multi-group base LRs to group 0's

### DIFF
--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -670,7 +670,7 @@ class WarmupLR(object):
         self.optimizer = get_torch_optimizer(optimizer)
 
         if warmup_max_lr is None:
-            warmup_max_lr = [group['lr'] for group in self.optimizer.param_groups][0]
+            warmup_max_lr = [group['lr'] for group in self.optimizer.param_groups]
 
         self.min_lrs = self._format_param(self.optimizer, warmup_min_lr, "min_lr")
         self.max_lrs = self._format_param(self.optimizer, warmup_max_lr, "max_lr")

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -546,6 +546,26 @@ def test_warmup_cosine_lr_initializes_all_param_groups():
     assert [group["lr"] for group in optimizer.param_groups] == pytest.approx(expected_lrs)
 
 
+def test_warmup_lr_inherits_per_group_lr_when_max_unspecified():
+    # With warmup_max_lr unspecified, WarmupLR inherits the optimizer's lr; on a
+    # multi-group optimizer it must inherit EACH group's own lr, not group 0's for
+    # all groups. Regression for the trailing [0] on the fallback, which reduced the
+    # per-group list to group 0's scalar and _format_param then broadcast it, so the
+    # other groups' configured LRs were silently discarded.
+    dense = torch.nn.Parameter(torch.zeros(1))
+    expert = torch.nn.Parameter(torch.zeros(1))
+    optimizer = torch.optim.Adam([{"params": [dense], "lr": 0.1}, {"params": [expert], "lr": 0.2}])
+
+    scheduler = WarmupLR(optimizer=optimizer, warmup_num_steps=10)
+
+    assert scheduler.max_lrs == [0.1, 0.2]
+
+    # Step to the end of warmup (gamma == 1.0): each group reaches its own base lr.
+    scheduler.step(10)
+    assert scheduler.get_lr() == pytest.approx([0.1, 0.2])
+    assert [group["lr"] for group in optimizer.param_groups] == pytest.approx([0.1, 0.2])
+
+
 def test_warmup_cosine_lr_total_num_steps_equals_warmup_num_steps():
     # total_num_steps == warmup_num_steps must not raise ZeroDivisionError, and because the
     # cosine decay window is empty, every step past warmup must stay at cos_min_ratio rather


### PR DESCRIPTION
## What

When `warmup_max_lr` is left unspecified, `WarmupLR` inherits the optimizer's learning rate (added in #7360). The fallback computed:

```python
warmup_max_lr = [group['lr'] for group in self.optimizer.param_groups][0]
```

The trailing `[0]` reduces the per-group list to group 0's scalar. `_format_param` then broadcasts that scalar back to every group (`[value] * len(param_groups)`). So on an optimizer with multiple parameter groups that have distinct base LRs, every group warms up to group 0's lr and the other groups' configured LRs are silently discarded.

## Fix

Drop the trailing `[0]` so `_format_param` receives the full per-group list and each group warms up to its own base lr. This mirrors #7969, which fixed the same multi-group collapse in the sibling `WarmupCosineLR`.

## Verification

Reproduced and verified on a CPU-only container against this branch (real `import deepspeed`, module resolved from the checkout). With two param groups at lr 0.1 and 0.2 and `warmup_max_lr` omitted:

- before: `max_lrs == [0.1, 0.1]` (group 1 collapsed to group 0)
- after: `max_lrs == [0.1, 0.2]`

Added `test_warmup_lr_inherits_per_group_lr_when_max_unspecified` in `tests/unit/runtime/test_lr_schedulers.py`, mirroring the existing `test_warmup_cosine_lr_initializes_all_param_groups`. It fails on master (`assert [0.1, 0.1] == [0.1, 0.2]`) and passes with this change. `WarmupDecayLR` defaults `warmup_max_lr=0.001`, so this path only changes behavior when the value is left unspecified.

Ran the repo's formatting hooks (yapf, flake8, codespell, license, end-of-file) on the changed files; all pass.

Note: this is a small follow-on in the same file as my open #8166 (a different scheduler class), kept to a one-line change plus one test.
