### PR TITLE
Make PipelineModule.set_checkpoint_interval actually change the interval

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -208,16 +208,20 @@ class PipelineEngine(DeepSpeedEngine):
         self.agg_train_loss = None
         self.agg_additional_losses = None
 
+        # use_reentrant picks the module's checkpoint function, and that choice also feeds
+        # _is_checkpointable(), so resolve it whatever the configured interval is: the module's
+        # set_checkpoint_interval() can enable checkpointing later, and it would otherwise run
+        # with the reentrant default even though the config asked for non-reentrant.
+        # set use_reentrant default to True.
+        if self._config.pipeline.get('use_reentrant') is None:
+            self._config.pipeline['use_reentrant'] = True
+        if self._config.pipeline['use_reentrant'] is False:
+            # set activation_checkpoint_func to non_reentrant_checkpoint func.
+            self.module.activation_checkpoint_func = ds_checkpointing.non_reentrant_checkpoint
+            if self.grid.get_global_rank() == 0:
+                logger.info('CONFIG: activation_checkpoint_func=non_reentrant_checkpoint')
         if self._config.pipeline['activation_checkpoint_interval'] > 0:
             self.module.activation_checkpoint_interval = self._config.pipeline['activation_checkpoint_interval']
-            # set use_reentrant default to True.
-            if self._config.pipeline.get('use_reentrant') is None:
-                self._config.pipeline['use_reentrant'] = True
-            if self._config.pipeline['use_reentrant'] is False:
-                # set activation_checkpoint_func to non_reentrant_checkpoint func.
-                self.module.activation_checkpoint_func = ds_checkpointing.non_reentrant_checkpoint
-                if self.grid.get_global_rank() == 0:
-                    logger.info('CONFIG: activation_checkpoint_func=non_reentrant_checkpoint')
         if self.module.activation_checkpoint_interval > 0:
             self.module._precompute_checkpointable_values()
 

--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -891,6 +891,20 @@ class PipelineEngine(DeepSpeedEngine):
             self.timers(BACKWARD_MICRO_TIMER).stop()
             self.timers(BACKWARD_GLOBAL_TIMER).stop()
 
+    def _reentrant_activation_checkpointing(self):
+        """True when the module checkpoints activations with the reentrant function.
+
+        Reentrant checkpointing needs the first stage's inputs to require grad, or the
+        first checkpointed segment is detached from autograd. Key that off the module,
+        not off ``self._config.pipeline``: the config only seeds the module at __init__,
+        so a module built with its own ``activation_checkpoint_interval``, or one changed
+        later via ``set_checkpoint_interval()``, would leave the config stale. The forward
+        pass already branches on the module attribute, so this keeps the two in agreement.
+        """
+        if self.module.activation_checkpoint_interval <= 0:
+            return False
+        return self.module.activation_checkpoint_func is not ds_checkpointing.non_reentrant_checkpoint
+
     def _exec_load_micro_batch(self, buffer_id):
         if self.wall_clock_breakdown():
             self.timers(BATCH_INPUT_TIMER).start()
@@ -901,8 +915,7 @@ class PipelineEngine(DeepSpeedEngine):
             loaded = None
             if torch.is_tensor(batch[0]):
                 loaded = batch[0].clone().to(self.device).detach()
-                if self._config.pipeline['activation_checkpoint_interval'] > 0 and self._config.pipeline[
-                        'use_reentrant']:
+                if self._reentrant_activation_checkpointing():
                     loaded.requires_grad = loaded.is_floating_point()
             else:
                 assert isinstance(batch[0], (tuple, list))
@@ -911,8 +924,7 @@ class PipelineEngine(DeepSpeedEngine):
                 for x in batch[0]:
                     assert torch.is_tensor(x)
                     mine = x.clone().detach().to(self.device)
-                    if self._config.pipeline['activation_checkpoint_interval'] > 0 and self._config.pipeline[
-                            'use_reentrant']:
+                    if self._reentrant_activation_checkpointing():
                         mine.requires_grad = mine.is_floating_point()
                     loaded.append(mine)
                 loaded = tuple(loaded)

--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -223,6 +223,9 @@ class PipelineModule(nn.Module):
         if self.activation_checkpoint_interval > 0 and self.is_checkpointable_results_interval != self.activation_checkpoint_interval:
             num_layers = len(self.forward_funcs)
             self.interval_was_zero = False
+            # results are cached per interval, so any left over from a previous interval no longer
+            # line up with the layer blocks forward() builds and must not be carried over
+            self.is_checkpointable_results = []
             for start_idx in range(0, num_layers, self.activation_checkpoint_interval):
                 end_idx = min(start_idx + self.activation_checkpoint_interval, num_layers)
                 funcs = self.forward_funcs[start_idx:end_idx]
@@ -551,7 +554,10 @@ class PipelineModule(nn.Module):
 
     def set_checkpoint_interval(self, interval):
         assert interval >= 0
-        self.checkpoint_interval = interval
+        self.activation_checkpoint_interval = interval
+        # forward() zips the layer blocks against the cached results, so they have to be rebuilt
+        # for the new interval before the next forward pass
+        self._precompute_checkpointable_values()
 
     def topology(self):
         """ ProcessTopology object to query process mappings. """

--- a/tests/unit/pipe/test_pipe_module.py
+++ b/tests/unit/pipe/test_pipe_module.py
@@ -58,6 +58,16 @@ def batch_input():
     return torch.randn(1, HIDDEN_DIM)
 
 
+@pytest.fixture
+def mixed_param_model():
+    # ReLU carries no parameters and Linear does, so _is_checkpointable differs between blocks
+    # and a misaligned result list is visible, not just a wrongly sized one.
+    return torch.nn.Sequential(
+        *[nn.ReLU() for _ in range(LAYERS // 2)],
+        *[nn.Linear(HIDDEN_DIM, HIDDEN_DIM) for _ in range(LAYERS // 2)],
+    )
+
+
 class TestPipeModuleSequential(DistributedTest):
     world_size = 2
     # needs to be set for torch.compile: running torch.compile with daemonic process causes an error
@@ -109,3 +119,25 @@ class TestPipeModuleSequential(DistributedTest):
         pipe_output = pipe_output.to('cpu')
 
         assert torch.allclose(base_output, pipe_output, atol=1e-4)
+
+
+class TestPipeModuleCheckpointInterval(DistributedTest):
+    world_size = 1
+
+    def test_set_checkpoint_interval(self, mixed_param_model):
+        model = PipelineModule(layers=copy.deepcopy(mixed_param_model), num_stages=1, activation_checkpoint_interval=4)
+        model._precompute_checkpointable_values()
+        assert model.is_checkpointable_results == [False, True]
+
+        model.set_checkpoint_interval(1)
+
+        # the setter has to update the interval forward() reads, not a separate attribute
+        assert model.activation_checkpoint_interval == 1
+
+        # and the cached results have to be rebuilt for the new interval rather than appended to,
+        # otherwise forward() zips the layer blocks against results computed for the old interval
+        reference = PipelineModule(layers=copy.deepcopy(mixed_param_model),
+                                   num_stages=1,
+                                   activation_checkpoint_interval=1)
+        reference._precompute_checkpointable_values()
+        assert model.is_checkpointable_results == reference.is_checkpointable_results

--- a/tests/unit/pipe/test_pipe_module.py
+++ b/tests/unit/pipe/test_pipe_module.py
@@ -13,6 +13,7 @@ import pytest
 
 import deepspeed
 from deepspeed.pipe import PipelineModule
+from deepspeed.runtime.activation_checkpointing import checkpointing as ds_checkpointing
 from deepspeed.utils import RepeatingLoader
 from deepspeed.accelerator import get_accelerator
 
@@ -172,4 +173,26 @@ class TestPipeModuleCheckpointInterval(DistributedTest):
                                                model=model,
                                                model_parameters=[p for p in model.parameters()])
         assert engine.module.activation_checkpoint_interval > 0
+        assert not engine._reentrant_activation_checkpointing()
+
+    def test_setter_honors_non_reentrant_when_the_config_disables_checkpointing(self, mixed_param_model,
+                                                                                simple_config):
+        # use_reentrant only reached the module inside the positive-interval branch, so a config
+        # that disables checkpointing left activation_checkpoint_func at the reentrant default.
+        # set_checkpoint_interval() then enabled checkpointing with the wrong function, silently
+        # ignoring use_reentrant=False, and _is_checkpointable() reads the same function.
+        config = copy.deepcopy(simple_config)
+        config["pipeline"]["activation_checkpoint_interval"] = 0
+        config["pipeline"]["use_reentrant"] = False
+
+        model = PipelineModule(layers=copy.deepcopy(mixed_param_model), num_stages=1)
+        engine, _, _, _ = deepspeed.initialize(config=config,
+                                               model=model,
+                                               model_parameters=[p for p in model.parameters()])
+        assert engine.module.activation_checkpoint_interval == 0
+        assert engine.module.activation_checkpoint_func is ds_checkpointing.non_reentrant_checkpoint
+
+        engine.module.set_checkpoint_interval(1)
+
+        assert engine.module.activation_checkpoint_func is ds_checkpointing.non_reentrant_checkpoint
         assert not engine._reentrant_activation_checkpointing()

--- a/tests/unit/pipe/test_pipe_module.py
+++ b/tests/unit/pipe/test_pipe_module.py
@@ -141,3 +141,35 @@ class TestPipeModuleCheckpointInterval(DistributedTest):
                                    activation_checkpoint_interval=1)
         reference._precompute_checkpointable_values()
         assert model.is_checkpointable_results == reference.is_checkpointable_results
+
+    def test_setter_keeps_reentrant_input_grads(self, mixed_param_model, simple_config):
+        # The engine decides whether to mark the first stage's inputs as requiring grad, which
+        # reentrant checkpointing needs, or its first checkpointed segment is cut off from
+        # autograd. Start from a config that disables checkpointing, so the only thing that
+        # turns it on is the setter this PR fixes.
+        config = copy.deepcopy(simple_config)
+        config["pipeline"]["activation_checkpoint_interval"] = 0
+
+        model = PipelineModule(layers=copy.deepcopy(mixed_param_model), num_stages=1)
+        engine, _, _, _ = deepspeed.initialize(config=config,
+                                               model=model,
+                                               model_parameters=[p for p in model.parameters()])
+        assert not engine._reentrant_activation_checkpointing()
+
+        engine.module.set_checkpoint_interval(2)
+
+        # forward() now checkpoints, so the inputs have to require grad to match
+        assert engine._reentrant_activation_checkpointing()
+
+    def test_non_reentrant_checkpointing_does_not_need_input_grads(self, mixed_param_model, simple_config):
+        # use_reentrant=False swaps in non_reentrant_checkpoint, which does not need the inputs
+        # to require grad, so the decision has to track the function and not just the interval.
+        config = copy.deepcopy(simple_config)
+        config["pipeline"]["use_reentrant"] = False
+
+        model = PipelineModule(layers=copy.deepcopy(mixed_param_model), num_stages=1)
+        engine, _, _, _ = deepspeed.initialize(config=config,
+                                               model=model,
+                                               model_parameters=[p for p in model.parameters()])
+        assert engine.module.activation_checkpoint_interval > 0
+        assert not engine._reentrant_activation_checkpointing()


### PR DESCRIPTION
## Problem

`PipelineModule.set_checkpoint_interval()` does not change the activation checkpoint interval.

```python
def set_checkpoint_interval(self, interval):
    assert interval >= 0
    self.checkpoint_interval = interval
```

Every reader uses `self.activation_checkpoint_interval`: `forward()` branches on it and steps the layer loop by it (`module.py` L370-379), `_precompute_checkpointable_values()` keys its cache on it (L223-230), and `PipelineEngine` assigns it directly (`pipe/engine.py` L212). `self.checkpoint_interval` is read nowhere in the repo, so the call assigns a dead attribute and the schedule silently stays as it was.

Assigning the right attribute is not sufficient on its own, because the recompute path it feeds is also broken:

```python
def _precompute_checkpointable_values(self):
    if self.activation_checkpoint_interval > 0 and self.is_checkpointable_results_interval != self.activation_checkpoint_interval:
        num_layers = len(self.forward_funcs)
        self.interval_was_zero = False
        for start_idx in range(0, num_layers, self.activation_checkpoint_interval):
            ...
            self.is_checkpointable_results.append(self._is_checkpointable(funcs))
        self.is_checkpointable_results_interval = self.activation_checkpoint_interval
```

The `is_checkpointable_results_interval != activation_checkpoint_interval` guard exists precisely so the values are recomputed when the interval changes, but the loop appends to `self.is_checkpointable_results` without clearing it, so results computed for the previous interval stay at the front of the list.

`forward()` then pairs the layer blocks with that list positionally:

```python
for start_idx, is_checkpointable_result in \
    zip(range(0, num_layers, self.activation_checkpoint_interval), self.is_checkpointable_results):
```

so each block is checkpointed according to a decision made for a different partitioning of the layers.

## Reproduction

8 layers, the first 4 without parameters and the last 4 with, so `_is_checkpointable` genuinely differs per block. Going from interval 4 to interval 1:

```
interval=4  results: [False, True]

set_checkpoint_interval(1) -> activation_checkpoint_interval = 4     # unchanged
  results: [False, True]                                            # never recomputed

# assigning activation_checkpoint_interval directly, the way PipelineEngine does:
  results: [False, True, False, False, False, False, True, True, True, True]   # 10 entries for 8 blocks
  expected:               [False, False, False, False, True, True, True, True]

forward blocks : [(0, False), (1, True), (2, False), (3, False), (4, False), (5, False), (6, True), (7, True)]
expected       : [(0, False), (1, False), (2, False), (3, False), (4, True), (5, True), (6, True), (7, True)]
```

Blocks 1, 4 and 5 are checkpointed against the wrong decision: block 1 holds no parameters and is checkpointed anyway, blocks 4 and 5 hold parameters and are not.

## Fix

Clear the cached results before recomputing them, and have the setter assign `activation_checkpoint_interval` and rebuild the cache:

```python
self.is_checkpointable_results = []
```

```python
def set_checkpoint_interval(self, interval):
    assert interval >= 0
    self.activation_checkpoint_interval = interval
    self._precompute_checkpointable_values()
```

The setter has to do both. Assigning the interval alone would leave `forward()` zipping the new, longer block range against a list still sized for the old interval, and `zip` stops at the shorter one, so trailing layer blocks would be dropped from the forward pass entirely.

Nothing changes for the normal path: `PipelineEngine` assigns the interval once and calls `_precompute_checkpointable_values()` while the cache is still empty, so clearing an empty list is a no-op and the guard still skips the recompute when the interval is unchanged.

## Testing

`TestPipeModuleCheckpointInterval` in `tests/unit/pipe/test_pipe_module.py` builds a `PipelineModule` at interval 4, calls `set_checkpoint_interval(1)`, and asserts the interval is updated and the results match a module constructed at interval 1 directly. It fails on master on both assertions (the interval stays 4, and the results stay `[False, True]`) and passes with the fix. The mixed `ReLU`/`Linear` model is deliberate: with a uniformly parameterised model only the length of the list is wrong, and the misalignment would not show.

`yapf` and `flake8` are clean on both changed files.
