### PR TITLE
Add keyword argument support to activation checkpointing

### DIFF
--- a/deepspeed/runtime/activation_checkpointing/checkpointing.py
+++ b/deepspeed/runtime/activation_checkpointing/checkpointing.py
@@ -945,9 +945,25 @@ def non_reentrant_checkpoint(function, *args):
 
 
 @compiler.disable  # WA from Pytorch repo for compile + zero 3 accuracy issue
-def checkpoint(function, *args):
+def checkpoint(function, *args, **kwargs):
     """Checkpoint a model or part of the model.
-    This has been directly copied from torch.utils.checkpoint. """
+    This has been directly copied from torch.utils.checkpoint.
+
+    Tensor arguments passed by keyword participate in autograd in the same way as positional tensor arguments.
+    """
+
+    if kwargs:
+        run_function = function
+        kwarg_keys = tuple(kwargs.keys())
+        positional_arg_count = len(args)
+
+        def function_with_kwargs(*all_args):
+            positional_args = all_args[:positional_arg_count]
+            keyword_args = dict(zip(kwarg_keys, all_args[positional_arg_count:]))
+            return run_function(*positional_args, **keyword_args)
+
+        function = function_with_kwargs
+        args = args + tuple(kwargs.values())
 
     all_outputs = []
     CheckpointFunction.apply(function, all_outputs, *args)

--- a/docs/code-docs/source/activation-checkpointing.rst
+++ b/docs/code-docs/source/activation-checkpointing.rst
@@ -24,6 +24,9 @@ Using Activation Checkpointing
 ------------------------------
 .. autofunction:: deepspeed.checkpointing.checkpoint
 
+Keyword arguments are forwarded to the checkpointed function. Tensor values passed by
+keyword participate in autograd just like positional tensor arguments.
+
 .. autofunction:: deepspeed.checkpointing.reset
 
 

--- a/tests/unit/runtime/activation_checkpointing/test_activation_checkpointing.py
+++ b/tests/unit/runtime/activation_checkpointing/test_activation_checkpointing.py
@@ -181,6 +181,33 @@ def _bool_to_float(btensor, dtype=torch.float32):
     return torch.where(btensor, ones, zeros)
 
 
+class TestActivationCheckpointKeywordArguments(DistributedTest):
+    world_size = 1
+
+    def test_tensor_and_non_tensor_keyword_arguments(self):
+        device = get_accelerator().device_name()
+        if device == "cpu":
+            pytest.skip("CPU accelerator does not support this test yet")
+
+        def function(value, *, scale, offset):
+            return value * scale + offset
+
+        value = torch.randn(HIDDEN_DIM, device=device, requires_grad=True)
+        scale = torch.randn(HIDDEN_DIM, device=device, requires_grad=True)
+        reference_value = value.detach().clone().requires_grad_()
+        reference_scale = scale.detach().clone().requires_grad_()
+
+        reference = function(reference_value, scale=reference_scale, offset=1.5)
+        reference.sum().backward()
+
+        output = ckpt(function, value, scale=scale, offset=1.5)
+        output.sum().backward()
+
+        torch.testing.assert_close(output, reference)
+        torch.testing.assert_close(value.grad, reference_value.grad)
+        torch.testing.assert_close(scale.grad, reference_scale.grad)
+
+
 #
 # Tests
 #


### PR DESCRIPTION
## Summary

DeepSpeed's activation checkpointing wrapper currently accepts positional
arguments only, while `torch.utils.checkpoint.checkpoint` also supports keyword
arguments. This change allows callers to pass keyword arguments through
`deepspeed.checkpointing.checkpoint`.

Keyword names and non-Tensor values are retained for reconstruction during the
forward and recompute passes. Tensor keyword values are flattened into the
inputs passed to `CheckpointFunction`, so autograd tracks them and returns their
gradients correctly.

The activation checkpointing documentation now describes keyword argument
support, and the regression test covers both Tensor and non-Tensor keyword
arguments as well as gradient propagation.

## Validation

- Activation checkpointing unit tests: 27 passed
- Pre-commit checks for all changed files: passed
- 1-GPU CUDA correctness smoke: direct and checkpointed execution matched, with
  zero maximum gradient error
- 2-GPU distributed CUDA correctness smoke: each rank matched direct execution,
  with zero maximum gradient error
- DCO sign-off is included in the commit

Fixes #7038
