### PR TITLE
Enable ZeRO-3 linear wrapper for existing models

### DIFF
--- a/deepspeed/runtime/zero/linear.py
+++ b/deepspeed/runtime/zero/linear.py
@@ -114,22 +114,34 @@ class LinearFunctionForZeroStage3(torch.autograd.Function):
             input, weight, bias = ctx.saved_tensors
 
             grad_input = grad_weight = grad_bias = None
+            weight_was_partitioned = (hasattr(weight, "ds_status")
+                                      and getattr(weight.ds_status, "name", None) == "NOT_AVAILABLE")
+            if weight_was_partitioned:
+                weight.all_gather()
 
-            dim = grad_output.dim()
-            if ctx.needs_input_grad[0]:
-                grad_input = grad_output.matmul(weight)
-            if ctx.needs_input_grad[1]:
-                if dim > 2:
-                    grad_weight = grad_output.reshape(-1, grad_output.shape[-1]).t().matmul(
-                        input.reshape(-1, input.shape[-1]))
-                else:
-                    grad_weight = grad_output.t().matmul(input)
-            if bias is not None and ctx.needs_input_grad[2]:
-                if dim > 2:
-                    grad_bias = grad_output.sum([i for i in range(dim - 1)])
-                else:
-                    grad_bias = grad_output.sum(0)
-            return grad_input, grad_weight, grad_bias
+            try:
+                dim = grad_output.dim()
+                if ctx.needs_input_grad[0]:
+                    grad_input = grad_output.matmul(weight)
+                if ctx.needs_input_grad[1]:
+                    if dim > 2:
+                        grad_weight = grad_output.reshape(-1, grad_output.shape[-1]).t().matmul(
+                            input.reshape(-1, input.shape[-1]))
+                    elif dim == 1:
+                        grad_weight = grad_output.unsqueeze(-1) * input.unsqueeze(0)
+                    else:
+                        grad_weight = grad_output.t().matmul(input)
+                if bias is not None and ctx.needs_input_grad[2]:
+                    if dim > 2:
+                        grad_bias = grad_output.sum([i for i in range(dim - 1)])
+                    elif dim == 1:
+                        grad_bias = grad_output
+                    else:
+                        grad_bias = grad_output.sum(0)
+                return grad_input, grad_weight, grad_bias
+            finally:
+                if weight_was_partitioned:
+                    weight.partition()
 
 
 def zero3_linear_wrap(input, weight, bias=None):

--- a/deepspeed/runtime/zero/linear.py
+++ b/deepspeed/runtime/zero/linear.py
@@ -24,6 +24,7 @@ from torch.nn.parameter import Parameter
 from torch.nn import init
 from torch.nn.modules.module import Module
 from deepspeed.runtime.utils import noop_decorator
+from deepspeed.runtime.zero.utils import is_zero_param
 from deepspeed import comm as dist
 from deepspeed.accelerator import get_accelerator
 
@@ -114,7 +115,7 @@ class LinearFunctionForZeroStage3(torch.autograd.Function):
             input, weight, bias = ctx.saved_tensors
 
             grad_input = grad_weight = grad_bias = None
-            weight_was_partitioned = (hasattr(weight, "ds_status")
+            weight_was_partitioned = (is_zero_param(weight)
                                       and getattr(weight.ds_status, "name", None) == "NOT_AVAILABLE")
             if weight_was_partitioned:
                 weight.all_gather()

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -395,6 +395,14 @@ class InsertPostInitMethodToModuleSubClasses(object):
             self.dtype = dtype or torch.float16 if get_accelerator().is_fp16_supported(
             ) else torch.bfloat16 if get_accelerator().is_bf16_supported else torch.float32
 
+    def _enable_mem_efficient_linear(self):
+        print_rank_0(
+            "nn.functional.linear has been overridden with a more memory efficient version. This will persist unless manually reset.",
+            force=False)
+        if not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk"):
+            InsertPostInitMethodToModuleSubClasses.linear_bk = torch.nn.functional.linear
+            torch.nn.functional.linear = zero3_linear_wrap
+
     def patch_init_and_builtins(self):
 
         def apply_with_gather(orig_module_apply_fn: Callable) -> Callable:
@@ -578,12 +586,7 @@ class InsertPostInitMethodToModuleSubClasses(object):
             self._add_tensor_creation_wrappers()
 
         if self.mem_efficient_linear:
-            print_rank_0(
-                "nn.functional.linear has been overridden with a more memory efficient version. This will persist unless manually reset.",
-                force=False)
-            if not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk"):
-                InsertPostInitMethodToModuleSubClasses.linear_bk = torch.nn.functional.linear
-                torch.nn.functional.linear = zero3_linear_wrap
+            self._enable_mem_efficient_linear()
 
             if self.quantized_initialization:
                 print_rank_0("nn.functional.linear has been overridden with quantized linear version.", force=False)
@@ -1017,6 +1020,9 @@ class Init(InsertPostInitMethodToModuleSubClasses):
         if not dist.is_initialized():
             init_distributed()
             assert dist.is_initialized(), "Parameters cannot be scattered without initializing deepspeed.comm"
+
+        if module is not None and self.enabled and self.mem_efficient_linear:
+            self._enable_mem_efficient_linear()
 
         if data_parallel_group is None:
             self.ds_process_group = dist.get_world_group()

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -401,6 +401,7 @@ class InsertPostInitMethodToModuleSubClasses(object):
             force=False)
         if not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk"):
             InsertPostInitMethodToModuleSubClasses.linear_bk = torch.nn.functional.linear
+        if torch.nn.functional.linear is InsertPostInitMethodToModuleSubClasses.linear_bk:
             torch.nn.functional.linear = zero3_linear_wrap
 
     def patch_init_and_builtins(self):

--- a/tests/unit/runtime/zero/test_zero_linear_direct_init.py
+++ b/tests/unit/runtime/zero/test_zero_linear_direct_init.py
@@ -1,0 +1,131 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import torch
+import torch.nn.functional as F
+
+import deepspeed
+from deepspeed.runtime.zero.partition_parameters import (InsertPostInitMethodToModuleSubClasses, ZeroParamStatus,
+                                                         zero3_linear_wrap)
+from deepspeed.utils import safe_get_full_fp32_param, safe_get_full_grad
+from unit.common import DistributedTest
+
+
+def _zero3_config(memory_efficient_linear):
+    return {
+        "train_micro_batch_size_per_gpu": 2,
+        "zero_optimization": {
+            "stage": 3,
+            "memory_efficient_linear": memory_efficient_linear,
+            "stage3_param_persistence_threshold": 0,
+            "stage3_max_reuse_distance": 0,
+        },
+    }
+
+
+def _storage_id(tensor):
+    return tensor.untyped_storage()._cdata
+
+
+class TestZero3LinearDirectInit(DistributedTest):
+    world_size = 2
+
+    def test_wrapper_and_parameter_storage_lifecycle(self):
+        torch.manual_seed(20260728)
+        assert not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk")
+        original_linear = F.linear
+        model = torch.nn.Linear(4, 3)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=0.1)
+        reference_input = torch.arange(8, dtype=torch.float32).reshape(2, 4) / 8
+        reference_weight = model.weight.detach().clone().requires_grad_()
+        reference_bias = model.bias.detach().clone().requires_grad_()
+        reference_output = original_linear(reference_input, reference_weight, reference_bias)
+        reference_output.sum().backward()
+
+        engine, *_ = deepspeed.initialize(model=model,
+                                          optimizer=optimizer,
+                                          config_params=_zero3_config(memory_efficient_linear=True))
+        assert F.linear is zero3_linear_wrap
+        assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear
+
+        weight = engine.module.weight
+        saved = []
+        unpacked = []
+
+        def pack_hook(tensor):
+            is_weight = tensor is weight
+            if is_weight:
+                saved.append((_storage_id(tensor), tensor.numel()))
+            return is_weight, tensor
+
+        def unpack_hook(packed):
+            is_weight, tensor = packed
+            if is_weight:
+                unpacked.append((_storage_id(tensor), tensor.numel()))
+            return tensor
+
+        inputs = reference_input.to(engine.device)
+        with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
+            output = engine(inputs)
+            assert saved and saved[0][1] == reference_weight.numel()
+            p0_storage = saved[0][0]
+            assert weight.ds_status == ZeroParamStatus.NOT_AVAILABLE
+            assert weight.numel() == 0
+            engine.backward(output.sum())
+
+        assert unpacked and unpacked[0][1] == reference_weight.numel()
+        assert unpacked[0][0] != p0_storage
+        assert all(storage != p0_storage for storage, _ in unpacked)
+        assert weight.ds_status == ZeroParamStatus.NOT_AVAILABLE
+        torch.testing.assert_close(output.detach().cpu(), reference_output.detach())
+        torch.testing.assert_close(safe_get_full_grad(weight).cpu(), reference_weight.grad)
+        torch.testing.assert_close(safe_get_full_grad(engine.module.bias).cpu(), reference_bias.grad)
+
+        before_step = safe_get_full_fp32_param(weight).clone()
+        engine.step()
+        after_step = safe_get_full_fp32_param(weight)
+        assert not torch.equal(before_step, after_step)
+
+
+class TestZero3LinearDirectInitDisabled(DistributedTest):
+    world_size = 2
+
+    def test_disabled_preserves_builtin_linear(self):
+        torch.manual_seed(20260728)
+        assert not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk")
+        original_linear = F.linear
+        model = torch.nn.Linear(4, 3)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=0.1)
+
+        engine, *_ = deepspeed.initialize(model=model,
+                                          optimizer=optimizer,
+                                          config_params=_zero3_config(memory_efficient_linear=False))
+        assert F.linear is original_linear
+        assert not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk")
+
+        output = engine(torch.ones(2, 4, device=engine.device))
+        engine.backward(output.sum())
+        assert safe_get_full_grad(engine.module.weight) is not None
+        engine.step()
+
+
+class TestZero3LinearInitContextPersistence(DistributedTest):
+    world_size = 1
+
+    def test_context_activation_is_idempotent_and_persistent(self):
+        assert not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk")
+        original_linear = F.linear
+        config = _zero3_config(memory_efficient_linear=True)
+
+        init = deepspeed.zero.Init(config_dict_or_path=config)
+        assert F.linear is original_linear
+        with init:
+            assert F.linear is zero3_linear_wrap
+            with deepspeed.zero.Init(config_dict_or_path=config):
+                assert F.linear is zero3_linear_wrap
+                assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear
+
+        assert F.linear is zero3_linear_wrap
+        assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear

--- a/tests/unit/runtime/zero/test_zero_linear_direct_init.py
+++ b/tests/unit/runtime/zero/test_zero_linear_direct_init.py
@@ -129,3 +129,54 @@ class TestZero3LinearInitContextPersistence(DistributedTest):
 
         assert F.linear is zero3_linear_wrap
         assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear
+
+    def test_direct_init_reinstalls_wrapper_without_replacing_backup(self):
+        assert not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk")
+        original_linear = F.linear
+        config = _zero3_config(memory_efficient_linear=True)
+
+        first_model = torch.nn.Linear(4, 3)
+        deepspeed.zero.Init(module=first_model, config_dict_or_path=config)
+        assert F.linear is zero3_linear_wrap
+        assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear
+
+        F.linear = original_linear
+        second_model = torch.nn.Linear(4, 3)
+        deepspeed.zero.Init(module=second_model, config_dict_or_path=config)
+
+        assert F.linear is zero3_linear_wrap
+        assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear
+
+    def test_direct_init_preserves_quantized_linear_wrapper(self):
+        assert not hasattr(InsertPostInitMethodToModuleSubClasses, "linear_bk")
+        original_linear = F.linear
+        quantized_config = _zero3_config(memory_efficient_linear=True)
+        quantized_config["weight_quantization"] = {
+            "quantized_initialization": {
+                "num_bits": 8,
+                "group_size": 2,
+                "group_dim": 1,
+                "symmetric": False,
+            },
+        }
+
+        with deepspeed.zero.Init(config_dict_or_path=quantized_config, dtype=torch.float32):
+            quantized_model = torch.nn.Linear(4, 4)
+
+        quantized_linear = F.linear
+        assert quantized_linear is not zero3_linear_wrap
+        assert quantized_linear.__wrapped__ is zero3_linear_wrap
+        assert quantized_model.weight.weight_quantized
+
+        ordinary_model = torch.nn.Linear(4, 4)
+        deepspeed.zero.Init(module=ordinary_model,
+                            config_dict_or_path=_zero3_config(memory_efficient_linear=True),
+                            dtype=torch.float32)
+
+        assert F.linear is quantized_linear
+        assert InsertPostInitMethodToModuleSubClasses.linear_bk is original_linear
+        with deepspeed.zero.GatheredParameters(quantized_model.parameters()):
+            inputs = torch.ones(2, 4, device=quantized_model.weight.device, dtype=quantized_model.weight.dtype)
+            output = F.linear(inputs, quantized_model.weight, quantized_model.bias)
+        assert output.shape == (2, 4)
+        assert torch.isfinite(output).all()

--- a/tests/unit/v1/zero/test_zero_activation_checkpoint_lifecycle.py
+++ b/tests/unit/v1/zero/test_zero_activation_checkpoint_lifecycle.py
@@ -11,6 +11,7 @@ from torch.utils.checkpoint import checkpoint, set_checkpoint_early_stop
 import deepspeed
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.zero.linear import zero3_linear_wrap
 from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
 
 from unit.common import DistributedTest
@@ -71,11 +72,12 @@ class _RaiseOnceInBackward(torch.autograd.Function):
         return grad_output, None
 
 
-def _zero3_config(*, gradient_accumulation_steps=1, dtype=torch.float32):
+def _zero3_config(*, gradient_accumulation_steps=1, dtype=torch.float32, module_granularity_threshold=0):
     config = get_config_dict(3, gradient_accumulation_steps=gradient_accumulation_steps, force_fp32=True)
     # Zero reuse window + no prefetch so residency reflects the current consumer, not a future reuse.
     config["zero_optimization"]["stage3_prefetch_bucket_size"] = 0
     config["zero_optimization"]["stage3_max_reuse_distance"] = 0
+    config["zero_optimization"]["stage3_module_granularity_threshold"] = module_granularity_threshold
     if dtype == torch.float16:
         config["fp16"] = {"enabled": True, "initial_scale_power": 8}
     elif dtype == torch.bfloat16:
@@ -83,10 +85,12 @@ def _zero3_config(*, gradient_accumulation_steps=1, dtype=torch.float32):
     return config
 
 
-def _initialize_zero3(model, *, gradient_accumulation_steps=1, dtype=torch.float32):
+def _initialize_zero3(model, *, gradient_accumulation_steps=1, dtype=torch.float32, module_granularity_threshold=0):
     trainable_parameters = [parameter for parameter in model.parameters() if parameter.requires_grad]
     engine, _, _, _ = deepspeed.initialize(config=_zero3_config(
-        gradient_accumulation_steps=gradient_accumulation_steps, dtype=dtype),
+        gradient_accumulation_steps=gradient_accumulation_steps,
+        dtype=dtype,
+        module_granularity_threshold=module_granularity_threshold),
                                            model=model,
                                            model_parameters=trainable_parameters)
     return engine
@@ -310,10 +314,14 @@ class TestZero3ActivationCheckpointLifecycle(DistributedTest):
 
     world_size = 1
 
-    def test_reused_checkpointed_module_invocations_release_independently(self):
+    @pytest.mark.parametrize("fast_sharding", [False, True])
+    def test_reused_checkpointed_module_invocations_release_independently(self, fast_sharding):
         """Nested calls to one module must retire independent hook invocations despite sharing a ds_id."""
         device, _, _ = initialize_distributed()
-        engine = _initialize_zero3(_RecursiveCheckpointModel(hidden_dim=8))
+        engine = _initialize_zero3(_RecursiveCheckpointModel(hidden_dim=8),
+                                   module_granularity_threshold=1_000_000 if fast_sharding else 0)
+        assert F.linear is zero3_linear_wrap
+        assert bool(getattr(engine.module, "_z3_leaf", False)) is fast_sharding
         value = torch.randn(2, 8, device=device, dtype=torch.float32, requires_grad=True)
 
         engine.backward(engine(value).sum())

--- a/tests/unit/v1/zero/test_zero_functorch_linear.py
+++ b/tests/unit/v1/zero/test_zero_functorch_linear.py
@@ -89,6 +89,22 @@ class TestZeroLinearAutocast(DistributedTest):
 
     world_size = 1
 
+    def test_unbatched_backward_matches_reference(self):
+        device = get_accelerator().device_name()
+        weight = torch.randn(4, 8, device=device, requires_grad=True)
+        inp = torch.randn(8, device=device, requires_grad=True)
+        bias = torch.randn(4, device=device, requires_grad=True)
+        reference_weight = weight.detach().clone().requires_grad_()
+        reference_input = inp.detach().clone().requires_grad_()
+        reference_bias = bias.detach().clone().requires_grad_()
+
+        zero3_linear_wrap(inp, weight, bias).sum().backward()
+        (reference_input.matmul(reference_weight.t()) + reference_bias).sum().backward()
+
+        torch.testing.assert_close(weight.grad, reference_weight.grad)
+        torch.testing.assert_close(inp.grad, reference_input.grad)
+        torch.testing.assert_close(bias.grad, reference_bias.grad)
+
     def _run_forward_backward(self, device, use_autocast, dtype=None):
         """Run zero3_linear_wrap forward+backward, optionally inside autocast."""
         weight = torch.randn(4, 4, device=device, dtype=torch.float32, requires_grad=True)


### PR DESCRIPTION
Passing an already-constructed model to `deepspeed.initialize()` with ZeRO-3 and `memory_efficient_linear=true` does not install the ZeRO-3 Linear wrapper. The wrapper is currently installed only when the model is constructed inside a `deepspeed.zero.Init()` context.

Without the wrapper, the standard Linear implementation can retain the gathered weight storage until backward completes, significantly increasing memory usage.

This PR activates the existing ZeRO-3 Linear wrapper for the `deepspeed.initialize(model=...)` path when `memory_efficient_linear=true`, without requiring a `deepspeed.zero.Init()` context.