### PR TITLE
Derive AutoEP rank splits from the per-expert count exchange

### DIFF
--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -93,6 +93,46 @@ def apply_scores_before_experts_if_enabled(
     return routed_input
 
 
+def _split_plan_from_expert_counts(
+    num_tokens_per_expert: torch.Tensor,  # [E_global], int32
+    ep_size: int,
+    num_local_experts: int,
+    ep_group: dist.ProcessGroup | None,
+) -> SplitPlan:
+    """Build a SplitPlan from a global per-expert token histogram (ep_size > 1).
+
+    A single all-to-all exchanges the whole ``[ep_size, E_local]`` count matrix.
+    Row ``s`` of the received matrix holds the per-local-expert counts sent by
+    source rank ``s``, so summing it over experts recovers exactly the per-rank
+    totals that a separate rank-count exchange would have produced.
+    """
+    count_matrix = num_tokens_per_expert.view(ep_size, num_local_experts)
+
+    send_counts = count_matrix.reshape(-1).contiguous()  # [ep_size * E_local]
+    received_counts_flat = torch.empty_like(send_counts)
+    dist.all_to_all_single(
+        received_counts_flat,
+        send_counts,
+        group=ep_group,
+    )
+    received_counts = received_counts_flat.view(ep_size, num_local_experts)
+
+    # input_splits: tokens THIS rank sends to each destination rank.
+    # output_splits: tokens THIS rank receives from each source rank.
+    # Stacked so both split lists share a single device-to-host sync.
+    input_splits, output_splits = torch.stack((
+        count_matrix.sum(dim=1),
+        received_counts.sum(dim=1),
+    )).cpu().tolist()
+
+    return SplitPlan(
+        input_splits=input_splits,
+        output_splits=output_splits,
+        local_counts=received_counts.sum(dim=0),  # [E_local]
+        local_counts_by_source=received_counts,
+    )
+
+
 def compute_split_plan(
     selected_experts: torch.Tensor,  # [T, K]
     num_experts: int,
@@ -105,15 +145,15 @@ def compute_split_plan(
     Returns SplitPlan with input_splits, output_splits, local_counts, and
     local_counts_by_source.
     """
-    T_K = selected_experts.numel()
+    num_tokens_per_expert = count_tokens_per_expert(
+        selected_experts,
+        num_experts,
+        out_dtype=torch.int32,
+    )
 
     if ep_size == 1:
         # No dispatch needed - all tokens stay local
-        num_tokens_per_expert = count_tokens_per_expert(
-            selected_experts,
-            num_experts,
-            out_dtype=torch.int32,
-        )
+        T_K = selected_experts.numel()
         return SplitPlan(
             input_splits=[T_K],
             output_splits=[T_K],
@@ -121,56 +161,7 @@ def compute_split_plan(
             local_counts_by_source=num_tokens_per_expert.view(1, num_local_experts),
         )
 
-    # Count tokens per expert globally
-    num_tokens_per_expert = count_tokens_per_expert(
-        selected_experts,
-        num_experts,
-        out_dtype=torch.int32,
-    )
-
-    # Reshape to [ep_size, num_local_experts] to get per-rank counts
-    count_matrix = num_tokens_per_expert.view(ep_size, num_local_experts)
-
-    # input_splits: how many tokens THIS rank sends to each destination rank
-    input_splits = count_matrix.sum(dim=1).cpu().tolist()
-
-    # Exchange counts with all ranks to get output_splits
-    # Each rank tells every other rank how many tokens it will send
-    local_counts_tensor = count_matrix.sum(dim=1).clone()  # [ep_size]
-    remote_counts_tensor = torch.zeros_like(local_counts_tensor)
-
-    dist.all_to_all_single(
-        remote_counts_tensor,
-        local_counts_tensor,
-        group=ep_group,
-    )
-    output_splits = remote_counts_tensor.cpu().tolist()
-
-    # local_counts: how many tokens this rank will process for each local expert
-    # After receiving tokens, we need per-expert counts for this rank
-    local_expert_counts = count_matrix[:, :].clone()  # [ep_size, E_local]
-
-    # Exchange the detailed per-expert counts
-    # Each rank needs to know, for its local experts, how many tokens come from each source
-    local_expert_counts_flat = local_expert_counts.view(-1).contiguous()  # [ep_size * E_local]
-    received_counts_flat = torch.zeros_like(local_expert_counts_flat)
-
-    dist.all_to_all_single(
-        received_counts_flat,
-        local_expert_counts_flat,
-        group=ep_group,
-    )
-
-    # Sum over source ranks to get total per local expert
-    received_counts = received_counts_flat.view(ep_size, num_local_experts)
-    local_counts = received_counts.sum(dim=0)  # [E_local]
-
-    return SplitPlan(
-        input_splits=input_splits,
-        output_splits=output_splits,
-        local_counts=local_counts,
-        local_counts_by_source=received_counts,
-    )
+    return _split_plan_from_expert_counts(num_tokens_per_expert, ep_size, num_local_experts, ep_group)
 
 
 def compute_split_plan_from_expert_indices(
@@ -181,25 +172,12 @@ def compute_split_plan_from_expert_indices(
     ep_group: dist.ProcessGroup | None,
 ) -> SplitPlan:
     """Compute EP AllToAllV splits for an already partitioned assignment list."""
+    counts = count_tokens_per_expert(expert_indices, num_experts, out_dtype=torch.int32)
     if ep_size == 1:
-        counts = count_tokens_per_expert(expert_indices, num_experts, out_dtype=torch.int32)
         return SplitPlan([int(expert_indices.numel())], [int(expert_indices.numel())], counts,
                          counts.view(1, num_local_experts))
 
-    counts = count_tokens_per_expert(expert_indices, num_experts, out_dtype=torch.int32)
-    count_matrix = counts.view(ep_size, num_local_experts)
-    input_splits = count_matrix.sum(dim=1).cpu().tolist()
-    local_counts_tensor = count_matrix.sum(dim=1).clone()
-    remote_counts_tensor = torch.zeros_like(local_counts_tensor)
-    dist.all_to_all_single(remote_counts_tensor, local_counts_tensor, group=ep_group)
-    output_splits = remote_counts_tensor.cpu().tolist()
-
-    local_expert_counts_flat = count_matrix.reshape(-1).contiguous()
-    received_counts_flat = torch.zeros_like(local_expert_counts_flat)
-    dist.all_to_all_single(received_counts_flat, local_expert_counts_flat, group=ep_group)
-    received_counts = received_counts_flat.view(ep_size, num_local_experts)
-    local_counts = received_counts.sum(dim=0)
-    return SplitPlan(input_splits, output_splits, local_counts, received_counts)
+    return _split_plan_from_expert_counts(counts, ep_size, num_local_experts, ep_group)
 
 
 class _AllToAllV(torch.autograd.Function):

--- a/tests/unit/v1/moe/test_autoep_unit.py
+++ b/tests/unit/v1/moe/test_autoep_unit.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 import deepspeed.runtime.engine as ds_engine
 import deepspeed.runtime.zero.stage3 as zero_stage3
 import deepspeed.moe.ep_repack as ep_repack
+import deepspeed.module_inject.auto_ep_layer as auto_ep_layer
 from deepspeed.module_inject.auto_ep import AutoEP, _resolve_route_scale
 from deepspeed.module_inject.auto_ep_config import (
     AutoEPConfig,
@@ -28,8 +29,11 @@ from deepspeed.module_inject.auto_ep_config import (
 )
 from deepspeed.module_inject.auto_ep_layer import (
     AutoEPMoELayer,
+    SplitPlan,
     apply_scores_before_experts_if_enabled,
     combine_from_routed,
+    compute_split_plan,
+    compute_split_plan_from_expert_indices,
     resolve_score_apply_mode,
 )
 from deepspeed.module_inject.auto_ep_preset_adapters import get_preset_adapter
@@ -892,6 +896,167 @@ class TestRoutingAndLayerSemantics:
                            ep_size=1,
                            ep_rank=0,
                            config=AutoEPConfig(enabled=True, autoep_size=1, load_balance_coeff=0.02))
+
+
+SPLIT_PLAN_EP_SIZE = 3
+SPLIT_PLAN_LOCAL_EXPERTS = 2
+SPLIT_PLAN_NUM_EXPERTS = SPLIT_PLAN_EP_SIZE * SPLIT_PLAN_LOCAL_EXPERTS
+
+# Each row is one source rank's flat [E_global] histogram over global experts.
+SPLIT_PLAN_SCENARIOS = {
+    "balanced": [[2, 2, 2, 2, 2, 2], [2, 2, 2, 2, 2, 2], [2, 2, 2, 2, 2, 2]],
+    "severe_skew": [[11, 0, 0, 0, 0, 1], [0, 1, 0, 9, 0, 0], [0, 0, 4, 0, 0, 8]],
+    "zero_token_destination": [[3, 1, 0, 0, 4, 0], [2, 2, 0, 0, 0, 5], [1, 1, 0, 0, 2, 2]],
+    "empty_local_expert": [[0, 4, 3, 1, 0, 6], [0, 2, 1, 1, 0, 3], [0, 5, 2, 2, 0, 1]],
+    "silent_source": [[4, 1, 2, 3, 1, 1], [0, 0, 0, 0, 0, 0], [1, 1, 1, 1, 1, 1]],
+}
+
+
+def _split_plan_counts(scenario):
+    return [torch.tensor(row, dtype=torch.int32) for row in SPLIT_PLAN_SCENARIOS[scenario]]
+
+
+def _split_plan_received(all_counts, ep_rank):
+    """Rows of the matrix rank ``ep_rank`` receives from the counts all-to-all."""
+    return torch.stack([counts.view(SPLIT_PLAN_EP_SIZE, SPLIT_PLAN_LOCAL_EXPERTS)[ep_rank]
+                        for counts in all_counts]).to(torch.int32)
+
+
+def _selected_experts_from_counts(counts):
+    """Build a routing assignment list whose histogram is exactly ``counts``."""
+    return torch.repeat_interleave(torch.arange(counts.numel()), counts.to(torch.int64))
+
+
+def _legacy_split_plan(num_tokens_per_expert):
+    """The two-collective planner this change replaces, kept as a reference."""
+    count_matrix = num_tokens_per_expert.to(torch.int32).view(SPLIT_PLAN_EP_SIZE, SPLIT_PLAN_LOCAL_EXPERTS)
+    input_splits = count_matrix.sum(dim=1).cpu().tolist()
+
+    rank_counts = count_matrix.sum(dim=1).clone()
+    remote_rank_counts = torch.zeros_like(rank_counts)
+    auto_ep_layer.dist.all_to_all_single(remote_rank_counts, rank_counts, group=None)
+    output_splits = remote_rank_counts.cpu().tolist()
+
+    expert_counts = count_matrix.reshape(-1).contiguous()
+    received_flat = torch.zeros_like(expert_counts)
+    auto_ep_layer.dist.all_to_all_single(received_flat, expert_counts, group=None)
+    received_counts = received_flat.view(SPLIT_PLAN_EP_SIZE, SPLIT_PLAN_LOCAL_EXPERTS)
+
+    return SplitPlan(input_splits, output_splits, received_counts.sum(dim=0), received_counts)
+
+
+class TestSplitPlan:
+    """Split metadata is exchanged once and rank splits are derived from it."""
+
+    @staticmethod
+    def _patch_counts_exchange(monkeypatch, all_counts, ep_rank):
+        """Emulate the EP metadata all-to-alls seen by rank ``ep_rank``.
+
+        Both the legacy per-rank exchange and the per-(rank, local-expert)
+        exchange are served, each derived independently from ``all_counts``.
+        Payloads are built lazily so callers that never reach a collective
+        (ep_size == 1) do not need a full ``[ep_size, E_local]`` layout.
+        """
+        sent = []
+
+        def fake_all_to_all_single(output, input_, group=None):
+            sent.append(input_.clone())
+            received = _split_plan_received(all_counts, ep_rank)
+            if input_.numel() == len(all_counts):
+                payload = received.sum(dim=1)
+            else:
+                payload = received.reshape(-1)
+            output.copy_(payload.to(output.dtype))
+
+        monkeypatch.setattr(auto_ep_layer.dist, "all_to_all_single", fake_all_to_all_single)
+        return sent
+
+    @pytest.mark.parametrize("scenario", sorted(SPLIT_PLAN_SCENARIOS))
+    @pytest.mark.parametrize("ep_rank", range(SPLIT_PLAN_EP_SIZE))
+    def test_single_exchange_derives_rank_splits(self, monkeypatch, scenario, ep_rank):
+        all_counts = _split_plan_counts(scenario)
+        sent = self._patch_counts_exchange(monkeypatch, all_counts, ep_rank)
+
+        plan = compute_split_plan(
+            selected_experts=_selected_experts_from_counts(all_counts[ep_rank]),
+            num_experts=SPLIT_PLAN_NUM_EXPERTS,
+            ep_size=SPLIT_PLAN_EP_SIZE,
+            num_local_experts=SPLIT_PLAN_LOCAL_EXPERTS,
+            ep_group=None,
+        )
+
+        assert len(sent) == 1
+        assert sent[0].dtype == torch.int32
+        assert sent[0].is_contiguous()
+        assert torch.equal(sent[0], all_counts[ep_rank])
+
+        received = _split_plan_received(all_counts, ep_rank)
+        mine = all_counts[ep_rank].view(SPLIT_PLAN_EP_SIZE, SPLIT_PLAN_LOCAL_EXPERTS)
+        assert plan.input_splits == mine.sum(dim=1).tolist()
+        assert plan.output_splits == received.sum(dim=1).tolist()
+        assert torch.equal(plan.local_counts, received.sum(dim=0))
+        assert torch.equal(plan.local_counts_by_source, received)
+        assert sum(plan.output_splits) == int(received.sum())
+
+    @pytest.mark.parametrize("scenario", sorted(SPLIT_PLAN_SCENARIOS))
+    @pytest.mark.parametrize("ep_rank", range(SPLIT_PLAN_EP_SIZE))
+    def test_matches_legacy_two_collective_planner(self, monkeypatch, scenario, ep_rank):
+        all_counts = _split_plan_counts(scenario)
+        sent = self._patch_counts_exchange(monkeypatch, all_counts, ep_rank)
+
+        expected = _legacy_split_plan(all_counts[ep_rank])
+        assert len(sent) == 2
+        sent.clear()
+
+        plan = compute_split_plan(
+            selected_experts=_selected_experts_from_counts(all_counts[ep_rank]),
+            num_experts=SPLIT_PLAN_NUM_EXPERTS,
+            ep_size=SPLIT_PLAN_EP_SIZE,
+            num_local_experts=SPLIT_PLAN_LOCAL_EXPERTS,
+            ep_group=None,
+        )
+
+        assert len(sent) == 1
+        assert plan.input_splits == expected.input_splits
+        assert plan.output_splits == expected.output_splits
+        assert torch.equal(plan.local_counts, expected.local_counts)
+        assert torch.equal(plan.local_counts_by_source, expected.local_counts_by_source)
+
+    @pytest.mark.parametrize("scenario", sorted(SPLIT_PLAN_SCENARIOS))
+    def test_folded_entry_point_agrees(self, monkeypatch, scenario):
+        all_counts = _split_plan_counts(scenario)
+        selected_experts = _selected_experts_from_counts(all_counts[1])
+        kwargs = dict(num_experts=SPLIT_PLAN_NUM_EXPERTS,
+                      ep_size=SPLIT_PLAN_EP_SIZE,
+                      num_local_experts=SPLIT_PLAN_LOCAL_EXPERTS,
+                      ep_group=None)
+
+        self._patch_counts_exchange(monkeypatch, all_counts, ep_rank=1)
+        derived = compute_split_plan(selected_experts=selected_experts, **kwargs)
+        folded = compute_split_plan_from_expert_indices(expert_indices=selected_experts, **kwargs)
+
+        assert derived.input_splits == folded.input_splits
+        assert derived.output_splits == folded.output_splits
+        assert torch.equal(derived.local_counts, folded.local_counts)
+        assert torch.equal(derived.local_counts_by_source, folded.local_counts_by_source)
+
+    def test_ep_size_one_needs_no_exchange(self, monkeypatch):
+        counts = torch.tensor([3, 0, 5, 1], dtype=torch.int32)
+        sent = self._patch_counts_exchange(monkeypatch, [counts], ep_rank=0)
+
+        plan = compute_split_plan(
+            selected_experts=_selected_experts_from_counts(counts),
+            num_experts=4,
+            ep_size=1,
+            num_local_experts=4,
+            ep_group=None,
+        )
+
+        assert sent == []
+        assert plan.input_splits == [9]
+        assert plan.output_splits == [9]
+        assert torch.equal(plan.local_counts, counts)
+        assert torch.equal(plan.local_counts_by_source, counts.view(1, 4))
 
 
 class TestModelDetectionAndReplacement:


### PR DESCRIPTION
## Redundancy

`compute_split_plan` (`deepspeed/module_inject/auto_ep_layer.py`) runs two all-to-all exchanges over overlapping metadata:

```python
# exchange 1: [ep_size] per-rank totals -> output_splits
local_counts_tensor = count_matrix.sum(dim=1).clone()
dist.all_to_all_single(remote_counts_tensor, local_counts_tensor, group=ep_group)
output_splits = remote_counts_tensor.cpu().tolist()

# exchange 2: [ep_size, E_local] per-expert matrix -> local_counts
dist.all_to_all_single(received_counts_flat, local_expert_counts_flat, group=ep_group)
received_counts = received_counts_flat.view(ep_size, num_local_experts)
```

The second exchange already contains the first. `received_counts[s, e]` is the number of tokens source rank `s` sends to local expert `e`, so

```
received_counts.sum(dim=1)[s] == (tokens rank s sends to this rank) == output_splits[s]
```

element-wise and exactly — the first exchange transmits a strict projection of what the second one transmits.

The planner also issued two separate `.cpu()` calls, each of which is a device-to-host sync.

## Fix

Drop the rank-total exchange and derive `output_splits` from the detailed one:

```python
received_counts = received_counts_flat.view(ep_size, num_local_experts)
input_splits, output_splits = torch.stack((
    count_matrix.sum(dim=1),
    received_counts.sum(dim=1),
)).cpu().tolist()
```

Per split-plan call this changes:

| | before | after |
|---|---|---|
| all-to-all collectives | 2 | 1 |
| device-to-host syncs | 2 | 1 |

`compute_split_plan_from_expert_indices` (folded-TP path) now shares the same helper instead of duplicating the logic.

Only metadata is affected. The dispatch/combine payload `_AllToAllV` calls are untouched.

## Measurements

EP=8 (2 nodes x 8 H100), 256 experts, 1024 tokens/rank, top_k=8, 50 trials, p50 of split-plan time per layer:

| token distribution | before | after | saved |
|---|---|---|---|
| balanced | 0.366 ms | 0.190 ms | 0.176 ms (-48%) |
| mild skew | 0.352 ms | 0.182 ms | 0.171 ms (-49%) |
| severe skew | 0.360 ms | 0.183 ms | 0.176 ms (-49%) |

Collective time alone goes 0.120 ms -> 0.058 ms, consistent with halving the number of exchanges. The saving is flat across skew because what is removed is fixed per-call overhead, not payload-dependent work. For a 20-layer MoE model this is ~3.5 ms per forward pass.

## Tests

`tests/unit/v1/moe/test_autoep_unit.py::TestSplitPlan` adds:

- an oracle check that the derived `output_splits` equal the per-rank totals, for every rank and three token distributions;
- a differential test against a local reimplementation of the old two-collective planner, asserting the old path issues 2 collectives, the new one issues 1, and all four `SplitPlan` fields are identical;
- a test that `compute_split_plan_from_expert_indices` produces an identical plan for the same routing assignment.
