### PR TITLE
Release GIL in blocking AIO bindings

### DIFF
--- a/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
+++ b/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
@@ -267,9 +267,8 @@ int deepspeed_io_handle_t::_pread(const torch::Tensor& buffer,
                                   const bool async,
                                   const int64_t file_offset)
 {
-    auto scheduled_op = _create_io_op_desc(true, buffer, fd, filename, validate, file_offset);
-
     std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    auto scheduled_op = _create_io_op_desc(true, buffer, fd, filename, validate, file_offset);
     _schedule_aio_work_locked(scheduled_op);
 
     if (async) { return 0; }
@@ -302,9 +301,8 @@ int deepspeed_io_handle_t::_pwrite(const torch::Tensor& buffer,
                                    const bool async,
                                    const int64_t file_offset)
 {
-    auto scheduled_op = _create_io_op_desc(false, buffer, fd, filename, validate, file_offset);
-
     std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    auto scheduled_op = _create_io_op_desc(false, buffer, fd, filename, validate, file_offset);
     _schedule_aio_work_locked(scheduled_op);
 
     if (async) { return 0; }

--- a/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
+++ b/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
@@ -191,7 +191,7 @@ std::shared_ptr<struct io_op_desc_t> deepspeed_io_handle_t::_wait_for_aio_work()
 
 void deepspeed_io_handle_t::_stop_threads()
 {
-    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    std::lock_guard<std::mutex> lock(_handle_mutex);
     assert(0 == _num_pending_ops);
     for (auto& ctxt : _thread_contexts) {
         {
@@ -204,7 +204,7 @@ void deepspeed_io_handle_t::_stop_threads()
 
 int deepspeed_io_handle_t::wait()
 {
-    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    std::lock_guard<std::mutex> lock(_handle_mutex);
     return _wait_locked();
 }
 
@@ -267,7 +267,7 @@ int deepspeed_io_handle_t::_pread(const torch::Tensor& buffer,
                                   const bool async,
                                   const int64_t file_offset)
 {
-    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    std::lock_guard<std::mutex> lock(_handle_mutex);
     auto scheduled_op = _create_io_op_desc(true, buffer, fd, filename, validate, file_offset);
     _schedule_aio_work_locked(scheduled_op);
 
@@ -301,7 +301,7 @@ int deepspeed_io_handle_t::_pwrite(const torch::Tensor& buffer,
                                    const bool async,
                                    const int64_t file_offset)
 {
-    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    std::lock_guard<std::mutex> lock(_handle_mutex);
     auto scheduled_op = _create_io_op_desc(false, buffer, fd, filename, validate, file_offset);
     _schedule_aio_work_locked(scheduled_op);
 
@@ -367,10 +367,12 @@ int deepspeed_io_handle_t::async_pwrite(const torch::Tensor& buffer,
 at::Tensor deepspeed_io_handle_t::new_cpu_locked_tensor(const int64_t num_elem,
                                                         const torch::Tensor& example_tensor)
 {
+    std::lock_guard<std::mutex> lock(_handle_mutex);
     return _pinned_tensor_mgr->alloc(num_elem, example_tensor.scalar_type());
 }
 
 bool deepspeed_io_handle_t::free_cpu_locked_tensor(torch::Tensor& locked_tensor)
 {
+    std::lock_guard<std::mutex> lock(_handle_mutex);
     return _pinned_tensor_mgr->free(locked_tensor);
 }

--- a/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
+++ b/csrc/aio/py_lib/deepspeed_py_io_handle.cpp
@@ -163,7 +163,8 @@ int deepspeed_io_handle_t::write(const torch::Tensor& buffer,
     return 0;
 }
 
-void deepspeed_io_handle_t::_schedule_aio_work(std::shared_ptr<struct io_op_desc_t> scheduled_op)
+void deepspeed_io_handle_t::_schedule_aio_work_locked(
+    std::shared_ptr<struct io_op_desc_t> scheduled_op)
 {
     for (auto& ctxt : _thread_contexts) {
         {
@@ -190,6 +191,7 @@ std::shared_ptr<struct io_op_desc_t> deepspeed_io_handle_t::_wait_for_aio_work()
 
 void deepspeed_io_handle_t::_stop_threads()
 {
+    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
     assert(0 == _num_pending_ops);
     for (auto& ctxt : _thread_contexts) {
         {
@@ -201,6 +203,12 @@ void deepspeed_io_handle_t::_stop_threads()
 }
 
 int deepspeed_io_handle_t::wait()
+{
+    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    return _wait_locked();
+}
+
+int deepspeed_io_handle_t::_wait_locked()
 {
     assert(_num_pending_ops > 0);
     auto num_completed_ops = 0;
@@ -261,11 +269,12 @@ int deepspeed_io_handle_t::_pread(const torch::Tensor& buffer,
 {
     auto scheduled_op = _create_io_op_desc(true, buffer, fd, filename, validate, file_offset);
 
-    _schedule_aio_work(scheduled_op);
+    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    _schedule_aio_work_locked(scheduled_op);
 
     if (async) { return 0; }
 
-    return wait();
+    return _wait_locked();
 }
 
 int deepspeed_io_handle_t::pread(const torch::Tensor& buffer,
@@ -295,11 +304,12 @@ int deepspeed_io_handle_t::_pwrite(const torch::Tensor& buffer,
 {
     auto scheduled_op = _create_io_op_desc(false, buffer, fd, filename, validate, file_offset);
 
-    _schedule_aio_work(scheduled_op);
+    std::lock_guard<std::mutex> lock(_pending_ops_mutex);
+    _schedule_aio_work_locked(scheduled_op);
 
     if (async) { return 0; }
 
-    return wait();
+    return _wait_locked();
 }
 
 int deepspeed_io_handle_t::pwrite(const torch::Tensor& buffer,

--- a/csrc/aio/py_lib/deepspeed_py_io_handle.h
+++ b/csrc/aio/py_lib/deepspeed_py_io_handle.h
@@ -22,7 +22,7 @@ struct deepspeed_io_handle_t {
 
     std::vector<std::shared_ptr<struct deepspeed_aio_thread_t>> _thread_contexts;
     std::vector<std::thread> _threads;
-    std::mutex _pending_ops_mutex;
+    std::mutex _handle_mutex;
     int _num_pending_ops;
     std::unique_ptr<struct deepspeed_pin_tensor_t> _pinned_tensor_mgr;
 

--- a/csrc/aio/py_lib/deepspeed_py_io_handle.h
+++ b/csrc/aio/py_lib/deepspeed_py_io_handle.h
@@ -9,6 +9,7 @@ Functionality for swapping optimizer tensors to/from (NVMe) storage devices.
 
 #include <condition_variable>
 #include <memory>
+#include <mutex>
 #include "deepspeed_aio_thread.h"
 #include "deepspeed_pin_tensor.h"
 
@@ -21,6 +22,7 @@ struct deepspeed_io_handle_t {
 
     std::vector<std::shared_ptr<struct deepspeed_aio_thread_t>> _thread_contexts;
     std::vector<std::thread> _threads;
+    std::mutex _pending_ops_mutex;
     int _num_pending_ops;
     std::unique_ptr<struct deepspeed_pin_tensor_t> _pinned_tensor_mgr;
 
@@ -80,9 +82,11 @@ struct deepspeed_io_handle_t {
 
     void _stop_threads();
 
-    void _schedule_aio_work(std::shared_ptr<struct io_op_desc_t> scheduled_op);
+    void _schedule_aio_work_locked(std::shared_ptr<struct io_op_desc_t> scheduled_op);
 
     std::shared_ptr<struct io_op_desc_t> _wait_for_aio_work();
+
+    int _wait_locked();
 
     bool _is_valid_parallel_aio_op(const bool read_op, const int64_t num_bytes);
 

--- a/csrc/aio/py_lib/py_ds_aio.cpp
+++ b/csrc/aio/py_lib/py_ds_aio.cpp
@@ -7,6 +7,7 @@
 Functionality for swapping optimizer tensors to/from (NVMe) storage devices.
 */
 #include <torch/extension.h>
+#include "deepspeed_aio_op_desc.h"
 #include "deepspeed_py_aio_handle.h"
 #include "deepspeed_py_copy.h"
 using namespace pybind11::literals;
@@ -62,16 +63,25 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              "file_offset"_a = 0,
              py::call_guard<py::gil_scoped_release>())
 
-        .def("pwrite",
-             &deepspeed_aio_handle_t::pwrite,
-             "Parallel file write with option of asynchronous completion. If synchronous, returns "
-             "count of completed write ops",
-             "buffer"_a,
-             "filename"_a,
-             "validate"_a,
-             "async"_a,
-             "file_offset"_a = 0,
-             py::call_guard<py::gil_scoped_release>())
+        .def(
+            "pwrite",
+            [](deepspeed_aio_handle_t& handle,
+               const torch::Tensor& buffer,
+               const char* filename,
+               const bool validate,
+               const bool async,
+               const int64_t file_offset) {
+                warn_consumer_ssd_writes();
+                py::gil_scoped_release release;
+                return handle.pwrite(buffer, filename, validate, async, file_offset);
+            },
+            "Parallel file write with option of asynchronous completion. If synchronous, returns "
+            "count of completed write ops",
+            "buffer"_a,
+            "filename"_a,
+            "validate"_a,
+            "async"_a,
+            "file_offset"_a = 0)
 
         .def("sync_pread",
              &deepspeed_aio_handle_t::sync_pread,
@@ -81,13 +91,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              "file_offset"_a = 0,
              py::call_guard<py::gil_scoped_release>())
 
-        .def("sync_pwrite",
-             &deepspeed_aio_handle_t::sync_pwrite,
-             "Synchronous parallel file write. Returns count of completed write ops",
-             "buffer"_a,
-             "filename"_a,
-             "file_offset"_a = 0,
-             py::call_guard<py::gil_scoped_release>())
+        .def(
+            "sync_pwrite",
+            [](deepspeed_aio_handle_t& handle,
+               const torch::Tensor& buffer,
+               const char* filename,
+               const int64_t file_offset) {
+                warn_consumer_ssd_writes();
+                py::gil_scoped_release release;
+                return handle.sync_pwrite(buffer, filename, file_offset);
+            },
+            "Synchronous parallel file write. Returns count of completed write ops",
+            "buffer"_a,
+            "filename"_a,
+            "file_offset"_a = 0)
 
         .def("async_pread",
              &deepspeed_aio_handle_t::async_pread,

--- a/csrc/aio/py_lib/py_ds_aio.cpp
+++ b/csrc/aio/py_lib/py_ds_aio.cpp
@@ -136,12 +136,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              &deepspeed_aio_handle_t::new_cpu_locked_tensor,
              "Allocate pinned CPU tensor.",
              "num_elem"_a,
-             "example_tenosr"_a)
+             "example_tenosr"_a,
+             py::call_guard<py::gil_scoped_release>())
 
         .def("free_cpu_locked_tensor",
              &deepspeed_aio_handle_t::free_cpu_locked_tensor,
              "Free pinned CPU tensor.",
-             "tensor"_a)
+             "tensor"_a,
+             py::call_guard<py::gil_scoped_release>())
 
         .def("wait",
              &deepspeed_aio_handle_t::wait,

--- a/csrc/aio/py_lib/py_ds_aio.cpp
+++ b/csrc/aio/py_lib/py_ds_aio.cpp
@@ -59,7 +59,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              "filename"_a,
              "validate"_a,
              "async"_a,
-             "file_offset"_a = 0)
+             "file_offset"_a = 0,
+             py::call_guard<py::gil_scoped_release>())
 
         .def("pwrite",
              &deepspeed_aio_handle_t::pwrite,
@@ -69,21 +70,24 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
              "filename"_a,
              "validate"_a,
              "async"_a,
-             "file_offset"_a = 0)
+             "file_offset"_a = 0,
+             py::call_guard<py::gil_scoped_release>())
 
         .def("sync_pread",
              &deepspeed_aio_handle_t::sync_pread,
              "Synchronous parallel file read. Returns count of completed read ops",
              "buffer"_a,
              "filename"_a,
-             "file_offset"_a = 0)
+             "file_offset"_a = 0,
+             py::call_guard<py::gil_scoped_release>())
 
         .def("sync_pwrite",
              &deepspeed_aio_handle_t::sync_pwrite,
              "Synchronous parallel file write. Returns count of completed write ops",
              "buffer"_a,
              "filename"_a,
-             "file_offset"_a = 0)
+             "file_offset"_a = 0,
+             py::call_guard<py::gil_scoped_release>())
 
         .def("async_pread",
              &deepspeed_aio_handle_t::async_pread,

--- a/tests/unit/ops/aio/test_aio_gil.py
+++ b/tests/unit/ops/aio/test_aio_gil.py
@@ -1,0 +1,93 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import os
+import sys
+import threading
+
+import pytest
+import torch
+
+import deepspeed
+from deepspeed.accelerator import get_accelerator
+from deepspeed.ops.op_builder import AsyncIOBuilder
+
+BLOCK_SIZE = 4096
+QUEUE_DEPTH = 2
+INTRA_OP_PARALLELISM = 2
+MAX_BLOCKING_CALLS = 32
+
+
+def _require_aio_cuda():
+    if not deepspeed.ops.__compatible_ops__[AsyncIOBuilder.NAME]:
+        pytest.skip("async_io is not compatible with this environment")
+    if get_accelerator().device_name() != "cuda" or not get_accelerator().is_available():
+        pytest.skip("CUDA-pinned memory is required")
+
+
+def _invoke_blocking_aio(handle, operation_name, buffer, filename):
+    if operation_name == "pread":
+        return handle.pread(buffer, filename, False, False, 0)
+    if operation_name == "pwrite":
+        return handle.pwrite(buffer, filename, False, False, 0)
+    if operation_name == "sync_pread":
+        return handle.sync_pread(buffer, filename, 0)
+    if operation_name == "sync_pwrite":
+        return handle.sync_pwrite(buffer, filename, 0)
+    raise AssertionError(f"unexpected operation: {operation_name}")
+
+
+@pytest.mark.parametrize("operation_name", ["pread", "pwrite", "sync_pread", "sync_pwrite"])
+def test_blocking_aio_releases_gil(tmp_path, operation_name):
+    _require_aio_cuda()
+
+    payload = os.urandom(BLOCK_SIZE)
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(payload)
+    target_path = tmp_path / "target.bin"
+
+    handle = AsyncIOBuilder().load().aio_handle(BLOCK_SIZE, QUEUE_DEPTH, True, True, INTRA_OP_PARALLELISM)
+    if "pread" in operation_name:
+        buffer = torch.zeros(BLOCK_SIZE, dtype=torch.uint8, device="cpu").pin_memory()
+        filename = str(source_path)
+    else:
+        buffer = torch.tensor(list(payload), dtype=torch.uint8, device="cpu").pin_memory()
+        filename = str(target_path)
+        assert _invoke_blocking_aio(handle, operation_name, buffer, filename) == 1
+
+    peer_ready = threading.Event()
+    peer_ran = threading.Event()
+    gate = threading.Lock()
+    gate.acquire()
+
+    def run_peer():
+        peer_ready.set()
+        with gate:
+            peer_ran.set()
+
+    peer = threading.Thread(target=run_peer)
+    peer.start()
+    assert peer_ready.wait(timeout=5)
+
+    original_switch_interval = sys.getswitchinterval()
+    try:
+        sys.setswitchinterval(60)
+        gate.release()
+        for _ in range(MAX_BLOCKING_CALLS):
+            assert _invoke_blocking_aio(handle, operation_name, buffer, filename) == 1
+            if peer_ran.is_set():
+                break
+        assert peer_ran.is_set(), f"{operation_name} held the GIL across all blocking calls"
+    finally:
+        sys.setswitchinterval(original_switch_interval)
+        if gate.locked():
+            gate.release()
+        peer.join(timeout=5)
+
+    assert not peer.is_alive()
+    if "pread" in operation_name:
+        assert bytes(buffer.tolist()) == payload
+    else:
+        assert target_path.read_bytes() == payload

--- a/tests/unit/v1/nvme/test_aio_gil.py
+++ b/tests/unit/v1/nvme/test_aio_gil.py
@@ -94,7 +94,8 @@ def test_blocking_aio_releases_gil(tmp_path, operation_name):
         assert target_path.read_bytes() == payload
 
 
-def test_concurrent_blocking_reads_on_shared_handle(tmp_path):
+@pytest.mark.parametrize("use_pinned_memory", [True, False])
+def test_concurrent_blocking_reads_on_shared_handle(tmp_path, use_pinned_memory):
     _require_aio_cuda()
 
     payloads = [os.urandom(BLOCK_SIZE), os.urandom(BLOCK_SIZE)]
@@ -104,7 +105,10 @@ def test_concurrent_blocking_reads_on_shared_handle(tmp_path):
         source_path = tmp_path / f"source-{index}.bin"
         source_path.write_bytes(payload)
         source_paths.append(source_path)
-        buffers.append(torch.zeros(BLOCK_SIZE, dtype=torch.uint8, device="cpu").pin_memory())
+        if use_pinned_memory:
+            buffers.append(torch.zeros(BLOCK_SIZE, dtype=torch.uint8, device="cpu").pin_memory())
+        else:
+            buffers.append(torch.zeros(BLOCK_SIZE, dtype=torch.uint8, device=get_accelerator().device_name()))
 
     handle = AsyncIOBuilder().load().aio_handle(BLOCK_SIZE, QUEUE_DEPTH, True, True, INTRA_OP_PARALLELISM)
     start = threading.Barrier(3, timeout=CONCURRENT_READ_TIMEOUT)

--- a/tests/unit/v1/nvme/test_aio_gil.py
+++ b/tests/unit/v1/nvme/test_aio_gil.py
@@ -19,6 +19,7 @@ QUEUE_DEPTH = 2
 INTRA_OP_PARALLELISM = 2
 MAX_BLOCKING_CALLS = 32
 CONCURRENT_READ_TIMEOUT = 30
+CONCURRENT_MANAGER_OPS = 32
 
 
 def _require_aio_cuda():
@@ -133,3 +134,47 @@ def test_concurrent_blocking_reads_on_shared_handle(tmp_path, use_pinned_memory)
     assert all(not reader.is_alive() for reader in readers)
     assert statuses == [1, 1]
     assert [bytes(buffer.tolist()) for buffer in buffers] == payloads
+
+
+def test_concurrent_unpinned_read_and_locked_tensor_management(tmp_path):
+    _require_aio_cuda()
+
+    payload = os.urandom(BLOCK_SIZE)
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(payload)
+    buffer = torch.zeros(BLOCK_SIZE, dtype=torch.uint8, device=get_accelerator().device_name())
+    example_tensor = torch.empty(1, dtype=torch.uint8, device="cpu")
+    handle = AsyncIOBuilder().load().aio_handle(BLOCK_SIZE, QUEUE_DEPTH, True, True, INTRA_OP_PARALLELISM)
+    start = threading.Barrier(3, timeout=CONCURRENT_READ_TIMEOUT)
+    errors = []
+
+    def run_reads():
+        try:
+            start.wait()
+            for _ in range(CONCURRENT_MANAGER_OPS):
+                assert handle.sync_pread(buffer, str(source_path), 0) == 1
+        except Exception as error:
+            errors.append(error)
+
+    def manage_locked_tensors():
+        try:
+            start.wait()
+            for _ in range(CONCURRENT_MANAGER_OPS):
+                locked_tensor = handle.new_cpu_locked_tensor(BLOCK_SIZE, example_tensor)
+                assert handle.free_cpu_locked_tensor(locked_tensor)
+        except Exception as error:
+            errors.append(error)
+
+    workers = [
+        threading.Thread(target=run_reads, daemon=True),
+        threading.Thread(target=manage_locked_tensors, daemon=True),
+    ]
+    for worker in workers:
+        worker.start()
+    start.wait()
+    for worker in workers:
+        worker.join(timeout=CONCURRENT_READ_TIMEOUT)
+
+    assert not errors
+    assert all(not worker.is_alive() for worker in workers)
+    assert bytes(buffer.tolist()) == payload

--- a/tests/unit/v1/nvme/test_aio_gil.py
+++ b/tests/unit/v1/nvme/test_aio_gil.py
@@ -18,6 +18,7 @@ BLOCK_SIZE = 4096
 QUEUE_DEPTH = 2
 INTRA_OP_PARALLELISM = 2
 MAX_BLOCKING_CALLS = 32
+CONCURRENT_READ_TIMEOUT = 30
 
 
 def _require_aio_cuda():
@@ -91,3 +92,40 @@ def test_blocking_aio_releases_gil(tmp_path, operation_name):
         assert bytes(buffer.tolist()) == payload
     else:
         assert target_path.read_bytes() == payload
+
+
+def test_concurrent_blocking_reads_on_shared_handle(tmp_path):
+    _require_aio_cuda()
+
+    payloads = [os.urandom(BLOCK_SIZE), os.urandom(BLOCK_SIZE)]
+    source_paths = []
+    buffers = []
+    for index, payload in enumerate(payloads):
+        source_path = tmp_path / f"source-{index}.bin"
+        source_path.write_bytes(payload)
+        source_paths.append(source_path)
+        buffers.append(torch.zeros(BLOCK_SIZE, dtype=torch.uint8, device="cpu").pin_memory())
+
+    handle = AsyncIOBuilder().load().aio_handle(BLOCK_SIZE, QUEUE_DEPTH, True, True, INTRA_OP_PARALLELISM)
+    start = threading.Barrier(3, timeout=CONCURRENT_READ_TIMEOUT)
+    statuses = [None, None]
+    errors = []
+
+    def run_read(index):
+        try:
+            start.wait()
+            statuses[index] = handle.sync_pread(buffers[index], str(source_paths[index]), 0)
+        except Exception as error:
+            errors.append(error)
+
+    readers = [threading.Thread(target=run_read, args=(index, ), daemon=True) for index in range(2)]
+    for reader in readers:
+        reader.start()
+    start.wait()
+    for reader in readers:
+        reader.join(timeout=CONCURRENT_READ_TIMEOUT)
+
+    assert not errors
+    assert all(not reader.is_alive() for reader in readers)
+    assert statuses == [1, 1]
+    assert [bytes(buffer.tolist()) for buffer in buffers] == payloads


### PR DESCRIPTION
The blocking parallel AIO bindings can call the handle's internal `wait()` while retaining the Python GIL. An AIO worker may need that GIL while completing PyTorch tensor cleanup. This causes a deadlock: the Python caller waits for the worker, while the worker waits for the GIL held by the caller.

This PR releases the GIL at the `pread`, `pwrite`, `sync_pread`, and `sync_pwrite` pybind entrypoints to avoid the deadlock.