### PR TITLE
Preserve tensor learning rates across scheduler updates

### DIFF
--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -13,7 +13,7 @@ import argparse
 from torch.optim import Optimizer
 import math
 from deepspeed.utils import logger
-from torch import tensor, is_tensor
+from torch import is_tensor
 
 LR_SCHEDULE = 'lr_schedule'
 LR_RANGE_TEST = 'LRRangeTest'
@@ -250,10 +250,11 @@ def get_lr_from_config(config):
 
 def update_lr(param_groups, lrs):
     for param_group, lr in zip(param_groups, lrs):
-        # new LR should match the type of current LR for scalar and Tensor LR support
         if is_tensor(param_group['lr']):
-            lr = tensor([lr], device=param_group['lr'].device)
-        param_group['lr'] = lr
+            lr = lr.squeeze() if is_tensor(lr) else lr
+            param_group['lr'].fill_(lr)
+        else:
+            param_group['lr'] = lr
     return [group['lr'] for group in param_groups]
 
 

--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -864,7 +864,9 @@ class WarmupCosineLR(object):
         if self.total_num_steps < self.warmup_num_steps:
             logger.warning('total_num_steps {} is less than warmup_num_steps {}'.format(
                 total_num_steps, warmup_num_steps))
-        self.org_lrs = [group['lr'] for group in self.optimizer.param_groups]
+        self.org_lrs = [
+            group['lr'].clone() if is_tensor(group['lr']) else group['lr'] for group in self.optimizer.param_groups
+        ]
 
         # Initialize lrs in optimizer groups
         if last_batch_iteration == -1:

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -566,6 +566,27 @@ def test_warmup_lr_inherits_per_group_lr_when_max_unspecified():
     assert [group["lr"] for group in optimizer.param_groups] == pytest.approx([0.1, 0.2])
 
 
+@pytest.mark.parametrize("lr_shape", [(), (1, )])
+def test_warmup_lr_preserves_tensor_lr(lr_shape):
+    param = torch.nn.Parameter(torch.zeros(1))
+    initial_lr = torch.full(lr_shape, 0.1, dtype=torch.float64)
+    optimizer = torch.optim.SGD([param], lr=initial_lr)
+
+    scheduler = WarmupLR(optimizer=optimizer, warmup_num_steps=10)
+
+    assert optimizer.param_groups[0]["lr"] is initial_lr
+    assert initial_lr.shape == lr_shape
+    assert initial_lr.dtype == torch.float64
+    assert initial_lr.item() == 0.0
+
+    scheduler.step(1)
+
+    assert optimizer.param_groups[0]["lr"] is initial_lr
+    assert initial_lr.shape == lr_shape
+    assert initial_lr.dtype == torch.float64
+    assert initial_lr.item() == pytest.approx(0.1 * math.log(2) / math.log(10))
+
+
 def test_warmup_cosine_lr_total_num_steps_equals_warmup_num_steps():
     # total_num_steps == warmup_num_steps must not raise ZeroDivisionError, and because the
     # cosine decay window is empty, every step past warmup must stay at cos_min_ratio rather

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -587,6 +587,27 @@ def test_warmup_lr_preserves_tensor_lr(lr_shape):
     assert initial_lr.item() == pytest.approx(0.1 * math.log(2) / math.log(10))
 
 
+@pytest.mark.parametrize("lr_shape", [(), (1, )])
+def test_warmup_cosine_lr_preserves_tensor_lr(lr_shape):
+    param = torch.nn.Parameter(torch.zeros(1))
+    initial_lr = torch.full(lr_shape, 0.1, dtype=torch.float64)
+    optimizer = torch.optim.SGD([param], lr=initial_lr)
+
+    scheduler = WarmupCosineLR(optimizer=optimizer, total_num_steps=100, warmup_num_steps=10)
+
+    assert optimizer.param_groups[0]["lr"] is initial_lr
+    assert initial_lr.shape == lr_shape
+    assert initial_lr.dtype == torch.float64
+    assert initial_lr.item() == 0.0
+
+    scheduler.step(1)
+
+    assert optimizer.param_groups[0]["lr"] is initial_lr
+    assert initial_lr.shape == lr_shape
+    assert initial_lr.dtype == torch.float64
+    assert initial_lr.item() == pytest.approx(0.1 * math.log(2) / math.log(10))
+
+
 def test_warmup_cosine_lr_total_num_steps_equals_warmup_num_steps():
     # total_num_steps == warmup_num_steps must not raise ZeroDivisionError, and because the
     # cosine decay window is empty, every step past warmup must stay at cos_min_ratio rather


### PR DESCRIPTION
## What it is

DeepSpeed's tensor learning-rate support currently replaces an optimizer's LR tensor on every scheduler update. A scalar `float64` LR tensor becomes a new one-dimensional tensor during scheduler initialization, changing its identity, shape, and initially its dtype. This also leaves any caller-held reference to the supplied LR tensor pointing at the stale value.

The root cause is `update_lr()` constructing `tensor([lr])` instead of updating the tensor supplied through the optimizer. This is a follow-up to the tensor LR support added in #7633.

## How it works

- Fill the optimizer's existing LR tensor in place, matching PyTorch scheduler behavior.
- Squeeze a calculated one-element tensor to the scalar value expected by `fill_`, covering both zero-dimensional and one-element LR tensors.
- Snapshot tensor base LRs in `WarmupCosineLR` before initialization updates the optimizer tensor, preserving the original value used by later schedule steps.
- Leave the scalar LR assignment path unchanged.
- Add `WarmupLR` and `WarmupCosineLR` regression tests that check object identity, shape, dtype, initialization, and scheduled values.

## E2E Top-hatting

On current `master`, a zero-dimensional `float64` LR tensor is replaced by a different one-dimensional tensor. With this change, both zero-dimensional and one-element LR tensors retain their original identity, shape, and dtype while reaching the expected warmup values. `WarmupCosineLR` also retains an independent base value, preventing its schedule from remaining at zero after initialization.

A clean GitHub-hosted Ubuntu 24.04 CPU run used Python 3.11 and PyTorch 2.10:

- `pytest --forked -n 4 unit/runtime/test_lr_schedulers.py --torch_ver=2.10`
- **70 passed** ([run](https://github.com/n33levo/DeepSpeed/actions/runs/30714252928))

## Checks

- `pre-commit run --files deepspeed/runtime/lr_schedules.py tests/unit/runtime/test_lr_schedulers.py`
- All formatting, lint, license, spelling, and custom Torch checks passed.
