### PR TITLE
Preserve tensor learning rates in OneCycle

### DIFF
--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -512,8 +512,7 @@ class OneCycle(object):
     def _initialize_lr(self, optimizer, cycle_min_lr, cycle_max_lr, decay_lr_rate, last_batch_iteration):
         self.min_lrs = [cycle_min_lr] * len(optimizer.param_groups)
         if last_batch_iteration == -1:
-            for lr, group in zip(self.min_lrs, optimizer.param_groups):
-                group['lr'] = lr
+            update_lr(optimizer.param_groups, self.min_lrs)
 
         self.max_lrs = [cycle_max_lr] * len(optimizer.param_groups)
         self.decay_lr_rate = decay_lr_rate

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -608,6 +608,32 @@ def test_warmup_cosine_lr_preserves_tensor_lr(lr_shape):
     assert initial_lr.item() == pytest.approx(0.1 * math.log(2) / math.log(10))
 
 
+@pytest.mark.parametrize("lr_shape", [(), (1, )])
+def test_one_cycle_preserves_tensor_lr(lr_shape):
+    param = torch.nn.Parameter(torch.zeros(1))
+    initial_lr = torch.full(lr_shape, 0.1, dtype=torch.float64)
+    optimizer = torch.optim.SGD([param], lr=initial_lr)
+
+    scheduler = OneCycle(optimizer=optimizer,
+                         cycle_min_lr=0.01,
+                         cycle_max_lr=0.1,
+                         cycle_first_step_size=10,
+                         cycle_second_step_size=10,
+                         cycle_momentum=False)
+
+    assert optimizer.param_groups[0]["lr"] is initial_lr
+    assert initial_lr.shape == lr_shape
+    assert initial_lr.dtype == torch.float64
+    assert initial_lr.item() == pytest.approx(0.01)
+
+    scheduler.step(1)
+
+    assert optimizer.param_groups[0]["lr"] is initial_lr
+    assert initial_lr.shape == lr_shape
+    assert initial_lr.dtype == torch.float64
+    assert initial_lr.item() == pytest.approx(0.01 + (0.1 - 0.01) * 2 / 10)
+
+
 def test_warmup_cosine_lr_total_num_steps_equals_warmup_num_steps():
     # total_num_steps == warmup_num_steps must not raise ZeroDivisionError, and because the
     # cosine decay window is empty, every step past warmup must stay at cos_min_ratio rather


### PR DESCRIPTION
Follow up #8202:

When an optimizer starts with a tensor learning rate, OneCycle initialization replaces it with a Python scalar while applying `cycle_min_lr`. This loses the caller's tensor identity, shape, and dtype before later scheduler updates can preserve them.

This PR initializes OneCycle learning rates through the existing tensor-aware update helper, matching the path used by subsequent scheduler steps.