### PR TITLE
Fix MLU_Accelerator conformance to the DeepSpeedAccelerator ABC

### DIFF
--- a/accelerator/mlu_accelerator.py
+++ b/accelerator/mlu_accelerator.py
@@ -78,8 +78,8 @@ class MLU_Accelerator(DeepSpeedAccelerator):
     def manual_seed_all(self, seed):
         return torch.mlu.manual_seed_all(seed)
 
-    def initial_seed(self, seed):
-        return torch.mlu.initial_seed(seed)
+    def initial_seed(self):
+        return torch.mlu.initial_seed()
 
     def default_generator(self, device_index):
         return torch.mlu.default_generators[device_index]
@@ -184,7 +184,7 @@ class MLU_Accelerator(DeepSpeedAccelerator):
 
     # Graph operations
     def create_graph(self):
-        torch.mlu.MLUGraph()
+        return torch.mlu.MLUGraph()
 
     def capture_to_graph(self, graph, pool=None, stream=None):
         return torch.mlu.graph(graph, pool, stream)
@@ -223,7 +223,7 @@ class MLU_Accelerator(DeepSpeedAccelerator):
     def LongTensor(self):
         return functools.partial(torch.tensor, dtype=torch.long, device='mlu')
 
-    def pin_memory(self, tensor):
+    def pin_memory(self, tensor, align_bytes=1):
         return tensor.pin_memory()
 
     def is_pinned(self, tensor):

--- a/tests/unit/accelerator/test_accelerator.py
+++ b/tests/unit/accelerator/test_accelerator.py
@@ -5,12 +5,16 @@
 
 import pytest
 
+import ast
 import os
 import sys
 import importlib
+import inspect
 import re
+import textwrap
 
 import deepspeed
+from deepspeed.accelerator.abstract_accelerator import DeepSpeedAccelerator
 
 DS_ACCEL_PATH = "deepspeed.accelerator"
 IGNORE_FILES = ["abstract_accelerator.py", "real_accelerator.py"]
@@ -57,3 +61,75 @@ def test_abstract_methods_defined(module_name, accel_class_name):
     accel_class = getattr(module, accel_class_name)
     accel_class.__init__ = lambda self: None
     _ = accel_class()
+
+
+def _positional_params(func):
+    params = list(inspect.signature(func).parameters.values())
+    keep = (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    return [p for p in params if p.kind in keep]
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        DS_ACCEL_PATH + "." + f.rstrip(".py") for f in os.listdir(deepspeed.accelerator.__path__[0])
+        if f.endswith("_accelerator.py") and f not in IGNORE_FILES
+    ],
+)
+def test_abstract_method_signatures(module_name, accel_class_name):
+    """An override may widen the abstract signature, never narrow it: callers hold a
+    DeepSpeedAccelerator, so any call the ABC permits has to work on every backend."""
+    module = importlib.import_module(module_name)
+    accel_class = getattr(module, accel_class_name)
+
+    errors = []
+    for name, abstract in inspect.getmembers(DeepSpeedAccelerator, inspect.isfunction):
+        if name.startswith("__") or not getattr(abstract, "__isabstractmethod__", False):
+            continue
+        override = getattr(accel_class, name, None)
+        if override is None or not inspect.isfunction(override):
+            continue
+
+        abstract_params = _positional_params(abstract)
+        override_params = _positional_params(override)
+        accepts_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD
+                             for p in inspect.signature(override).parameters.values())
+
+        abstract_required = [p for p in abstract_params if p.default is inspect.Parameter.empty]
+        override_required = [p for p in override_params if p.default is inspect.Parameter.empty]
+        if len(override_required) > len(abstract_required):
+            errors.append(f"{name}: requires {len(override_required)} args, ABC requires "
+                          f"{len(abstract_required)} ({inspect.signature(override)} vs "
+                          f"{inspect.signature(abstract)})")
+            continue
+
+        if not accepts_kwargs:
+            override_names = {p.name for p in override_params}
+            for p in abstract_params:
+                if p.default is not inspect.Parameter.empty and p.name not in override_names:
+                    errors.append(f"{name}: does not accept optional ABC parameter "
+                                  f"'{p.name}' ({inspect.signature(override)} vs "
+                                  f"{inspect.signature(abstract)})")
+
+    assert not errors, f"{accel_class_name} narrows the DeepSpeedAccelerator contract: " + "; ".join(errors)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        DS_ACCEL_PATH + "." + f.rstrip(".py") for f in os.listdir(deepspeed.accelerator.__path__[0])
+        if f.endswith("_accelerator.py") and f not in IGNORE_FILES
+    ],
+)
+def test_create_graph_returns(module_name, accel_class_name):
+    """create_graph() must return its graph object, or None to opt out: graph_process()
+    feeds the result straight to capture_to_graph() and replay_graph(). Checked
+    statically because instantiating a vendor graph type needs the vendor runtime."""
+    module = importlib.import_module(module_name)
+    accel_class = getattr(module, accel_class_name)
+
+    source = textwrap.dedent(inspect.getsource(accel_class.create_graph))
+    body = ast.parse(source).body[0].body
+    assert isinstance(
+        body[-1], ast.Return), (f"{accel_class_name}.create_graph does not return; graph_process() would pass None "
+                                f"to capture_to_graph() and replay_graph(). Source:\n{source}")


### PR DESCRIPTION
`MLU_Accelerator` diverges from the `DeepSpeedAccelerator` contract in three places. I compared all nine backends against the ABC and it is the only one that does.

## 1. `pin_memory` drops `align_bytes` (`accelerator/mlu_accelerator.py:226`)

The ABC declares `pin_memory(self, tensor, align_bytes=1)` (`abstract_accelerator.py:264`); MLU declares `pin_memory(self, tensor)`. Three in-tree call sites pass it by keyword, all on the ZeRO-Infinity / NVMe offload swap path:

- `deepspeed/runtime/swap_tensor/utils.py:188`
- `deepspeed/runtime/swap_tensor/partitioned_param_swapper.py:131`
- `deepspeed/runtime/swap_tensor/partitioned_param_swapper.py:398`

all `align_bytes=0`, so on MLU these raise `TypeError` rather than differing quietly.

## 2. `initial_seed` requires an argument the ABC does not declare (`:81`)

#5569 changed `initial_seed(self, seed)` to `initial_seed(self)` in the ABC and in cpu/cuda/hpu/mps/npu/xpu, on the grounds that `torch.<device>.initial_seed()` takes no argument. MLU landed 3 months later in #6472 as a copy of the pre-#5569 NPU code, which brought the argument back, so `get_accelerator().initial_seed()` raises `TypeError` on MLU alone.

To be accurate about severity: the only in-tree reference is commented out (`deepspeed/runtime/pipe/module.py:200`), so this is a break in the public accelerator API and a regression of the #5569 decision, not a live in-tree crash.

## 3. `create_graph` builds a graph and drops it (`:186`)

```python
def create_graph(self):
    torch.mlu.MLUGraph()
```

The in-tree consumers use the returned handle: `graph_process()` (`deepspeed/runtime/utils.py:101`) passes it straight into `capture_to_graph()` and then `replay_graph()`, so both get `None`.

Worth separating from a deliberate opt-out. cpu, mps, npu, sdaa and xpu return `None` *and* pair it with a `noop_context()` `capture_to_graph`. MLU pairs the missing return with a real capture (`torch.mlu.graph(...)`, `:189`) and a real `graph.replay()` (`:192`), which is the cuda/hpu/supa shape. That reads as an oversight rather than an abstention, but you would know better than I would.

## The fix

Three one-line changes, matching what the other backends already do: add `align_bytes=1` to `pin_memory` (the cuda/npu/sdaa/supa body is byte-identical to MLU's, so nothing else changes), drop the `seed` argument from `initial_seed`, and return from `create_graph`.

## How I verified

- Added two CPU-only tests to `tests/unit/accelerator/test_accelerator.py`: a Liskov check that an override may widen the abstract signature but never narrow it, and a check that `create_graph` returns. On `df84f6d8` the file goes from 2 failed / 25 passed to 27 passed; both failures are MLU and the other eight backends pass untouched.
- The signature check is deliberately not "arity must match": every backend gives `device`/`device_name` a default the ABC declares required, and that widening is fine. Only requiring *more* than the ABC, or dropping one of its defaulted parameters, fails. That is what keeps the cpu/mps `create_op_builder` naming difference from tripping it.
- Both tests need no accelerator hardware, so they run in the existing `cpu-torch-latest` job. yapf 0.40.0 reports both files clean.
- What I did not check: I have no Cambricon hardware, so none of this ran on an MLU device. The three contract faults are exercised directly, but the downstream consequences I describe (the swap path, `graph_process`) are read from the call sites rather than observed on silicon.

Happy to split this into three commits, or to drop the tests if you would rather keep the suite as it is.
