### PR TITLE
Reduce redundant work in AutoEP token routing

### DIFF
--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -150,11 +150,7 @@ def compute_split_plan(
     local_counts_by_source.
     """
     if num_tokens_per_expert is None:
-        num_tokens_per_expert = count_tokens_per_expert(
-            selected_experts,
-            num_experts,
-            out_dtype=torch.int32,
-        )
+        num_tokens_per_expert = count_tokens_per_expert(selected_experts, num_experts)
 
     if ep_size == 1:
         # No dispatch needed - all tokens stay local
@@ -177,7 +173,7 @@ def compute_split_plan_from_expert_indices(
     ep_group: dist.ProcessGroup | None,
 ) -> SplitPlan:
     """Compute EP AllToAllV splits for an already partitioned assignment list."""
-    counts = count_tokens_per_expert(expert_indices, num_experts, out_dtype=torch.int32)
+    counts = count_tokens_per_expert(expert_indices, num_experts)
     if ep_size == 1:
         return SplitPlan([int(expert_indices.numel())], [int(expert_indices.numel())], counts,
                          counts.view(1, num_local_experts))

--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -25,7 +25,6 @@ from deepspeed.utils import logger
 from deepspeed.moe.ep_router import TokenChoiceTopKRouter
 from deepspeed.moe.ep_count import count_tokens_per_expert
 from deepspeed.moe.ep_experts import GroupedExperts
-from deepspeed.moe.ep_kernels import TokenReorderer
 from deepspeed.moe.ep_repack import _gather_source_zero_params, repack_expert_requires_grad_flags, repack_expert_weights
 
 # ---------------------------------------------------------------------------
@@ -134,22 +133,28 @@ def _split_plan_from_expert_counts(
 
 
 def compute_split_plan(
-    selected_experts: torch.Tensor,  # [T, K]
-    num_experts: int,
-    ep_size: int,
-    num_local_experts: int,
-    ep_group: dist.ProcessGroup | None,
+        selected_experts: torch.Tensor,  # [T, K]
+        num_experts: int,
+        ep_size: int,
+        num_local_experts: int,
+        ep_group: dist.ProcessGroup | None,
+        num_tokens_per_expert: torch.Tensor | None = None,  # [E_global], int32
 ) -> SplitPlan:
     """Compute AllToAllV split sizes for token dispatch/combine.
+
+    ``num_tokens_per_expert`` may be supplied by the caller to reuse the
+    histogram already computed by the router; when omitted it is derived from
+    ``selected_experts``.
 
     Returns SplitPlan with input_splits, output_splits, local_counts, and
     local_counts_by_source.
     """
-    num_tokens_per_expert = count_tokens_per_expert(
-        selected_experts,
-        num_experts,
-        out_dtype=torch.int32,
-    )
+    if num_tokens_per_expert is None:
+        num_tokens_per_expert = count_tokens_per_expert(
+            selected_experts,
+            num_experts,
+            out_dtype=torch.int32,
+        )
 
     if ep_size == 1:
         # No dispatch needed - all tokens stay local
@@ -469,7 +474,6 @@ class AutoEPMoELayer(nn.Module):
         self.experts.w2.requires_grad_(w2_requires_grad)
         self.experts.w3.requires_grad_(w3_requires_grad)
 
-        self.reorderer = TokenReorderer(num_experts=self.num_experts, top_k=self.top_k)
         self.shared_experts = getattr(source_module, spec.shared_experts_name,
                                       None) if spec.has_shared_experts else None
         self.shared_experts_gate = getattr(source_module, spec.shared_experts_gate_name,
@@ -594,8 +598,9 @@ class AutoEPMoELayer(nn.Module):
         with torch.no_grad():
             self.tokens_per_expert.add_(ro.num_tokens_per_expert)
 
-        # Reorder tokens by expert
-        top_scores_sorted, token_indices_sorted, _ = self.reorderer(ro.top_scores, ro.selected_experts)
+        # Reorder tokens into expert-contiguous order.
+        token_indices_sorted = torch.argsort(ro.selected_experts.view(-1), stable=True)
+        top_scores_sorted = ro.top_scores.view(-1)[token_indices_sorted]
         expert_indices_sorted = ro.selected_experts.reshape(-1).index_select(0, token_indices_sorted)
 
         folded_tp = self.folding_group_handles is not None and self.folding_group_handles.spec.tp_size > 1
@@ -650,11 +655,7 @@ class AutoEPMoELayer(nn.Module):
 
         if self.ep_size == 1:
             # No AllToAll needed - local computation only
-            local_counts = count_tokens_per_expert(
-                ro.selected_experts,
-                self.num_local_experts,
-                out_dtype=torch.int32,
-            )
+            local_counts = ro.num_tokens_per_expert
 
             routed_input_permuted, perm_indices, aligned_counts, n_tokens = permute_by_local_expert(
                 routed_input, local_counts)
@@ -677,6 +678,7 @@ class AutoEPMoELayer(nn.Module):
                     ep_size=self.ep_size,
                     num_local_experts=self.num_local_experts,
                     ep_group=self.ep_group,
+                    num_tokens_per_expert=ro.num_tokens_per_expert,
                 )
 
             routed_input = _AllToAllV.apply(self.ep_group, routed_input, plan.input_splits, plan.output_splits)

--- a/deepspeed/moe/ep_count.py
+++ b/deepspeed/moe/ep_count.py
@@ -18,10 +18,15 @@ def count_tokens_per_expert(
 ) -> torch.Tensor:
     """Count routed tokens per expert.
 
-    Fast path uses ``torch.bincount`` on the current device.
-    If ``deterministic_safe=True`` and deterministic algorithms are enabled
-    on CUDA, this falls back to CPU bincount to avoid non-deterministic kernel
-    restrictions.
+    The fast path scatter-adds into a fixed ``[num_experts]`` buffer. Because the
+    output shape is known up front, it avoids the device-to-host synchronization
+    that ``torch.bincount`` incurs to size its output from ``max_index + 1``.
+
+    Counting integers is order-independent, so the result is deterministic even
+    though ``scatter_add_`` accumulates with atomics: integer addition is
+    associative, unlike float addition. The ``deterministic_safe`` fallback to
+    CPU bincount exists only because PyTorch's categorical determinism guard may
+    reject atomic scatter on some builds, not because the counts would differ.
     """
     flat_indices = selected_experts_indices.reshape(-1).to(torch.int64)
 
@@ -30,7 +35,8 @@ def count_tokens_per_expert(
         counts = torch.bincount(flat_indices.detach().cpu(), minlength=num_experts)
         counts = counts.to(selected_experts_indices.device)
     else:
-        counts = torch.bincount(flat_indices, minlength=num_experts)
+        counts = torch.zeros(num_experts, dtype=torch.int64, device=flat_indices.device)
+        counts.scatter_add_(0, flat_indices, torch.ones_like(flat_indices))
 
     if counts.numel() < num_experts:
         pad = torch.zeros(num_experts - counts.numel(), device=counts.device, dtype=counts.dtype)

--- a/deepspeed/moe/ep_count.py
+++ b/deepspeed/moe/ep_count.py
@@ -12,36 +12,15 @@ from deepspeed.accelerator import get_accelerator
 def count_tokens_per_expert(
     selected_experts_indices: torch.Tensor,
     num_experts: int,
-    *,
-    out_dtype: torch.dtype = torch.float32,
-    deterministic_safe: bool = False,
 ) -> torch.Tensor:
     """Count routed tokens per expert.
 
-    The fast path scatter-adds into a fixed ``[num_experts]`` buffer. Because the
-    output shape is known up front, it avoids the device-to-host synchronization
+    Because the output shape is known up front, it avoids the device-to-host synchronization
     that ``torch.bincount`` incurs to size its output from ``max_index + 1``.
-
-    Counting integers is order-independent, so the result is deterministic even
-    though ``scatter_add_`` accumulates with atomics: integer addition is
-    associative, unlike float addition. The ``deterministic_safe`` fallback to
-    CPU bincount exists only because PyTorch's categorical determinism guard may
-    reject atomic scatter on some builds, not because the counts would differ.
     """
-    flat_indices = selected_experts_indices.reshape(-1).to(torch.int64)
+    flat_indices = selected_experts_indices.reshape(-1)
 
-    if deterministic_safe and torch.are_deterministic_algorithms_enabled() and get_accelerator().on_accelerator(
-            flat_indices):
-        counts = torch.bincount(flat_indices.detach().cpu(), minlength=num_experts)
-        counts = counts.to(selected_experts_indices.device)
-    else:
-        counts = torch.zeros(num_experts, dtype=torch.int64, device=flat_indices.device)
-        counts.scatter_add_(0, flat_indices, torch.ones_like(flat_indices))
+    counts = torch.zeros(num_experts, dtype=torch.int32, device=flat_indices.device)
+    counts.scatter_add_(0, flat_indices, torch.ones_like(flat_indices, dtype=counts.dtype))
 
-    if counts.numel() < num_experts:
-        pad = torch.zeros(num_experts - counts.numel(), device=counts.device, dtype=counts.dtype)
-        counts = torch.cat([counts, pad], dim=0)
-    elif counts.numel() > num_experts:
-        counts = counts[:num_experts]
-
-    return counts.to(out_dtype)
+    return counts

--- a/deepspeed/moe/ep_count.py
+++ b/deepspeed/moe/ep_count.py
@@ -6,8 +6,6 @@
 
 import torch
 
-from deepspeed.accelerator import get_accelerator
-
 
 def count_tokens_per_expert(
     selected_experts_indices: torch.Tensor,

--- a/deepspeed/moe/ep_kernels.py
+++ b/deepspeed/moe/ep_kernels.py
@@ -10,7 +10,7 @@
 """
 Token reordering and permutation utilities for expert parallelism.
 
-Ported from TorchTitan's TokenReorderer, Triton kernels, and alignment
+Ported from TorchTitan's Triton kernels and alignment
 utilities with adaptations for DeepSpeed:
   - Triton import guarded with try/except; pure-PyTorch fallback provided
   - Alignment config exposed as TOKEN_GROUP_ALIGN_SIZE_M
@@ -23,9 +23,6 @@ import logging
 from typing import Callable
 
 import torch
-import torch.nn as nn
-
-from deepspeed.moe.ep_count import count_tokens_per_expert
 
 logger = logging.getLogger(__name__)
 
@@ -329,53 +326,3 @@ def indices_padding_wrapper(func: Callable) -> Callable:
         return out
 
     return wrapper
-
-
-# ===================================================================
-# TokenReorderer
-# ===================================================================
-
-
-class TokenReorderer(nn.Module):
-    """Reorder token indices to match expert order for efficient parallel
-    processing.
-
-    Args:
-        num_experts (int): Number of experts in the MoE layer.
-        top_k (int): Number of experts each token is routed to.
-    """
-
-    def __init__(self, num_experts: int, top_k: int):
-        super().__init__()
-        self.num_experts = num_experts
-        self.top_k = top_k
-
-    def forward(
-        self,
-        top_scores: torch.Tensor,
-        selected_experts_indices: torch.Tensor,
-    ) -> tuple:
-        """
-        Args:
-            top_scores: Routing scores, shape ``(T, top_k)``.
-            selected_experts_indices: Expert indices, shape ``(T, top_k)``.
-
-        Returns:
-            Tuple of:
-                - top_scores_experts_sorted ``(T * top_k,)``: scores in
-                  expert-sorted order.
-                - token_indices_experts_sorted ``(T * top_k,)``: flattened
-                  token-slot indices sorted by expert.
-                - num_tokens_per_expert ``(num_experts,)``: histogram.
-        """
-        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices, self.num_experts)
-
-        token_indices_experts_sorted = torch.argsort(selected_experts_indices.view(-1), stable=True)
-
-        top_scores_experts_sorted = top_scores.view(-1)[token_indices_experts_sorted]
-
-        return (
-            top_scores_experts_sorted,
-            token_indices_experts_sorted,
-            num_tokens_per_expert,
-        )

--- a/deepspeed/moe/ep_router.py
+++ b/deepspeed/moe/ep_router.py
@@ -184,8 +184,6 @@ class TokenChoiceTopKRouter(nn.Module):
 
         top_scores = top_scores * self.route_scale
 
-        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices,
-                                                        self.num_experts,
-                                                        out_dtype=torch.int32)
+        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices, self.num_experts)
 
         return top_scores, selected_experts_indices, num_tokens_per_expert

--- a/deepspeed/moe/ep_router.py
+++ b/deepspeed/moe/ep_router.py
@@ -148,7 +148,7 @@ class TokenChoiceTopKRouter(nn.Module):
             Tuple of:
                 - top_scores ``(T, top_k)``: routing weights for selected experts.
                 - selected_experts ``(T, top_k)``: expert indices per token.
-                - num_tokens_per_expert ``(num_experts,)``: histogram of token counts.
+                - num_tokens_per_expert ``(num_experts,)``: int32 histogram of token counts.
         """
         # Gate projection -> (T, num_experts)
         scores = self.gate(x)
@@ -184,6 +184,8 @@ class TokenChoiceTopKRouter(nn.Module):
 
         top_scores = top_scores * self.route_scale
 
-        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices, self.num_experts)
+        num_tokens_per_expert = count_tokens_per_expert(selected_experts_indices,
+                                                        self.num_experts,
+                                                        out_dtype=torch.int32)
 
         return top_scores, selected_experts_indices, num_tokens_per_expert

--- a/tests/unit/v1/moe/test_autoep_unit.py
+++ b/tests/unit/v1/moe/test_autoep_unit.py
@@ -43,7 +43,6 @@ from deepspeed.module_inject.auto_ep_presets.registry import (
 )
 from deepspeed.moe.layer import MoE
 from deepspeed.moe.ep_experts import GroupedExperts
-from deepspeed.moe.ep_kernels import TokenReorderer
 from deepspeed.moe.ep_repack import repack_expert_weights
 from deepspeed.moe.ep_router import TokenChoiceTopKRouter
 from deepspeed.runtime.engine import DeepSpeedEngine
@@ -850,7 +849,7 @@ class TestRoutingAndLayerSemantics:
         assert torch.equal(scaled_counts, base_counts)
         assert base_counts.shape == (8, )
 
-    def test_grouped_experts_and_token_reorderer(self):
+    def test_grouped_experts(self):
         experts = GroupedExperts(dim=64, hidden_dim=128, num_experts=4, use_grouped_mm=False)
         nn.init.normal_(experts.w1, std=0.02)
         nn.init.normal_(experts.w2, std=0.02)
@@ -858,13 +857,6 @@ class TestRoutingAndLayerSemantics:
         out = experts(torch.randn(8, 64), torch.tensor([2, 2, 2, 2]))
         assert out.shape == (8, 64)
         assert not torch.isnan(out).any()
-
-        top_scores = torch.randn(20, 2)
-        selected_experts = torch.randint(0, 4, (20, 2))
-        scores_sorted, indices_sorted, counts = TokenReorderer(num_experts=4, top_k=2)(top_scores, selected_experts)
-        assert scores_sorted.shape == (40, )
-        assert set(indices_sorted.tolist()) == set(range(40))
-        assert torch.equal(counts, torch.bincount(selected_experts.reshape(-1), minlength=4).to(counts.dtype))
 
     def test_score_application_and_combine(self):
         x = torch.randn(4, 8)


### PR DESCRIPTION
**Motivations**
``count_tokens_per_expert`` function was called three times in each forward pass, and the ``torch.bincount`` inside it will introduce cpu-gpu sync. But the results of the first call could be reused.

**Changes**
• Reuse the router's histogram. The router already computes num_tokens_per_expert; reuse it through compute_split_plan  and the  ep_size == 1 path instead of recomputing it in AutoEPMoELayer.forward .
• Faster count_tokens_per_expert. Replace  torch.bincount  with a pre-sized  zeros(num_experts, int32)  +  scatter_add_ , avoiding the device-to-host sync that  bincount needs . The helper now always returns an int32 histogram; the unused  out_dtype / deterministic_safe  params and padding logic are removed.
• Remove deterministic_safe path in ``count_tokens_per_expert``.  The histogram of integers is inherently deterministic. The op just sums 1 per bucket. Integer addition is associative and commutative, so the atomic accumulation order has zero effect on the result — every run produces identical counts
• Remove the  TokenReorderer  module. Its logic (argsort by expert + score gather) is a two-liner, now inlined directly in the layer forward. 

**Performance**
The time below is measured from the moe gate kernel to the last kernel before first all-to-all communication. 
A100: 2.3ms -> 1.7ms. 
H200: 0.89ms -> 0.53ms. 