### PR TITLE
Add configurable sum gradient reduction

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -1030,6 +1030,8 @@ class DeepSpeedConfig(object):
             raise ValueError(f"{GRADIENT_ALLREDUCE_OP}='sum' is not supported with ZeRO stage 3")
         if self.gradient_allreduce_op == GRADIENT_ALLREDUCE_OP_SUM and self.zero_config.zenflow is not None:
             raise ValueError(f"{GRADIENT_ALLREDUCE_OP}='sum' is not supported with ZenFlow")
+        if self.gradient_allreduce_op == GRADIENT_ALLREDUCE_OP_SUM and self.compile_config.deepcompile:
+            raise ValueError(f"{GRADIENT_ALLREDUCE_OP}='sum' is not supported with DeepCompile")
 
         if self.float16_config.fp16_master_weights_and_grads:
             assert self.zero_enabled and self.zero_optimization_stage in (

--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -231,6 +231,17 @@ def get_gradient_predivide_factor(param_dict):
     return get_scalar_param(param_dict, GRADIENT_PREDIVIDE_FACTOR, GRADIENT_PREDIVIDE_FACTOR_DEFAULT)
 
 
+def get_gradient_allreduce_op(param_dict):
+    value = get_scalar_param(param_dict, GRADIENT_ALLREDUCE_OP, GRADIENT_ALLREDUCE_OP_DEFAULT)
+    if isinstance(value, str):
+        value = value.lower()
+    if value not in GRADIENT_ALLREDUCE_OP_SUPPORTED:
+        raise ValueError(
+            f"Invalid {GRADIENT_ALLREDUCE_OP}. Supported operations: {list(GRADIENT_ALLREDUCE_OP_SUPPORTED)}. "
+            f"Got: {value!r}")
+    return value
+
+
 def get_steps_per_print(param_dict):
     return get_scalar_param(param_dict, STEPS_PER_PRINT, STEPS_PER_PRINT_DEFAULT)
 
@@ -795,6 +806,7 @@ class DeepSpeedConfig(object):
             param_dict, SEQ_PARALLEL_COMMUNICATION_DATA_TYPE, SEQ_PARALLEL_COMMUNICATION_DATA_TYPE_DEFAULT)
         self.prescale_gradients = get_prescale_gradients(param_dict)
         self.gradient_predivide_factor = get_gradient_predivide_factor(param_dict)
+        self.gradient_allreduce_op = get_gradient_allreduce_op(param_dict)
         self.sparse_gradients_enabled = get_sparse_gradients_enabled(param_dict)
 
         self.zero_config = get_zero_config(param_dict)
@@ -1012,6 +1024,12 @@ class DeepSpeedConfig(object):
             assert (self.zero_optimization_stage
                     <= ZeroStageEnum.max_stage), "DeepSpeedConfig: Maximum supported ZeRO stage is {}".format(
                         ZeroStageEnum.max_stage)
+
+        if (self.gradient_allreduce_op == GRADIENT_ALLREDUCE_OP_SUM
+                and self.zero_optimization_stage == ZeroStageEnum.weights):
+            raise ValueError(f"{GRADIENT_ALLREDUCE_OP}='sum' is not supported with ZeRO stage 3")
+        if self.gradient_allreduce_op == GRADIENT_ALLREDUCE_OP_SUM and self.zero_config.zenflow is not None:
+            raise ValueError(f"{GRADIENT_ALLREDUCE_OP}='sum' is not supported with ZenFlow")
 
         if self.float16_config.fp16_master_weights_and_grads:
             assert self.zero_enabled and self.zero_optimization_stage in (

--- a/deepspeed/runtime/constants.py
+++ b/deepspeed/runtime/constants.py
@@ -324,6 +324,16 @@ Gradient predivide factor should be enabled as:
 GRADIENT_PREDIVIDE_FACTOR = "gradient_predivide_factor"
 GRADIENT_PREDIVIDE_FACTOR_DEFAULT = 1.0
 
+GRADIENT_ALLREDUCE_OP_FORMAT = '''
+Gradient allreduce operation should be set as:
+"gradient_allreduce_op": "mean"
+'''
+GRADIENT_ALLREDUCE_OP = "gradient_allreduce_op"
+GRADIENT_ALLREDUCE_OP_MEAN = "mean"
+GRADIENT_ALLREDUCE_OP_SUM = "sum"
+GRADIENT_ALLREDUCE_OP_DEFAULT = GRADIENT_ALLREDUCE_OP_MEAN
+GRADIENT_ALLREDUCE_OP_SUPPORTED = (GRADIENT_ALLREDUCE_OP_MEAN, GRADIENT_ALLREDUCE_OP_SUM)
+
 #########################################
 # Disable AllGather
 #########################################

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -59,7 +59,7 @@ from deepspeed.runtime.zero.muon.muon_optimizer import MuonWithAuxAdam
 from deepspeed.runtime.constants import \
     ROUTE_TRAIN, ROUTE_PREDICT, ROUTE_EVAL, \
     PLD_THETA, PLD_GAMMA, BFLOAT16, FP16, AMP, GRADIENT_ACCUMULATION_STEPS, \
-    DATA_PARALLEL_GROUP, GLOBAL_RANK, DDP_BFLOAT16
+    DATA_PARALLEL_GROUP, GLOBAL_RANK, DDP_BFLOAT16, GRADIENT_ALLREDUCE_OP_MEAN
 from deepspeed.runtime.zero.config import ZeroStageEnum
 from deepspeed.compression import compression_scheduler
 from deepspeed.compression.constants import \
@@ -264,7 +264,7 @@ class DeepSpeedEngine(Module):
         # Unmanaged mode: backward() calls since the last step(), used to advance global_samples.
         self._unmanaged_backward_count = 0
         self.skipped_steps = 0
-        self.gradient_average = True
+        self.gradient_average = config_class.gradient_allreduce_op == GRADIENT_ALLREDUCE_OP_MEAN
         self.warn_unscaled_loss = True
         self.config = config
         self._config = config_class
@@ -2365,6 +2365,7 @@ class DeepSpeedEngine(Module):
                 mpu=self.mpu,
                 postscale_gradients=self.postscale_gradients(),
                 gradient_predivide_factor=self.gradient_predivide_factor(),
+                gradient_average=self.gradient_average,
                 gradient_accumulation_steps=self.gradient_accumulation_steps(),
                 ignore_unused_parameters=self.zero_ignore_unused_parameters(),
                 partition_grads=zero_stage == ZeroStageEnum.gradients,
@@ -3610,14 +3611,15 @@ class DeepSpeedEngine(Module):
 
         if dp_world_size is None:
             dp_world_size = dist.get_world_size(group=dp_group)
-        if self.postscale_gradients():
+        if not self.gradient_average:
+            dist.all_reduce(tensor_to_allreduce, group=dp_group)
+        elif self.postscale_gradients():
             if self.gradient_predivide_factor() != 1.0:
                 tensor_to_allreduce.mul_(1.0 / self.gradient_predivide_factor())
 
             dist.all_reduce(tensor_to_allreduce, group=dp_group)
-            if self.gradient_average:
-                if self.gradient_predivide_factor() != dp_world_size:
-                    tensor_to_allreduce.mul_(self.gradient_predivide_factor() / dp_world_size)
+            if self.gradient_predivide_factor() != dp_world_size:
+                tensor_to_allreduce.mul_(self.gradient_predivide_factor() / dp_world_size)
         else:
             tensor_to_allreduce.mul_(1. / dp_world_size)
             dist.all_reduce(tensor_to_allreduce, group=dp_group)
@@ -3770,11 +3772,11 @@ class DeepSpeedEngine(Module):
 
         if dp_world_size is None:
             dp_world_size = dist.get_world_size(group=dp_group)
-        if self.postscale_gradients():
-            if self.gradient_average:
+        if self.gradient_average:
+            if self.postscale_gradients():
                 values.mul_(self.gradient_predivide_factor() / (dp_world_size))
-        else:
-            values.mul_(1. / (dp_world_size))
+            else:
+                values.mul_(1. / (dp_world_size))
 
         indices_device_list = self.sparse_all_gather(indices, dp_group)
         values_device_list = self.sparse_all_gather(values, dp_group)

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -169,6 +169,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                  communication_data_type=torch.float16,
                  postscale_gradients=True,
                  gradient_predivide_factor=1.0,
+                 gradient_average=True,
                  gradient_accumulation_steps=1,
                  ignore_unused_parameters=True,
                  partition_grads=True,
@@ -281,6 +282,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.communication_data_type = communication_data_type
         self.gradient_predivide_factor = gradient_predivide_factor
         self.postscale_gradients = postscale_gradients
+        self.gradient_average = gradient_average
         self.gradient_accumulation_steps = gradient_accumulation_steps
         self.micro_step_id = INITIAL_MICRO_STEP_ID
         self.ignore_unused_parameters = ignore_unused_parameters
@@ -306,8 +308,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if self.reduce_scatter and self.partition_gradients:
             valid_reduce_scatter_dtypes = (torch.float16, torch.bfloat16, torch.float32)
             assert self.communication_data_type in valid_reduce_scatter_dtypes, f"{self.zero_stage_string} supports {valid_reduce_scatter_dtypes} communication_data_type with reduce scatter enabled. Got: '{self.communication_data_type}'"
-            assert self.gradient_predivide_factor == 1.0, f"gradient_predivide_factor != 1.0 is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
-            assert self.postscale_gradients, f"pre-scale gradients is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
+            if self.gradient_average:
+                assert self.gradient_predivide_factor == 1.0, f"gradient_predivide_factor != 1.0 is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
+                assert self.postscale_gradients, f"pre-scale gradients is not yet supported with {self.zero_stage_string} with reduce scatter enabled"
 
         # param flattened by groups
         self.bit16_groups = []
@@ -1210,7 +1213,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if communication_data_type != tensor.dtype:
             tensor_to_allreduce = tensor.to(communication_data_type)
 
-        if self.postscale_gradients:
+        if not self.gradient_average:
+            dist.all_reduce(tensor_to_allreduce, group=self.dp_process_group)
+        elif self.postscale_gradients:
             if self.gradient_predivide_factor != 1.0:
                 tensor_to_allreduce.mul_(1. / self.gradient_predivide_factor)
 
@@ -1373,7 +1378,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     curr_size += numel
                     prev_id, prev_process_group, prev_copy_ranks = partition_id, process_group, copy_ranks
 
-            tensor.div_(dist.get_world_size(group=self.dp_process_group) / float(self.sequence_parallel_size))
+            if self.gradient_average:
+                tensor.div_(dist.get_world_size(group=self.dp_process_group) / float(self.sequence_parallel_size))
 
             buckets = {}
             for i, (dst, bucket_offset, numel, copy_ranks) in enumerate(rank_and_offsets):
@@ -1788,7 +1794,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if communication_data_type != tensor.dtype:
             tensor_to_allreduce = tensor.to(communication_data_type)
 
-        if divide:
+        if divide and self.gradient_average:
             tensor_to_allreduce.div_(dist.get_world_size(group=process_group) / float(self.sequence_parallel_size))
 
         if rank is None:

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -226,17 +226,23 @@ Example of <i>**scheduler**</i>
 | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
 | During gradient averaging perform communication with selected data type. By default it will be determined by selected regime  |  None   |
 
+<i>**gradient_allreduce_op**</i>: [string]
+
+| Description                                                                                                                                                                                            | Default  |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| Select `"mean"` to average gradients across data-parallel workers or `"sum"` to keep the unscaled sum. `"sum"` supports ZeRO stages 0, 1, and 2 without ZenFlow; ZeRO stage 3 and ZenFlow reject this setting. | `"mean"` |
+
 <i>**prescale_gradients**</i>: [boolean]
 
 | Description                            | Default |
 | -------------------------------------- | ------- |
-| Scale gradients before doing allreduce | `false` |
+| Scale gradients before doing mean allreduce | `false` |
 
 <i>**gradient_predivide_factor**</i>: [float]
 
 | Description                                                                                                                                       | Default |
 | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| Before gradient averaging predivide gradients by a specified factor, can sometimes help with fp16 stability when scaling to large numbers of GPUs | `1.0`   |
+| Before mean gradient allreduce, predivide gradients by a specified factor; this can sometimes help with fp16 stability when scaling to large numbers of GPUs | `1.0`   |
 
 <i>**sparse_gradients**</i>: [boolean]
 

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -230,7 +230,7 @@ Example of <i>**scheduler**</i>
 
 | Description                                                                                                                                                                                            | Default  |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
-| Select `"mean"` to average gradients across data-parallel workers or `"sum"` to keep the unscaled sum. `"sum"` supports ZeRO stages 0, 1, and 2 without ZenFlow; ZeRO stage 3 and ZenFlow reject this setting. | `"mean"` |
+| Select `"mean"` to average gradients across data-parallel workers or `"sum"` to keep the unscaled sum. `"sum"` supports ZeRO stages 0, 1, and 2 when neither ZenFlow nor DeepCompile is enabled; ZeRO stage 3, ZenFlow, and DeepCompile reject this setting. | `"mean"` |
 
 <i>**prescale_gradients**</i>: [boolean]
 

--- a/tests/unit/runtime/test_ds_config_dict.py
+++ b/tests/unit/runtime/test_ds_config_dict.py
@@ -135,6 +135,51 @@ def test_temp_config_json(tmpdir):
     assert 'train_batch_size' in config_json
 
 
+@pytest.mark.parametrize("value,expected", [("mean", "mean"), ("SUM", "sum")])
+def test_gradient_allreduce_op(value, expected):
+    config = DeepSpeedConfig({
+        "train_batch_size": 1,
+        "gradient_allreduce_op": value,
+    })
+    assert config.gradient_allreduce_op == expected
+
+
+def test_gradient_allreduce_op_default():
+    config = DeepSpeedConfig({"train_batch_size": 1})
+    assert config.gradient_allreduce_op == "mean"
+
+
+def test_invalid_gradient_allreduce_op():
+    with pytest.raises(ValueError, match="Invalid gradient_allreduce_op"):
+        DeepSpeedConfig({
+            "train_batch_size": 1,
+            "gradient_allreduce_op": "max",
+        })
+
+
+def test_sum_gradient_allreduce_rejects_zero3():
+    with pytest.raises(ValueError, match="not supported with ZeRO stage 3"):
+        DeepSpeedConfig({
+            "train_batch_size": 1,
+            "gradient_allreduce_op": "sum",
+            "zero_optimization": {
+                "stage": 3,
+            },
+        })
+
+
+def test_sum_gradient_allreduce_rejects_zenflow():
+    with pytest.raises(ValueError, match="not supported with ZenFlow"):
+        DeepSpeedConfig({
+            "train_batch_size": 1,
+            "gradient_allreduce_op": "sum",
+            "zero_optimization": {
+                "stage": 2,
+                "zenflow": {},
+            },
+        })
+
+
 @pytest.mark.parametrize("gather_weights_key",
                          ["stage3_gather_16bit_weights_on_model_save", "stage3_gather_fp16_weights_on_model_save"])
 def test_gather_16bit_params_on_model_save(gather_weights_key):

--- a/tests/unit/runtime/test_ds_config_dict.py
+++ b/tests/unit/runtime/test_ds_config_dict.py
@@ -180,6 +180,21 @@ def test_sum_gradient_allreduce_rejects_zenflow():
         })
 
 
+@pytest.mark.parametrize("zero_stage", [1, 2])
+def test_sum_gradient_allreduce_rejects_deepcompile(zero_stage):
+    with pytest.raises(ValueError, match="not supported with DeepCompile"):
+        DeepSpeedConfig({
+            "train_batch_size": 1,
+            "gradient_allreduce_op": "sum",
+            "zero_optimization": {
+                "stage": zero_stage,
+            },
+            "compile": {
+                "deepcompile": True,
+            },
+        })
+
+
 @pytest.mark.parametrize("gather_weights_key",
                          ["stage3_gather_16bit_weights_on_model_save", "stage3_gather_fp16_weights_on_model_save"])
 def test_gather_16bit_params_on_model_save(gather_weights_key):

--- a/tests/unit/v1/zero/test_zero.py
+++ b/tests/unit/v1/zero/test_zero.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+from copy import deepcopy
 import math
 from collections import namedtuple
 from typing import Dict, List, NamedTuple, Set, Tuple
@@ -16,7 +17,7 @@ from torch.nn.modules.loss import L1Loss
 from torch.nn.parameter import Parameter
 from torch.nn.utils import skip_init
 
-from unit.common import DistributedTest, preferred_dtype
+from unit.common import DistributedTest, preferred_dtype, allclose_on_all_ranks
 from unit.simple_model import SimpleModel, random_dataloader
 
 import deepspeed
@@ -26,6 +27,7 @@ from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
 from deepspeed.utils.zero_to_fp32 import load_state_dict_from_zero_checkpoint
 from deepspeed.runtime.zero.utils import ZeRORuntimeException
 from deepspeed.accelerator import get_accelerator
+from deepspeed.utils import safe_get_full_fp32_param, safe_get_full_grad
 
 
 @pytest.mark.parametrize("zero_stage", [0, 1, 2])
@@ -78,6 +80,147 @@ class TestGradientAllreduceOp(DistributedTest):
         expected = -inputs * expected_scale
         torch.testing.assert_close(actual, expected)
         engine.destroy()
+
+
+@pytest.mark.parametrize(
+    "optimizer_name,zero_stage",
+    [
+        pytest.param("AdamW", 0, id="adamw-zero0"),
+        pytest.param("AdamW", 1, id="adamw-zero1"),
+        pytest.param("AdamW", 2, id="adamw-zero2"),
+        pytest.param("Muon", 1, id="muon-zero1"),
+        pytest.param("Muon", 2, id="muon-zero2"),
+    ],
+)
+class TestGradientAllreduceOpTraining(DistributedTest):
+    world_size = 2
+
+    def test(self, optimizer_name, zero_stage):
+        world_size = dist.get_world_size()
+        rank = dist.get_rank()
+        hidden_dim = 32
+        micro_batch_size = 4
+        steps = 5
+        use_muon = optimizer_name == "Muon"
+        if use_muon and torch.half not in get_accelerator().supported_dtypes():
+            pytest.skip(f"fp16 not supported, valid dtype: {get_accelerator().supported_dtypes()}")
+
+        dtype = torch.float16 if use_muon else torch.float32
+        rtol, atol = ((1e-3, 1e-4) if use_muon else (1e-5, 1e-6))
+
+        optimizer_params = {
+            "lr": 0.01 if use_muon else 1e-3,
+            "weight_decay": 0.0,
+        }
+        if use_muon:
+            optimizer_params.update({
+                "momentum": 0.95,
+                "ns_method": "gram",
+            })
+        else:
+            optimizer_params["torch_adam"] = True
+
+        def config(gradient_allreduce_op):
+            config_dict = {
+                "train_micro_batch_size_per_gpu": micro_batch_size,
+                "gradient_clipping": 0.0,
+                "steps_per_print": 1000,
+                "gradient_allreduce_op": gradient_allreduce_op,
+                "optimizer": {
+                    "type": optimizer_name,
+                    "params": optimizer_params,
+                },
+                "zero_optimization": {
+                    "stage": zero_stage,
+                    "contiguous_gradients": True,
+                },
+            }
+            if zero_stage > 0:
+                config_dict["zero_optimization"]["reduce_scatter"] = True
+            if use_muon:
+                config_dict["fp16"] = {
+                    "enabled": True,
+                    "loss_scale": 1.0,
+                }
+            return config_dict
+
+        def get_batch(step, device):
+            generator = torch.Generator().manual_seed(999 + step)
+            global_x = torch.randn(world_size * micro_batch_size, hidden_dim, generator=generator)
+            global_y = torch.randint(0, hidden_dim, (world_size * micro_batch_size, ), generator=generator)
+            start = rank * micro_batch_size
+            x = global_x[start:start + micro_batch_size].to(device, dtype=dtype)
+            y = global_y[start:start + micro_batch_size].to(device)
+            return x, y
+
+        def clone_full_param(param):
+            full_param = safe_get_full_fp32_param(param)
+            if full_param is None:
+                full_param = param.detach().float()
+            return full_param.clone()
+
+        torch.manual_seed(1234)
+        base_model = SimpleModel(hidden_dim=hidden_dim, nlayers=2)
+        mean_model = deepcopy(base_model)
+        mean_engine, _, _, _ = deepspeed.initialize(config=config("mean"),
+                                                    model=mean_model,
+                                                    model_parameters=mean_model.parameters())
+        mean_losses = []
+        mean_gradients = []
+        mean_parameters = []
+        for step in range(steps):
+            x, y = get_batch(step, mean_engine.device)
+            mean_loss = mean_engine(x, y)
+            mean_engine.backward(mean_loss)
+            mean_losses.append(mean_loss.detach().clone())
+            mean_gradients.append({
+                name: safe_get_full_grad(param).detach().clone()
+                for name, param in mean_engine.module.named_parameters()
+            })
+            mean_engine.step()
+            mean_parameters.append({
+                name: clone_full_param(param)
+                for name, param in mean_engine.module.named_parameters()
+            })
+        mean_engine.destroy()
+
+        sum_model = deepcopy(base_model)
+        sum_engine, _, _, _ = deepspeed.initialize(config=config("sum"),
+                                                   model=sum_model,
+                                                   model_parameters=sum_model.parameters())
+
+        for step in range(steps):
+            x, y = get_batch(step, sum_engine.device)
+            sum_loss = sum_engine(x, y)
+            allclose_on_all_ranks(sum_loss,
+                                  mean_losses[step],
+                                  assert_message=f"{optimizer_name} ZeRO-{zero_stage} loss differs at step {step}",
+                                  rtol=rtol,
+                                  atol=atol)
+            # SUM scales gradients by world_size. Normalize only the backward loss so
+            # adaptive and nonlinear optimizers receive the same gradients as MEAN.
+            sum_engine.backward(sum_loss / world_size)
+
+            for sum_name, sum_param in sum_engine.module.named_parameters():
+                normalized_sum_grad = safe_get_full_grad(sum_param)
+                allclose_on_all_ranks(
+                    normalized_sum_grad,
+                    mean_gradients[step][sum_name],
+                    assert_message=f"{optimizer_name} ZeRO-{zero_stage} gradient {sum_name} differs at step {step}",
+                    rtol=rtol,
+                    atol=atol)
+
+            sum_engine.step()
+
+            for sum_name, sum_param in sum_engine.module.named_parameters():
+                allclose_on_all_ranks(
+                    clone_full_param(sum_param),
+                    mean_parameters[step][sum_name],
+                    assert_message=f"{optimizer_name} ZeRO-{zero_stage} parameter {sum_name} differs at step {step}",
+                    rtol=rtol,
+                    atol=atol)
+
+        sum_engine.destroy()
 
 
 def run_unbalanced_gradients(model, data_loader):

--- a/tests/unit/v1/zero/test_zero.py
+++ b/tests/unit/v1/zero/test_zero.py
@@ -28,6 +28,58 @@ from deepspeed.runtime.zero.utils import ZeRORuntimeException
 from deepspeed.accelerator import get_accelerator
 
 
+@pytest.mark.parametrize("zero_stage", [0, 1, 2])
+@pytest.mark.parametrize("gradient_allreduce_op,expected_scale", [("mean", 1.0), ("sum", 2.0)])
+@pytest.mark.parametrize(
+    "reduce_scatter,contiguous_gradients,prescale_gradients,gradient_predivide_factor",
+    [
+        (True, True, False, 1.0),
+        (False, True, False, 2.0),
+        (False, False, True, 1.0),
+    ],
+)
+class TestGradientAllreduceOp(DistributedTest):
+    world_size = 2
+
+    def test(self, zero_stage, gradient_allreduce_op, expected_scale, reduce_scatter, contiguous_gradients,
+             prescale_gradients, gradient_predivide_factor):
+
+        class LinearLoss(Module):
+
+            def __init__(self):
+                super().__init__()
+                self.weight = Parameter(torch.zeros(2))
+
+            def forward(self, inputs):
+                return (self.weight * inputs).sum()
+
+        model = LinearLoss()
+        optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+        config_dict = {
+            "train_micro_batch_size_per_gpu": 1,
+            "gradient_clipping": 0.0,
+            "zero_allow_untested_optimizer": True,
+            "gradient_allreduce_op": gradient_allreduce_op,
+            "prescale_gradients": prescale_gradients,
+            "gradient_predivide_factor": gradient_predivide_factor,
+            "zero_optimization": {
+                "stage": zero_stage,
+                "reduce_scatter": reduce_scatter,
+                "contiguous_gradients": contiguous_gradients,
+            },
+        }
+        engine, _, _, _ = deepspeed.initialize(model=model, optimizer=optimizer, config=config_dict)
+
+        inputs = torch.tensor([1.0, 2.0], device=engine.device)
+        engine.backward(engine(inputs))
+        engine.step()
+
+        actual = engine.module.weight.detach().clone()
+        expected = -inputs * expected_scale
+        torch.testing.assert_close(actual, expected)
+        engine.destroy()
+
+
 def run_unbalanced_gradients(model, data_loader):
 
     def drop_some_gradients(model, iter):


### PR DESCRIPTION
## Summary

- add a `gradient_allreduce_op` configuration with `"mean"` as the default and `"sum"` as the new option
- support unscaled gradient sums for ZeRO stages 0, 1, and 2 across reduce-scatter, allreduce, and non-contiguous fallback paths
- reject unsupported ZeRO stage 3, ZenFlow, and DeepCompile combinations with clear configuration errors
- document the option and preserve existing mean-reduction behavior

Addresses #7107.

## Motivation

Some distributed objectives, including contrastive learning over globally gathered embeddings, require summing data-parallel gradients rather than averaging them. Today users need to rescale the loss manually to cancel DeepSpeed's world-size normalization.

This change makes the reduction semantics explicit while keeping the current behavior as the default.

## Validation

Tested on two NVIDIA GeForce RTX 3090 GPUs with PyTorch 2.13.0+cu130:

- `pytest --forked -q tests/unit/v1/zero/test_zero.py::TestGradientAllreduceOp` — 18 passed
- targeted configuration tests in `tests/unit/runtime/test_ds_config_dict.py` — 8 passed; the new ZeRO-1/2 DeepCompile cases both failed against the prior head because no error was raised
- `pytest --forked -q tests/unit/v1/zero/test_zero_coalesce_grad_reduction.py::TestCoalesceCombinations` — 12 passed
- `pytest --forked -q tests/unit/runtime/sparse_tensor/test_averaging_sparse_gradients.py` — 1 passed
- changed-file `pre-commit` hooks, including YAPF, flake8, codespell, license, `check-torchdist`, and `check-torchcuda` — passed

The distributed test matrix covers ZeRO stages 0/1/2, mean and sum reductions, reduce-scatter, gradient predivide, prescale, and non-contiguous gradient fallback.

### Real-training equivalence

A deterministic two-rank, five-step `SimpleModel` regression compares the default MEAN reduction with SUM while normalizing only the SUM backward loss by `world_size`, so both modes provide identical gradients to the optimizer.

- AdamW: ZeRO-0/1/2
- Muon: ZeRO-1/2
- targeted gradient-reduction tests: `23 passed`
- complete `tests/unit/v1/zero/test_zero.py`: `98 passed, 1 skipped`

Across all five optimizer/stage configurations and all five training steps, the observed loss, full-gradient, and full-parameter differences were zero.

<img width="2496" height="1572" alt="loss_comparison" src="https://github.com/user-attachments/assets/3532ad11-5297-42db-baca-8a632bf793ad" />

## Limitations

`gradient_allreduce_op="sum"` is intentionally not supported with ZeRO stage 3, ZenFlow, or DeepCompile. These combinations fail during configuration instead of silently applying mean semantics.
