### PR TITLE
Add adaptive gather-buffer pooling for DeepCompile ZeRO-3

### DIFF
--- a/blogs/deepcompile/README.md
+++ b/blogs/deepcompile/README.md
@@ -153,6 +153,21 @@ This project is the result of a close collaboration between Microsoft and the Un
 
 # Appendix
 
+## Diagnostics
+
+DeepCompile's low-level scheduler diagnostics are controlled by an opt-in environment variable rather than a
+`compile` configuration field. Prefix the normal launch command with the variable, for example:
+
+```bash
+DEEPSPEED_COMPILE_SCHEDULER_BUDGET_DEBUG=1 deepspeed <training-script>
+```
+
+The flag is disabled when unset or set, case-insensitively, to an empty value, `0`, `false`, or `no`; any other
+value enables the diagnostic. It prints rank-zero scheduler budget and
+cross-rank schedule-fingerprint lines beginning with `DeepCompile ZeRO-3 scheduler`, `DeepCompile ZeRO-3
+collective_schedule_projection`, or `DeepCompile ZeRO-3 final_schedule_fingerprint`.
+This debugging stream is not JSON or a stable machine-readable API and may add synchronization or logging overhead.
+
 ## Examples and Benchmarks
 
 Our DeepSpeedExamples repository provides [example code](https://github.com/deepspeedai/DeepSpeedExamples/tree/master/benchmarks/deepcompile) to enable DeepCompile.

--- a/blogs/deepcompile/README.md
+++ b/blogs/deepcompile/README.md
@@ -155,18 +155,21 @@ This project is the result of a close collaboration between Microsoft and the Un
 
 ## Diagnostics
 
-DeepCompile's low-level scheduler diagnostics are controlled by an opt-in environment variable rather than a
-`compile` configuration field. Prefix the normal launch command with the variable, for example:
+DeepCompile's low-level scheduler and gather-buffer diagnostics are opt-in environment variables rather than
+`compile` configuration fields. Prefix the normal launch command with either variable, for example:
 
 ```bash
 DEEPSPEED_COMPILE_SCHEDULER_BUDGET_DEBUG=1 deepspeed <training-script>
+DEEPSPEED_ALLOCATOR_TELEMETRY=1 deepspeed <training-script>
 ```
 
-The flag is disabled when unset or set, case-insensitively, to an empty value, `0`, `false`, or `no`; any other
-value enables the diagnostic. It prints rank-zero scheduler budget and
+Both flags are disabled when unset or set, case-insensitively, to an empty value, `0`, `false`, or `no`; any other
+value enables the diagnostic. `DEEPSPEED_COMPILE_SCHEDULER_BUDGET_DEBUG` prints rank-zero scheduler budget and
 cross-rank schedule-fingerprint lines beginning with `DeepCompile ZeRO-3 scheduler`, `DeepCompile ZeRO-3
 collective_schedule_projection`, or `DeepCompile ZeRO-3 final_schedule_fingerprint`.
-This debugging stream is not JSON or a stable machine-readable API and may add synchronization or logging overhead.
+`DEEPSPEED_ALLOCATOR_TELEMETRY` prints native, line-oriented gather-buffer pool events from each process beginning
+with `DEEPSPEED_Z3_GATHER_BUFFER_POOL`. These debugging streams are not JSON or a stable machine-readable API and
+may add synchronization or logging overhead.
 
 ## Examples and Benchmarks
 

--- a/csrc/compile/deepcompile.cpp
+++ b/csrc/compile/deepcompile.cpp
@@ -15,7 +15,8 @@ std::shared_ptr<DoubleBufferedReduceBucket> reduce_buckets = nullptr;
 
 c10::intrusive_ptr<c10d::ProcessGroup> process_group = nullptr;
 c10::intrusive_ptr<c10d::symmetric_memory::SymmetricMemory> symm_mem = nullptr;
-ncclComm_t nccl_comm;
+ncclComm_t nccl_comm = nullptr;
+bool nccl_comm_initialized = false;
 bool use_symm_mem;
 bool profile = false;
 bool pre_div_reduce = true;
@@ -84,10 +85,20 @@ void reset()
 void cleanup()
 {
     reset();
+    if (reduce_buckets) {
+        reduce_buckets->clear();
+        reduce_buckets.reset();
+    }
+    param_registry.reset();
 
-    ncclCommDestroy(nccl_comm);
+    if (nccl_comm_initialized) {
+        ncclCommDestroy(nccl_comm);
+        nccl_comm = nullptr;
+        nccl_comm_initialized = false;
+    }
     process_group = nullptr;
     symm_mem = nullptr;
+    profile = false;
 }
 
 at::Tensor reduce_grad(at::Tensor grad_tensor, long graph_id, long ds_id)
@@ -150,6 +161,7 @@ void init(c10::intrusive_ptr<c10d::ProcessGroup> pg,
     // create a new nccl communicator
     std::memcpy(&ncclID, tensor.to(torch::Device(torch::kCPU)).data_ptr(), NCCL_UNIQUE_ID_BYTES);
     ncclCommInitRank(&nccl_comm, process_group->getSize(), ncclID, process_group->getRank());
+    nccl_comm_initialized = true;
 
     param_registry = std::make_shared<DSParamRegistry>();
     reduce_buckets = std::make_shared<DoubleBufferedReduceBucket>(

--- a/csrc/compile/deepcompile.cpp
+++ b/csrc/compile/deepcompile.cpp
@@ -4,6 +4,7 @@
 // DeepSpeed Team
 
 #include "deepcompile.h"
+#include "z3.h"
 
 #define USE_C10D_NCCL
 
@@ -85,6 +86,7 @@ void reset()
 void cleanup()
 {
     reset();
+    reset_z3_gather_buffer_pool();
     if (reduce_buckets) {
         reduce_buckets->clear();
         reduce_buckets.reset();

--- a/csrc/compile/deepcompile.cpp
+++ b/csrc/compile/deepcompile.cpp
@@ -78,6 +78,7 @@ ncclDataType_t get_nccl_data_type(at::ScalarType scalar_type)
 
 void reset()
 {
+    for (auto& [_, executor] : executors) { executor->prepareForReset(); }
     executors.clear();
     // We keep the buckets for memory estimation
     // reduce_buckets->clear();

--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -105,6 +105,15 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("register_graph_z3",
           &dc::register_graph_z3,
           "Register graph with a list of ds parameter ids");
+    m.def("set_z3_gather_buffer_pool_fixed_budget_for_test",
+          &dc::set_z3_gather_buffer_pool_fixed_budget_for_test,
+          "Set a fixed ZeRO-3 gather-buffer-pool budget for tests");
+    m.def("update_z3_gather_buffer_pool_allocator_pressure_for_test",
+          &dc::update_z3_gather_buffer_pool_allocator_pressure_for_test,
+          "Simulate allocator pressure for ZeRO-3 gather-buffer-pool tests");
+    m.def("get_z3_gather_buffer_pool_state_for_test",
+          &dc::get_z3_gather_buffer_pool_state_for_test,
+          "Inspect ZeRO-3 gather-buffer-pool accounting for tests");
     m.def("start_forward", &dc::start_forward, "Start forward pass");
     m.def("end_forward", &dc::end_forward, "End forward pass");
     m.def("start_backward", &dc::start_backward, "Start backward pass");

--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -114,6 +114,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("get_z3_gather_buffer_pool_state_for_test",
           &dc::get_z3_gather_buffer_pool_state_for_test,
           "Inspect ZeRO-3 gather-buffer-pool accounting for tests");
+    m.def("get_z3_gather_buffer_pool_reclaimable_bytes",
+          &dc::get_z3_gather_buffer_pool_reclaimable_bytes,
+          "Read immediately reclaimable idle bytes in the ZeRO-3 gather-buffer pool");
+    m.def("get_z3_gather_buffer_pool_transition_reclaimable_bytes",
+          &dc::get_z3_gather_buffer_pool_transition_reclaimable_bytes,
+          "Read pool-owned bytes retired before a ZeRO-3 prefetch arena takes ownership");
     m.def("configure_z3_prefetch_arena",
           &dc::configure_z3_prefetch_arena,
           "Configure a fixed ZeRO-3 prefetch arena plan");

--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -117,6 +117,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("configure_z3_prefetch_arena",
           &dc::configure_z3_prefetch_arena,
           "Configure a fixed ZeRO-3 prefetch arena plan");
+    m.def("disable_z3_prefetch_arena",
+          &dc::disable_z3_prefetch_arena,
+          "Disable every phase of a ZeRO-3 prefetch arena session");
     m.def("get_z3_prefetch_arena_state_for_test",
           &dc::get_z3_prefetch_arena_state_for_test,
           "Inspect ZeRO-3 prefetch arena accounting for tests");

--- a/csrc/compile/init.cpp
+++ b/csrc/compile/init.cpp
@@ -13,7 +13,7 @@ TORCH_LIBRARY(dc, m)
     m.def("allgather_param(Tensor a, int graph_id, int id, ScalarType? dtype = None) -> Tensor");
     m.def(
         "prefetch_params_fused(int graph_id, Tensor[] params, int[] ids,"
-        "                      ScalarType[]? dtypes = None) -> ()");
+        "                      ScalarType[]? dtypes = None, int arena_plan_id = -1) -> ()");
     m.def("wait_allgather(Tensor(a) a, int graph_id, int id) -> Tensor(a)");
     m.def("release_param(Tensor(a) a, int graph_id, int id, int n_users) -> Tensor(a)");
     m.def("reduce_grad(Tensor a, int graph_id, int id) -> Tensor");
@@ -114,6 +114,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("get_z3_gather_buffer_pool_state_for_test",
           &dc::get_z3_gather_buffer_pool_state_for_test,
           "Inspect ZeRO-3 gather-buffer-pool accounting for tests");
+    m.def("configure_z3_prefetch_arena",
+          &dc::configure_z3_prefetch_arena,
+          "Configure a fixed ZeRO-3 prefetch arena plan");
+    m.def("get_z3_prefetch_arena_state_for_test",
+          &dc::get_z3_prefetch_arena_state_for_test,
+          "Inspect ZeRO-3 prefetch arena accounting for tests");
     m.def("start_forward", &dc::start_forward, "Start forward pass");
     m.def("end_forward", &dc::end_forward, "End forward pass");
     m.def("start_backward", &dc::start_backward, "Start backward pass");

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -191,6 +191,7 @@ public:
                 }
             }
             auto target_dtype = dtype ? dtype.value() : ds_tensor.scalar_type();
+            at::cuda::CUDAStreamGuard guard(ag_stream_);
             output_bufs[ds_id] =
                 torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
         }

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -1695,7 +1695,7 @@ public:
         // before any slice can be leased.  Memory profiling is itself part of
         // asynchronous per-rank compilation, so it must never enter this
         // collective.
-        if (diagnosticEnvEnabled("DEEPSPEED_COMPILE_PREFETCH_ARENA") && !profile) {
+        if (!profile && arena_plan_id >= 0) {
             prefetch_arena_->ensureRankConsistent(nccl_comm_, gather_buffer_pool_);
         }
 

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -7,16 +7,642 @@
 #include "deepcompile.h"
 
 #include <ATen/native/cuda/Resize.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 namespace dc {
 
 const size_t TIMEOUT_SYMMETRIC_MEMORY_BARRIER = 60000;
+
+namespace {
+
+bool diagnosticEnvEnabled(const char* name)
+{
+    const char* raw_value = std::getenv(name);
+    if (raw_value == nullptr) { return false; }
+
+    std::string value(raw_value);
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    return !value.empty() && value != "0" && value != "false" && value != "no";
+}
+
+class GatherBufferPool {
+public:
+    enum class ReleaseDisposition { NoResizeNeeded, ResizeByCaller };
+
+    at::Tensor acquire(int64_t numel,
+                       at::ScalarType dtype,
+                       const c10::Device& device,
+                       at::cuda::CUDAStream stream)
+    {
+        flushCompletedPressureRecovery();
+        observeAllocatorPressure(device.index());
+        if (!enabled_ || pressure_recovery_in_progress_) { return at::Tensor(); }
+
+        Entry* best = nullptr;
+        for (auto& entry : entries_) {
+            if (entry.checked_out || entry.buffer.scalar_type() != dtype ||
+                entry.buffer.device() != device || entry.buffer.numel() < numel) {
+                continue;
+            }
+            if (best == nullptr || entry.buffer.numel() < best->buffer.numel()) { best = &entry; }
+        }
+        if (best == nullptr) { return at::Tensor(); }
+
+        best->ready_event->block(stream);
+        at::Tensor result = best->buffer.narrow(0, 0, numel);
+        best->checked_out = true;
+        best->ready_event.reset();
+        best->last_use = ++clock_;
+        return result;
+    }
+
+    void excludeFromAdmission(const at::Tensor& buffer)
+    {
+        if (!buffer.defined() || buffer.storage().nbytes() == 0) { return; }
+        non_retainable_storages_.insert(buffer.storage().unsafeGetStorageImpl());
+    }
+
+    void cancelAdmissionExclusion(const at::Tensor& buffer)
+    {
+        if (!buffer.defined()) { return; }
+        non_retainable_storages_.erase(buffer.storage().unsafeGetStorageImpl());
+    }
+
+    void discard(const at::Tensor& buffer)
+    {
+        if (!buffer.defined()) { return; }
+
+        auto storage = buffer.storage();
+        auto storage_impl = storage.unsafeGetStorageImpl();
+        non_retainable_storages_.erase(storage_impl);
+        if (storage.nbytes() == 0) {
+            removeEntryOwnership(storage_impl, "discarded", false);
+            return;
+        }
+
+        buffer.record_stream(at::cuda::getCurrentCUDAStream());
+        removeEntryOwnership(storage_impl, "discarded", false);
+    }
+
+    ReleaseDisposition release(const at::Tensor& buffer)
+    {
+        auto storage = buffer.storage();
+        if (storage.nbytes() == 0) {
+            auto storage_impl = storage.unsafeGetStorageImpl();
+            non_retainable_storages_.erase(storage_impl);
+            if (removeEntryOwnership(storage_impl, "released_zero_storage", false)) {
+                return ReleaseDisposition::NoResizeNeeded;
+            }
+            return ReleaseDisposition::ResizeByCaller;
+        }
+
+        auto consumer_stream = at::cuda::getCurrentCUDAStream();
+        buffer.record_stream(consumer_stream);
+        observeAllocatorPressure(buffer.device().index());
+
+        auto storage_impl = storage.unsafeGetStorageImpl();
+        const bool excluded = non_retainable_storages_.erase(storage_impl) > 0;
+
+        for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+            if (storageImpl(*it) != storage_impl) { continue; }
+            if (excluded) { return retireEntry(it, storage_impl, "excluded", false); }
+            if (pressure_recovery_in_progress_) {
+                return retireEntry(it, storage_impl, "recovery_release", true);
+            }
+            if (!enabled_ || charged_bytes_ > budget_bytes_) {
+                return retireEntry(it, storage_impl, "evicted_on_return", true);
+            }
+            auto ready_event = std::make_shared<at::cuda::CUDAEvent>(cudaEventDisableTiming);
+            ready_event->record(consumer_stream);
+            it->ready_event = ready_event;
+            it->checked_out = false;
+            it->last_use = ++clock_;
+            return ReleaseDisposition::NoResizeNeeded;
+        }
+
+        if (excluded || !enabled_ || pressure_recovery_in_progress_) {
+            return ReleaseDisposition::ResizeByCaller;
+        }
+
+        const size_t capacity_bytes = storage.nbytes();
+        if (pressure_recovery_complete_ &&
+            !hasRecoveryAdmissionSlot(capacity_bytes, buffer.scalar_type(), buffer.device())) {
+            return ReleaseDisposition::ResizeByCaller;
+        }
+        if (capacity_bytes > budget_bytes_ || !makeRoom(capacity_bytes)) {
+            return ReleaseDisposition::ResizeByCaller;
+        }
+
+        const int64_t capacity_numel = static_cast<int64_t>(capacity_bytes / buffer.element_size());
+        at::Tensor candidate = at::as_strided(buffer.detach(), {capacity_numel}, {1}, 0);
+        auto ready_event = std::make_shared<at::cuda::CUDAEvent>(cudaEventDisableTiming);
+        ready_event->record(consumer_stream);
+        entries_.push_back({candidate, ready_event, false, ++clock_, capacity_bytes});
+        charged_bytes_ += capacity_bytes;
+        if (charged_bytes_ > high_water_bytes_) {
+            high_water_bytes_ = charged_bytes_;
+            logState("high_water");
+        }
+        return ReleaseDisposition::NoResizeNeeded;
+    }
+
+    void setFixedBudgetForTest(int64_t fixed_budget_bytes)
+    {
+        fixed_budget_override_ = true;
+        enabled_ = fixed_budget_bytes > 0;
+        budget_bytes_ = fixed_budget_bytes > 0 ? static_cast<size_t>(fixed_budget_bytes) : 0;
+        baseline_retries_.reset();
+        idle_pressure_score_ = 0;
+        pressure_recovery_in_progress_ = false;
+        pressure_recovery_complete_ = false;
+        pressure_recovery_flush_pending_ = false;
+        pressure_recovery_budget_bytes_ = 0;
+        pressure_recovery_targets_.clear();
+        makeRoom(0);
+        logState("fixed_budget_for_test");
+    }
+
+    void reset()
+    {
+        entries_.clear();
+        non_retainable_storages_.clear();
+        baseline_retries_.reset();
+        idle_pressure_score_ = 0;
+        pressure_recovery_in_progress_ = false;
+        pressure_recovery_complete_ = false;
+        pressure_recovery_flush_pending_ = false;
+        pressure_recovery_budget_bytes_ = 0;
+        pressure_recovery_targets_.clear();
+        budget_bytes_ = 0;
+        charged_bytes_ = 0;
+        high_water_bytes_ = 0;
+        clock_ = 0;
+        enabled_ = false;
+        fixed_budget_override_ = false;
+        adaptive_budget_initialized_ = false;
+    }
+
+    void observeAllocatorPressureForTest(int64_t retries, int64_t free_bytes, int64_t total_bytes)
+    {
+        TORCH_CHECK(!fixed_budget_override_,
+                    "allocator-pressure simulation requires the production adaptive pool");
+        TORCH_CHECK(retries >= 0 && free_bytes >= 0 && total_bytes >= 0,
+                    "allocator-pressure simulation values must be nonnegative");
+        updateBudgetForAllocatorPressure(
+            retries, static_cast<size_t>(free_bytes), static_cast<size_t>(total_bytes));
+    }
+
+    std::vector<int64_t> stateForTest() const
+    {
+        size_t checked_out = 0;
+        for (const auto& entry : entries_) { checked_out += entry.checked_out ? 1 : 0; }
+        return {static_cast<int64_t>(budget_bytes_),
+                static_cast<int64_t>(charged_bytes_),
+                static_cast<int64_t>(high_water_bytes_),
+                static_cast<int64_t>(entries_.size()),
+                static_cast<int64_t>(checked_out),
+                baseline_retries_.value_or(-1),
+                enabled_ ? 1 : 0,
+                adaptive_budget_initialized_ ? 1 : 0,
+                idle_pressure_score_,
+                pressure_recovery_complete_ ? 1 : 0,
+                static_cast<int64_t>(pressure_recovery_budget_bytes_),
+                static_cast<int64_t>(recoveryPendingEntries()),
+                pressure_recovery_in_progress_ ? 1 : 0};
+    }
+
+private:
+    struct Entry {
+        at::Tensor buffer;
+        std::shared_ptr<at::cuda::CUDAEvent> ready_event;
+        bool checked_out;
+        uint64_t last_use;
+        size_t capacity_bytes;
+    };
+
+    struct RecoveryTarget {
+        size_t capacity_bytes;
+        at::ScalarType dtype;
+        c10::Device device;
+        uint64_t last_use;
+    };
+
+    static bool matchesRecoveryTarget(const Entry& entry, const RecoveryTarget& target)
+    {
+        return entry.capacity_bytes == target.capacity_bytes &&
+               entry.buffer.scalar_type() == target.dtype && entry.buffer.device() == target.device;
+    }
+
+    bool hasRecoveryAdmissionSlot(size_t capacity_bytes,
+                                  at::ScalarType dtype,
+                                  const c10::Device& device) const
+    {
+        const size_t target_count =
+            std::count_if(pressure_recovery_targets_.begin(),
+                          pressure_recovery_targets_.end(),
+                          [&](const RecoveryTarget& target) {
+                              return capacity_bytes == target.capacity_bytes &&
+                                     dtype == target.dtype && device == target.device;
+                          });
+        const size_t resident_count =
+            std::count_if(entries_.begin(), entries_.end(), [&](const Entry& entry) {
+                return entry.capacity_bytes == capacity_bytes &&
+                       entry.buffer.scalar_type() == dtype && entry.buffer.device() == device;
+            });
+        return resident_count < target_count;
+    }
+
+    size_t recoveryPendingEntries() const
+    {
+        std::vector<bool> matched(pressure_recovery_targets_.size(), false);
+        size_t resident_targets = 0;
+        for (const auto& entry : entries_) {
+            for (size_t i = 0; i < pressure_recovery_targets_.size(); ++i) {
+                if (!matched[i] && matchesRecoveryTarget(entry, pressure_recovery_targets_[i])) {
+                    matched[i] = true;
+                    ++resident_targets;
+                    break;
+                }
+            }
+        }
+        return pressure_recovery_targets_.size() - resident_targets;
+    }
+
+    static c10::StorageImpl* storageImpl(const Entry& entry)
+    {
+        return entry.buffer.storage().unsafeGetStorageImpl();
+    }
+
+    static bool recoveryTargetPriority(const RecoveryTarget& lhs, const RecoveryTarget& rhs)
+    {
+        if (lhs.capacity_bytes != rhs.capacity_bytes) {
+            return lhs.capacity_bytes > rhs.capacity_bytes;
+        }
+        return lhs.last_use > rhs.last_use;
+    }
+
+    void boundRecoveryTargets(size_t hard_cap)
+    {
+        std::stable_sort(pressure_recovery_targets_.begin(),
+                         pressure_recovery_targets_.end(),
+                         recoveryTargetPriority);
+        std::vector<RecoveryTarget> bounded_targets;
+        bounded_targets.reserve(pressure_recovery_targets_.size());
+        size_t bounded_bytes = 0;
+        for (const auto& target : pressure_recovery_targets_) {
+            if (target.capacity_bytes > hard_cap - bounded_bytes) { continue; }
+            bounded_targets.push_back(target);
+            bounded_bytes += target.capacity_bytes;
+        }
+        pressure_recovery_targets_ = std::move(bounded_targets);
+        pressure_recovery_budget_bytes_ = bounded_bytes;
+    }
+
+    void dropRecoveryTarget(const Entry& entry)
+    {
+        auto target = std::find_if(pressure_recovery_targets_.begin(),
+                                   pressure_recovery_targets_.end(),
+                                   [&](const RecoveryTarget& candidate) {
+                                       return candidate.last_use == entry.last_use &&
+                                              matchesRecoveryTarget(entry, candidate);
+                                   });
+        if (target == pressure_recovery_targets_.end()) { return; }
+        pressure_recovery_budget_bytes_ -= target->capacity_bytes;
+        pressure_recovery_targets_.erase(target);
+        budget_bytes_ = std::min(budget_bytes_, pressure_recovery_budget_bytes_);
+        enabled_ = budget_bytes_ > 0;
+    }
+
+    ReleaseDisposition retireEntry(std::vector<Entry>::iterator entry,
+                                   c10::StorageImpl* storage_impl,
+                                   const char* event,
+                                   bool keep_recovery_target)
+    {
+        // The final consumer stream was recorded before this method. Resize
+        // must succeed before pool accounting forgets the live storage.
+        at::native::resize_bytes_cuda(storage_impl, 0);
+        if (pressure_recovery_in_progress_ && !keep_recovery_target) { dropRecoveryTarget(*entry); }
+        charged_bytes_ -= entry->capacity_bytes;
+        entries_.erase(entry);
+        if (pressure_recovery_in_progress_ && entries_.empty()) {
+            completePressureRecovery();
+        } else {
+            logState(event);
+        }
+        return ReleaseDisposition::NoResizeNeeded;
+    }
+
+    bool removeEntryOwnership(c10::StorageImpl* storage_impl,
+                              const char* event,
+                              bool keep_recovery_target)
+    {
+        for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+            if (storageImpl(*it) != storage_impl) { continue; }
+            if (pressure_recovery_in_progress_ && !keep_recovery_target) {
+                dropRecoveryTarget(*it);
+            }
+            charged_bytes_ -= it->capacity_bytes;
+            entries_.erase(it);
+            if (pressure_recovery_in_progress_ && entries_.empty()) {
+                completePressureRecovery();
+            } else {
+                logState(event);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    void observeAllocatorPressure(c10::DeviceIndex device)
+    {
+        if (fixed_budget_override_) { return; }
+
+        const auto stats = c10::cuda::CUDACachingAllocator::getDeviceStats(device);
+        size_t free_bytes = 0;
+        size_t total_bytes = 0;
+        if (baseline_retries_ && stats.num_alloc_retries > baseline_retries_.value()) {
+            C10_CUDA_CHECK(cudaMemGetInfo(&free_bytes, &total_bytes));
+        }
+        updateBudgetForAllocatorPressure(stats.num_alloc_retries, free_bytes, total_bytes);
+    }
+
+    void updateBudgetForAllocatorPressure(int64_t retries, size_t free_bytes, size_t total_bytes)
+    {
+        if (!baseline_retries_) {
+            baseline_retries_ = retries;
+            idle_pressure_score_ = 0;
+            return;
+        }
+        if (retries < baseline_retries_.value()) {
+            baseline_retries_ = retries;
+            idle_pressure_score_ = 0;
+            return;
+        }
+        if (retries == baseline_retries_.value()) { return; }
+        const int64_t retry_delta = retries - baseline_retries_.value();
+        baseline_retries_ = retries;
+
+        constexpr size_t granularity = 2 * 1024 * 1024;
+        // Bound prefetch-expanded overlap while preserving headroom for large
+        // non-gather allocations in the compiled graph. Allocator retries are
+        // also the signal that idle cached gathers may need to yield memory.
+        // Keep the byte-exact working set on isolated retries. On the first
+        // sustained-pressure wave, stop new retention, release idle entries,
+        // and retire checked-out entries as their final consumers return. Keep
+        // a byte-exact, typed recovery plan, preserving the complete hot set
+        // when it fits the hard cap. The lifecycle latch prevents later waves
+        // from draining it again and recreating per-step churn.
+        size_t hard_cap = total_bytes / 32;
+        hard_cap -= hard_cap % granularity;
+        size_t free_target = free_bytes / 4;
+        free_target -= free_target % granularity;
+        const size_t observed_budget = std::min(hard_cap, std::max(free_target, charged_bytes_));
+        budget_bytes_ = adaptive_budget_initialized_ ? std::min(budget_bytes_, observed_budget)
+                                                     : observed_budget;
+        if (pressure_recovery_in_progress_ || pressure_recovery_complete_) {
+            boundRecoveryTargets(hard_cap);
+            budget_bytes_ = std::max(budget_bytes_, pressure_recovery_budget_bytes_);
+        }
+        adaptive_budget_initialized_ = true;
+        enabled_ = budget_bytes_ > 0;
+        idle_pressure_score_ =
+            retry_delta > std::numeric_limits<int64_t>::max() - idle_pressure_score_
+                ? std::numeric_limits<int64_t>::max()
+                : idle_pressure_score_ + retry_delta;
+        if (pressure_recovery_in_progress_) {
+            idle_pressure_score_ = 0;
+        } else if (!pressure_recovery_complete_ &&
+                   idle_pressure_score_ >= kIdlePressureEvictionThreshold &&
+                   beginPressureRecovery(hard_cap)) {
+            return;
+        } else {
+            const size_t charged_before_hard_cap = charged_bytes_;
+            makeRoom(0);
+            if (charged_bytes_ < charged_before_hard_cap) { idle_pressure_score_ = 0; }
+        }
+        logState(enabled_ ? "pressure" : "disabled");
+    }
+
+    bool beginPressureRecovery(size_t hard_cap)
+    {
+        if (entries_.empty()) { return false; }
+
+        std::vector<RecoveryTarget> recovery_targets;
+        recovery_targets.reserve(entries_.size());
+        for (const auto& entry : entries_) {
+            recovery_targets.push_back(RecoveryTarget{entry.capacity_bytes,
+                                                      entry.buffer.scalar_type(),
+                                                      entry.buffer.device(),
+                                                      entry.last_use});
+        }
+        pressure_recovery_targets_ = std::move(recovery_targets);
+        boundRecoveryTargets(hard_cap);
+
+        for (auto it = entries_.begin(); it != entries_.end();) {
+            if (it->checked_out) {
+                ++it;
+                continue;
+            }
+            // Relinquish the pool's active ownership before flushing free
+            // blocks. Later gathers can still reuse allocator-cached storage.
+            auto victim_storage = it->buffer.storage();
+            at::native::resize_bytes_cuda(victim_storage.unsafeGetStorageImpl(), 0);
+            if (non_retainable_storages_.erase(victim_storage.unsafeGetStorageImpl()) > 0) {
+                dropRecoveryTarget(*it);
+            }
+            charged_bytes_ -= it->capacity_bytes;
+            it = entries_.erase(it);
+        }
+
+        idle_pressure_score_ = 0;
+        budget_bytes_ = pressure_recovery_budget_bytes_;
+        enabled_ = budget_bytes_ > 0;
+        pressure_recovery_in_progress_ = !entries_.empty();
+        pressure_recovery_complete_ = false;
+        if (entries_.empty()) {
+            completePressureRecovery();
+        } else {
+            logState("recovering_pressure");
+        }
+        return true;
+    }
+
+    void completePressureRecovery()
+    {
+        pressure_recovery_in_progress_ = false;
+        pressure_recovery_complete_ = true;
+        pressure_recovery_flush_pending_ = true;
+        idle_pressure_score_ = 0;
+        budget_bytes_ = pressure_recovery_budget_bytes_;
+        enabled_ = budget_bytes_ > 0;
+        logState("recovered_pressure");
+    }
+
+    void flushCompletedPressureRecovery()
+    {
+        if (!pressure_recovery_flush_pending_) { return; }
+        c10::cuda::CUDACachingAllocator::emptyCache();
+        pressure_recovery_flush_pending_ = false;
+        logState("flushed_recovered_pressure");
+    }
+
+    bool makeRoom(size_t capacity_bytes)
+    {
+        while (charged_bytes_ + capacity_bytes > budget_bytes_) {
+            auto victim = entries_.end();
+            for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+                if (it->checked_out) { continue; }
+                if (victim == entries_.end() || it->last_use < victim->last_use) { victim = it; }
+            }
+            if (victim == entries_.end()) { return false; }
+
+            auto victim_storage = victim->buffer.storage();
+            at::native::resize_bytes_cuda(victim_storage.unsafeGetStorageImpl(), 0);
+            charged_bytes_ -= victim->capacity_bytes;
+            entries_.erase(victim);
+        }
+        return true;
+    }
+
+    void logState(const char* event) const
+    {
+        if (!diagnosticEnvEnabled("DEEPSPEED_ALLOCATOR_TELEMETRY")) { return; }
+        size_t checked_out = 0;
+        for (const auto& entry : entries_) { checked_out += entry.checked_out ? 1 : 0; }
+        std::cout << "DEEPSPEED_Z3_GATHER_BUFFER_POOL event=" << event
+                  << " budget_bytes=" << budget_bytes_ << " charged_bytes=" << charged_bytes_
+                  << " high_water_bytes=" << high_water_bytes_ << " entries=" << entries_.size()
+                  << " checked_out=" << checked_out
+                  << " idle_pressure_score=" << idle_pressure_score_
+                  << " pressure_recovery_in_progress=" << (pressure_recovery_in_progress_ ? 1 : 0)
+                  << " pressure_recovery_complete=" << (pressure_recovery_complete_ ? 1 : 0)
+                  << " pressure_recovery_budget_bytes=" << pressure_recovery_budget_bytes_
+                  << " pressure_recovery_pending_entries=" << recoveryPendingEntries() << std::endl;
+    }
+
+    static constexpr int64_t kIdlePressureEvictionThreshold = 3;
+    std::vector<Entry> entries_;
+    std::unordered_set<c10::StorageImpl*> non_retainable_storages_;
+    std::optional<int64_t> baseline_retries_;
+    int64_t idle_pressure_score_ = 0;
+    bool pressure_recovery_in_progress_ = false;
+    bool pressure_recovery_complete_ = false;
+    bool pressure_recovery_flush_pending_ = false;
+    size_t pressure_recovery_budget_bytes_ = 0;
+    std::vector<RecoveryTarget> pressure_recovery_targets_;
+    size_t budget_bytes_ = 0;
+    size_t charged_bytes_ = 0;
+    size_t high_water_bytes_ = 0;
+    uint64_t clock_ = 0;
+    bool enabled_ = false;
+    bool fixed_budget_override_ = false;
+    bool adaptive_budget_initialized_ = false;
+};
+
+class AdmissionExclusionRollback {
+public:
+    explicit AdmissionExclusionRollback(std::shared_ptr<GatherBufferPool> pool)
+        : pool_(std::move(pool))
+    {
+    }
+
+    AdmissionExclusionRollback(const AdmissionExclusionRollback&) = delete;
+    AdmissionExclusionRollback& operator=(const AdmissionExclusionRollback&) = delete;
+
+    ~AdmissionExclusionRollback() noexcept
+    {
+        if (committed_) { return; }
+        for (const auto& buffer : buffers_) {
+            try {
+                pool_->cancelAdmissionExclusion(buffer);
+            } catch (...) {
+                // Destructors must not replace the original prefetch exception.
+            }
+        }
+    }
+
+    void exclude(const at::Tensor& buffer)
+    {
+        // Retain the Tensor before installing its raw StorageImpl identity so
+        // allocation/event exceptions cannot leave an ABA-prone dangling key.
+        buffers_.push_back(buffer);
+        pool_->excludeFromAdmission(buffers_.back());
+    }
+
+    void commit()
+    {
+        committed_ = true;
+        buffers_.clear();
+    }
+
+private:
+    std::shared_ptr<GatherBufferPool> pool_;
+    std::vector<at::Tensor> buffers_;
+    bool committed_ = false;
+};
+
+std::weak_ptr<GatherBufferPool> weak_gather_buffer_pool;
+std::optional<int64_t> gather_buffer_pool_fixed_budget_for_test;
+
+std::shared_ptr<GatherBufferPool> get_gather_buffer_pool()
+{
+    auto pool = weak_gather_buffer_pool.lock();
+    if (!pool) {
+        pool = std::make_shared<GatherBufferPool>();
+        weak_gather_buffer_pool = pool;
+        if (gather_buffer_pool_fixed_budget_for_test) {
+            pool->setFixedBudgetForTest(gather_buffer_pool_fixed_budget_for_test.value());
+        }
+    }
+    return pool;
+}
+
+}  // namespace
+
+void set_z3_gather_buffer_pool_fixed_budget_for_test(int64_t fixed_budget_bytes)
+{
+    gather_buffer_pool_fixed_budget_for_test = fixed_budget_bytes;
+    if (auto pool = weak_gather_buffer_pool.lock()) {
+        pool->setFixedBudgetForTest(fixed_budget_bytes);
+    }
+}
+
+void update_z3_gather_buffer_pool_allocator_pressure_for_test(int64_t retries,
+                                                              int64_t free_bytes,
+                                                              int64_t total_bytes)
+{
+    get_gather_buffer_pool()->observeAllocatorPressureForTest(retries, free_bytes, total_bytes);
+}
+
+std::vector<int64_t> get_z3_gather_buffer_pool_state_for_test()
+{
+    return get_gather_buffer_pool()->stateForTest();
+}
+
+void reset_z3_gather_buffer_pool()
+{
+    if (auto pool = weak_gather_buffer_pool.lock()) { pool->reset(); }
+    weak_gather_buffer_pool.reset();
+    gather_buffer_pool_fixed_budget_for_test.reset();
+}
 
 class Z3CustomOpExecutor : public CustomOpExecutor {
 public:
     Z3CustomOpExecutor(c10::intrusive_ptr<c10d::ProcessGroup> process_group,
                        std::shared_ptr<DSParamRegistry> param_registry,
                        std::shared_ptr<DoubleBufferedReduceBucket> reduce_buckets,
+                       std::shared_ptr<GatherBufferPool> gather_buffer_pool,
                        std::vector<long> ds_ids,
                        ncclComm_t nccl_comm,
                        at::cuda::CUDAStream ag_stream,
@@ -33,6 +659,7 @@ public:
                            rs_stream,
                            copy_stream,
                            pre_div_reduce),
+          gather_buffer_pool_(gather_buffer_pool),
           ag_stream_(ag_stream),
           offload_stream_(offload_stream),
           reload_stream_(reload_stream)
@@ -146,8 +773,12 @@ public:
             if (existing.defined() && existing.numel() == padded_numel) { output_buf = existing; }
         }
         if (!output_buf.defined()) {
-            at::cuda::CUDAStreamGuard guard(ag_stream_);
-            output_buf = torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
+            output_buf = gather_buffer_pool_->acquire(
+                padded_numel, target_dtype, ds_tensor.device(), ag_stream_);
+            if (!output_buf.defined()) {
+                at::cuda::CUDAStreamGuard guard(ag_stream_);
+                output_buf = torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
+            }
         }
 
         assert(hasKey(ag_comp_done_events_, ds_id));
@@ -176,6 +807,7 @@ public:
         }
 
         std::unordered_map<long, at::Tensor> output_bufs;
+        AdmissionExclusionRollback admission_exclusions(gather_buffer_pool_);
         for (const auto& [ds_id, dtype] : invalid_params) {
             const DSParam& param = param_registry_->getParam(ds_id);
             const at::Tensor& ds_tensor = param.getDSTensor();
@@ -187,13 +819,18 @@ public:
                 auto existing = param_registry_->getGatheredParam(ds_id);
                 if (existing.defined() && existing.numel() == padded_numel) {
                     output_bufs[ds_id] = existing;
-                    continue;
                 }
             }
-            auto target_dtype = dtype ? dtype.value() : ds_tensor.scalar_type();
-            at::cuda::CUDAStreamGuard guard(ag_stream_);
-            output_bufs[ds_id] =
-                torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
+            if (!hasKey(output_bufs, ds_id)) {
+                auto target_dtype = dtype ? dtype.value() : ds_tensor.scalar_type();
+                at::cuda::CUDAStreamGuard guard(ag_stream_);
+                output_bufs[ds_id] =
+                    torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
+            }
+            // Prefetch lifetimes are already controlled by the memory-aware scheduler.
+            // Bind the exclusion to the selected storage so a stale ds_id generation
+            // cannot admit a different demand-gather buffer into the independent pool.
+            admission_exclusions.exclude(output_bufs.at(ds_id));
         }
 
         for (const auto& [ds_id, _] : invalid_params) {
@@ -211,6 +848,7 @@ public:
         for (const auto& [ds_id, _] : invalid_params) {
             ag_comm_done_events_[ds_id]->record(ag_stream_);
         }
+        admission_exclusions.commit();
     }
 
     void releaseParam(long ds_id, long n_users)
@@ -227,10 +865,14 @@ public:
             if (gathered_param.defined()) {  // gathered param is undefined while profiling
                 auto storage = gathered_param.storage();
                 if (storage.nbytes() > 0) {
-                    // Required so the caching allocator defers reuse for consumer-stream kernels
-                    // queued behind wait_allgather.
-                    gathered_param.record_stream(at::cuda::getCurrentCUDAStream());
-                    at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
+                    // Demand gathers may enter the byte-bounded pool. Prefetched gathers
+                    // keep the scheduler's ownership boundary and use the original
+                    // resize-to-zero path after their final consumer.
+                    const auto release_disposition = gather_buffer_pool_->release(gathered_param);
+                    if (release_disposition ==
+                        GatherBufferPool::ReleaseDisposition::ResizeByCaller) {
+                        at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
+                    }
                 }
 
                 const auto options = gathered_param.options();
@@ -421,6 +1063,7 @@ public:
     bool hasParam(long ds_id) const { return hasKey(has_acc_grad_, ds_id); }
 
 private:
+    std::shared_ptr<GatherBufferPool> gather_buffer_pool_;
     at::cuda::CUDAStream ag_stream_;
     at::cuda::CUDAStream offload_stream_;
     at::cuda::CUDAStream reload_stream_;
@@ -476,6 +1119,7 @@ void register_graph_z3(long graph_id, const std::vector<long>& ds_ids)
     executors[graph_id] = std::make_shared<Z3CustomOpExecutor>(process_group,
                                                                param_registry,
                                                                reduce_buckets,
+                                                               get_gather_buffer_pool(),
                                                                ds_ids,
                                                                nccl_comm,
                                                                get_ag_stream(),
@@ -554,13 +1198,22 @@ void set_persistent(long ds_id)
 
     // Allocate buffer here
     // Memory fragmentation will be more severe if we allocate in forward/backward
+    auto gather_buffer_pool = get_gather_buffer_pool();
+    bool gathered = false;
     for (auto& it : executors) {
         if (it.second->hasParam(ds_id)) {
             auto executor = getExecutor<Z3CustomOpExecutor>(it.first, executors);
             auto dtype = param_registry->getParam(ds_id).getDtype();
             executor->allgatherParam(ds_id, dtype, symm_mem);
+            gathered = true;
         }
     }
+    // Selective unsharding owns persistent storage for the remainder of the
+    // compiled lifecycle. If the initial gather reused a demand-pool entry,
+    // transfer that storage out of pool accounting without freeing it so
+    // pressure recovery cannot wait forever for a release that persistent
+    // parameters intentionally never issue.
+    if (gathered) { gather_buffer_pool->discard(param_registry->getGatheredParam(ds_id)); }
 }
 
 void prefetch_params_fused(long graph_id,
@@ -585,17 +1238,22 @@ void invalidate_gathered_param(long ds_id)
     const DSParam& param = param_registry->getParam(ds_id);
     if (param.isPersistent()) { return; }
 
+    auto gathered_param = param_registry->getGatheredParam(ds_id);
+    get_gather_buffer_pool()->discard(gathered_param);
     param_registry->unregisterGatheredParam(ds_id);
     param_registry->registerGatheredParam(ds_id, at::Tensor());
 }
 
 void clear_all_gathered_params()
 {
+    auto gather_buffer_pool = get_gather_buffer_pool();
     for (const auto& it : param_registry->getParams()) {
         long ds_id = it.first;
         const DSParam& param = param_registry->getParam(ds_id);
         if (param.isPersistent()) { continue; }
         if (param_registry->hasGatheredParam(ds_id)) {
+            auto gathered_param = param_registry->getGatheredParam(ds_id);
+            gather_buffer_pool->discard(gathered_param);
             param_registry->unregisterGatheredParam(ds_id);
         }
     }

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -48,6 +48,7 @@ public:
                        const c10::Device& device,
                        at::cuda::CUDAStream stream)
     {
+        if (arena_transition_started_) { return at::Tensor(); }
         flushCompletedPressureRecovery();
         observeAllocatorPressure(device.index());
         if (!enabled_ || pressure_recovery_in_progress_) { return at::Tensor(); }
@@ -120,6 +121,9 @@ public:
         for (auto it = entries_.begin(); it != entries_.end(); ++it) {
             if (storageImpl(*it) != storage_impl) { continue; }
             if (excluded) { return retireEntry(it, storage_impl, "excluded", false); }
+            if (arena_transition_started_) {
+                return retireEntry(it, storage_impl, "arena_transition_release", false);
+            }
             if (pressure_recovery_in_progress_) {
                 return retireEntry(it, storage_impl, "recovery_release", true);
             }
@@ -134,7 +138,7 @@ public:
             return ReleaseDisposition::NoResizeNeeded;
         }
 
-        if (excluded || !enabled_ || pressure_recovery_in_progress_) {
+        if (excluded || arena_transition_started_ || !enabled_ || pressure_recovery_in_progress_) {
             return ReleaseDisposition::ResizeByCaller;
         }
 
@@ -194,6 +198,79 @@ public:
         enabled_ = false;
         fixed_budget_override_ = false;
         adaptive_budget_initialized_ = false;
+        arena_transition_started_ = false;
+        arena_transition_flush_complete_ = false;
+    }
+
+    bool prepareForArenaTransition()
+    {
+        if (!arena_transition_started_) {
+            // Once the optimized prefetch session has both phase plans, the
+            // independent gather pool is no longer part of that execution
+            // mode. Relinquish idle storages immediately and make checked-out
+            // storages retire on their final release. This keeps the old pool
+            // and the fixed arena from becoming two simultaneous budgets.
+            arena_transition_started_ = true;
+            enabled_ = false;
+            budget_bytes_ = 0;
+            pressure_recovery_in_progress_ = false;
+            pressure_recovery_complete_ = false;
+            pressure_recovery_flush_pending_ = false;
+            pressure_recovery_budget_bytes_ = 0;
+            pressure_recovery_targets_.clear();
+
+            for (auto it = entries_.begin(); it != entries_.end();) {
+                if (it->checked_out) {
+                    ++it;
+                    continue;
+                }
+                auto storage = it->buffer.storage();
+                non_retainable_storages_.erase(storage.unsafeGetStorageImpl());
+                at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
+                charged_bytes_ -= it->capacity_bytes;
+                it = entries_.erase(it);
+            }
+            logState(entries_.empty() ? "arena_transition_drained" : "arena_transition_waiting");
+        }
+
+        return entries_.empty();
+    }
+
+    void flushForArenaTransition()
+    {
+        TORCH_CHECK(arena_transition_started_,
+                    "gather-buffer-pool flush requested before arena transition");
+        TORCH_CHECK(entries_.empty(),
+                    "gather-buffer-pool flush requested with live entries: ",
+                    entries_.size());
+        if (!arena_transition_flush_complete_) {
+            // Resizing releases pool ownership, but the CUDA allocator may
+            // still retain those blocks. Flush exactly once before requesting
+            // the single contiguous arena backing.
+            c10::cuda::CUDACachingAllocator::emptyCache();
+            arena_transition_flush_complete_ = true;
+            logState("arena_transition_flushed");
+        }
+    }
+
+    int64_t reclaimableBytes() const
+    {
+        size_t reclaimable_bytes = 0;
+        for (const auto& entry : entries_) {
+            if (!entry.checked_out && entry.ready_event) {
+                reclaimable_bytes += entry.capacity_bytes;
+            }
+        }
+        return static_cast<int64_t>(reclaimable_bytes);
+    }
+
+    int64_t transitionReclaimableBytes() const
+    {
+        // Arena transition disables further pool reuse, drains idle entries,
+        // and waits for checked-out entries to retire on final release before
+        // allocating the arena. Unlike reclaimableBytes(), every pool-owned
+        // charge is therefore guaranteed to leave allocated memory first.
+        return static_cast<int64_t>(charged_bytes_);
     }
 
     void observeAllocatorPressureForTest(int64_t retries, int64_t free_bytes, int64_t total_bytes)
@@ -222,7 +299,9 @@ public:
                 pressure_recovery_complete_ ? 1 : 0,
                 static_cast<int64_t>(pressure_recovery_budget_bytes_),
                 static_cast<int64_t>(recoveryPendingEntries()),
-                pressure_recovery_in_progress_ ? 1 : 0};
+                pressure_recovery_in_progress_ ? 1 : 0,
+                arena_transition_started_ ? 1 : 0,
+                arena_transition_flush_complete_ ? 1 : 0};
     }
 
 private:
@@ -531,7 +610,10 @@ private:
                   << " pressure_recovery_in_progress=" << (pressure_recovery_in_progress_ ? 1 : 0)
                   << " pressure_recovery_complete=" << (pressure_recovery_complete_ ? 1 : 0)
                   << " pressure_recovery_budget_bytes=" << pressure_recovery_budget_bytes_
-                  << " pressure_recovery_pending_entries=" << recoveryPendingEntries() << std::endl;
+                  << " pressure_recovery_pending_entries=" << recoveryPendingEntries()
+                  << " arena_transition_started=" << (arena_transition_started_ ? 1 : 0)
+                  << " arena_transition_flush_complete="
+                  << (arena_transition_flush_complete_ ? 1 : 0) << std::endl;
     }
 
     static constexpr int64_t kIdlePressureEvictionThreshold = 3;
@@ -551,6 +633,8 @@ private:
     bool enabled_ = false;
     bool fixed_budget_override_ = false;
     bool adaptive_budget_initialized_ = false;
+    bool arena_transition_started_ = false;
+    bool arena_transition_flush_complete_ = false;
 };
 
 class AdmissionExclusionRollback {
@@ -731,7 +815,8 @@ public:
         logState("session_disable_pending_consensus");
     }
 
-    void ensureRankConsistent(ncclComm_t nccl_comm)
+    void ensureRankConsistent(ncclComm_t nccl_comm,
+                              const std::shared_ptr<GatherBufferPool>& gather_buffer_pool)
     {
         if (rank_consistency_checked_) { return; }
 
@@ -789,6 +874,40 @@ public:
             }
             return;
         }
+
+        // Admission is a session decision, so every rank must finish retiring
+        // the old gather pool before any rank allocates the shared arena. A
+        // rank with an outstanding old-pool lease makes this fused prefetch use
+        // the normal allocation path; the next fused prefetch retries after
+        // release. The collective keeps rank control flow aligned.
+        at::Tensor transition_ready;
+        {
+            at::cuda::CUDAStreamGuard guard(ag_stream_);
+            transition_ready =
+                torch::tensor({gather_buffer_pool->prepareForArenaTransition() ? 1 : 0},
+                              at::TensorOptions().dtype(at::kLong))
+                    .to(at::TensorOptions().dtype(at::kLong).device(at::kCUDA));
+            const auto transition_result = ncclAllReduce(transition_ready.data_ptr(),
+                                                         transition_ready.data_ptr(),
+                                                         transition_ready.numel(),
+                                                         ncclInt64,
+                                                         ncclMin,
+                                                         nccl_comm,
+                                                         ag_stream_);
+            TORCH_CHECK(transition_result == ncclSuccess,
+                        "prefetch arena pool-transition reduction failed: ",
+                        ncclGetErrorString(transition_result));
+        }
+        at::cuda::stream_synchronize(ag_stream_);
+        if (transition_ready.cpu().item<int64_t>() == 0) {
+            enabled_ = false;
+            logState("pool_transition_pending");
+            return;
+        }
+        // Flush only after every rank has drained its pool. Otherwise an early
+        // rank could flush, fall back while another rank still owns a lease,
+        // then allocate unrelated cache before the eventual arena attempt.
+        gather_buffer_pool->flushForArenaTransition();
 
         std::vector<long> phase_ids;
         phase_ids.reserve(phases_.size());
@@ -1350,6 +1469,18 @@ std::vector<int64_t> get_z3_gather_buffer_pool_state_for_test()
     return get_gather_buffer_pool()->stateForTest();
 }
 
+int64_t get_z3_gather_buffer_pool_reclaimable_bytes()
+{
+    if (auto pool = weak_gather_buffer_pool.lock()) { return pool->reclaimableBytes(); }
+    return 0;
+}
+
+int64_t get_z3_gather_buffer_pool_transition_reclaimable_bytes()
+{
+    if (auto pool = weak_gather_buffer_pool.lock()) { return pool->transitionReclaimableBytes(); }
+    return 0;
+}
+
 void reset_z3_gather_buffer_pool()
 {
     if (auto pool = weak_gather_buffer_pool.lock()) { pool->reset(); }
@@ -1565,7 +1696,7 @@ public:
         // asynchronous per-rank compilation, so it must never enter this
         // collective.
         if (diagnosticEnvEnabled("DEEPSPEED_COMPILE_PREFETCH_ARENA") && !profile) {
-            prefetch_arena_->ensureRankConsistent(nccl_comm_);
+            prefetch_arena_->ensureRankConsistent(nccl_comm_, gather_buffer_pool_);
         }
 
         std::vector<std::tuple<long, std::optional<at::ScalarType>>> invalid_params;

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -10,10 +10,13 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <set>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -592,8 +595,626 @@ private:
     bool committed_ = false;
 };
 
+struct PrefetchArenaPlanKey {
+    long plan_id;
+    long ds_id;
+
+    bool operator==(const PrefetchArenaPlanKey& other) const
+    {
+        return plan_id == other.plan_id && ds_id == other.ds_id;
+    }
+};
+
+struct PrefetchArenaPlanKeyHash {
+    size_t operator()(const PrefetchArenaPlanKey& key) const
+    {
+        const auto lhs = std::hash<long>{}(key.plan_id);
+        const auto rhs = std::hash<long>{}(key.ds_id);
+        return lhs ^ (rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2));
+    }
+};
+
+class PrefetchArena {
+public:
+    enum class ReleaseDisposition { NoLease, ReleasedCurrentRegistry, ReleasedStaleRegistry };
+
+    PrefetchArena(long graph_id, uint64_t generation, int rank, at::cuda::CUDAStream ag_stream)
+        : graph_id_(graph_id), generation_(generation), rank_(rank), ag_stream_(ag_stream)
+    {
+    }
+
+    ~PrefetchArena() noexcept
+    {
+        try {
+            logState("destruction");
+        } catch (...) {
+        }
+    }
+
+    void configure(long phase,
+                   int64_t capacity_bytes,
+                   int64_t max_live_bytes,
+                   int64_t digest,
+                   const std::vector<long>& plan_ids,
+                   const std::vector<long>& ds_ids,
+                   const std::vector<int64_t>& offsets,
+                   const std::vector<int64_t>& request_bytes)
+    {
+        TORCH_CHECK(capacity_bytes > 0, "prefetch arena capacity must be positive");
+        TORCH_CHECK(max_live_bytes > 0 && max_live_bytes <= capacity_bytes,
+                    "prefetch arena max-live bytes must fit capacity");
+        TORCH_CHECK(plan_ids.size() == ds_ids.size() && plan_ids.size() == offsets.size() &&
+                        plan_ids.size() == request_bytes.size(),
+                    "prefetch arena plan vectors must have equal length");
+
+        auto existing = phases_.find(phase);
+        if (existing != phases_.end()) {
+            if (!sameConfiguration(existing->second,
+                                   capacity_bytes,
+                                   max_live_bytes,
+                                   digest,
+                                   plan_ids,
+                                   ds_ids,
+                                   offsets,
+                                   request_bytes)) {
+                existing->second.disabled = true;
+                rank_consistency_checked_ = false;
+                noteFallback("reconfigure_mismatch", capacity_bytes);
+                logState("reconfigure_mismatch");
+            } else {
+                logState("configure_idempotent");
+            }
+            return;
+        }
+
+        Phase configured;
+        configured.capacity_bytes = capacity_bytes;
+        configured.max_live_bytes = max_live_bytes;
+        configured.digest = digest;
+        for (size_t index = 0; index < plan_ids.size(); ++index) {
+            TORCH_CHECK(offsets[index] >= 0 && offsets[index] % kAlignment == 0,
+                        "prefetch arena slice offsets must be aligned");
+            TORCH_CHECK(request_bytes[index] > 0, "prefetch arena request bytes must be positive");
+            const int64_t span_bytes = alignUp(request_bytes[index]);
+            TORCH_CHECK(offsets[index] + span_bytes <= capacity_bytes,
+                        "prefetch arena slice exceeds backing capacity");
+            PrefetchArenaPlanKey key{plan_ids[index], ds_ids[index]};
+            SlicePlan plan{phase, offsets[index], request_bytes[index], span_bytes};
+            const auto [_, inserted] = configured.plans.emplace(key, plan);
+            TORCH_CHECK(inserted, "duplicate prefetch arena plan entry");
+            configured.ordered_entries.push_back(
+                {plan_ids[index], ds_ids[index], offsets[index], request_bytes[index]});
+        }
+
+        phases_.emplace(phase, std::move(configured));
+        // This method is called by the Python optimization pass while
+        // FakeTensorMode may be active.  Keep it metadata-only: allocating or
+        // inspecting a CUDA tensor here would either create a fake backing or
+        // attempt to read a FakeTensor data pointer.  The first native fused
+        // prefetch materializes the backing after rank consensus instead.
+        enabled_ = false;
+        rank_consistency_checked_ = false;
+        logState("plan_configured");
+    }
+
+    void ensureRankConsistent(ncclComm_t nccl_comm)
+    {
+        if (rank_consistency_checked_) { return; }
+
+        std::vector<long> phase_ids;
+        phase_ids.reserve(phases_.size());
+        for (const auto& [phase_id, _] : phases_) { phase_ids.push_back(phase_id); }
+        std::sort(phase_ids.begin(), phase_ids.end());
+
+        int64_t total_capacity = 0;
+        int64_t total_max_live = 0;
+        int64_t disabled_phases = 0;
+        uint64_t aggregate_digest = 1469598103934665603ULL;
+        const auto mix = [&aggregate_digest](uint64_t value) {
+            aggregate_digest ^= value;
+            aggregate_digest *= 1099511628211ULL;
+        };
+        for (long phase_id : phase_ids) {
+            const auto& phase = phases_.at(phase_id);
+            total_capacity += phase.capacity_bytes;
+            total_max_live += phase.max_live_bytes;
+            disabled_phases += phase.disabled ? 1 : 0;
+            mix(static_cast<uint64_t>(phase_id));
+            mix(static_cast<uint64_t>(phase.capacity_bytes));
+            mix(static_cast<uint64_t>(phase.max_live_bytes));
+            mix(static_cast<uint64_t>(phase.digest));
+            mix(static_cast<uint64_t>(phase.ordered_entries.size()));
+        }
+
+        const std::vector<int64_t> host_signature = {
+            static_cast<int64_t>(phases_.size()),
+            total_capacity,
+            total_max_live,
+            disabled_phases,
+            static_cast<int64_t>(aggregate_digest & std::numeric_limits<int64_t>::max()),
+        };
+        at::Tensor minimum;
+        at::Tensor maximum;
+        {
+            at::cuda::CUDAStreamGuard guard(ag_stream_);
+            auto local = torch::tensor(host_signature, at::TensorOptions().dtype(at::kLong))
+                             .to(at::TensorOptions().dtype(at::kLong).device(at::kCUDA));
+            minimum = local.clone();
+            maximum = local.clone();
+            const auto min_result = ncclAllReduce(minimum.data_ptr(),
+                                                  minimum.data_ptr(),
+                                                  minimum.numel(),
+                                                  ncclInt64,
+                                                  ncclMin,
+                                                  nccl_comm,
+                                                  ag_stream_);
+            TORCH_CHECK(min_result == ncclSuccess,
+                        "prefetch arena rank-consistency MIN reduction failed: ",
+                        ncclGetErrorString(min_result));
+            const auto max_result = ncclAllReduce(maximum.data_ptr(),
+                                                  maximum.data_ptr(),
+                                                  maximum.numel(),
+                                                  ncclInt64,
+                                                  ncclMax,
+                                                  nccl_comm,
+                                                  ag_stream_);
+            TORCH_CHECK(max_result == ncclSuccess,
+                        "prefetch arena rank-consistency MAX reduction failed: ",
+                        ncclGetErrorString(max_result));
+        }
+        at::cuda::stream_synchronize(ag_stream_);
+
+        rank_consistency_checks_++;
+        rank_consistency_checked_ = true;
+        if (!minimum.cpu().equal(maximum.cpu())) {
+            enabled_ = false;
+            rank_plan_mismatches_++;
+            for (auto& [_, phase] : phases_) { phase.disabled = true; }
+            noteFallback("rank_plan_mismatch", 0);
+            logState("rank_plan_mismatch");
+            return;
+        }
+
+        {
+            at::cuda::CUDAStreamGuard guard(ag_stream_);
+            int64_t shared_capacity_bytes = 0;
+            for (const auto& [_, phase] : phases_) {
+                shared_capacity_bytes = std::max(shared_capacity_bytes, phase.capacity_bytes);
+            }
+            if (!shared_backing_.defined()) {
+                shared_backing_ =
+                    torch::empty({shared_capacity_bytes},
+                                 at::TensorOptions().dtype(at::kByte).device(at::kCUDA));
+                shared_backing_pointer_ = reinterpret_cast<uintptr_t>(shared_backing_.data_ptr());
+                shared_storage_identity_ = shared_backing_.storage().unsafeGetStorageImpl();
+                shared_capacity_bytes_ = shared_capacity_bytes;
+                backing_allocation_count_++;
+            }
+            TORCH_CHECK(shared_capacity_bytes_ == shared_capacity_bytes,
+                        "prefetch arena shared backing capacity changed");
+            for (auto& [_, phase] : phases_) {
+                if (phase.backing.defined()) { continue; }
+                phase.backing = shared_backing_;
+                phase.backing_pointer = shared_backing_pointer_;
+                phase.storage_identity = shared_storage_identity_;
+                phase.backing_allocation_count = 1;
+            }
+        }
+        enabled_ = !phases_.empty();
+        logState("rank_plan_consistent");
+    }
+
+    at::Tensor acquire(long plan_id,
+                       long ds_id,
+                       int64_t numel,
+                       at::ScalarType dtype,
+                       const c10::Device& device)
+    {
+        const int64_t requested_bytes = numel * c10::elementSize(dtype);
+        request_bytes_ += requested_bytes;
+        if (!enabled_) {
+            noteFallback("not_configured", requested_bytes);
+            return at::Tensor();
+        }
+
+        const PrefetchArenaPlanKey key{plan_id, ds_id};
+        Phase* phase = nullptr;
+        const SlicePlan* plan = nullptr;
+        for (auto& [_, candidate] : phases_) {
+            auto it = candidate.plans.find(key);
+            if (it != candidate.plans.end()) {
+                phase = &candidate;
+                plan = &it->second;
+                break;
+            }
+        }
+        if (phase == nullptr || plan == nullptr) {
+            noteFallback("plan_miss", requested_bytes);
+            return at::Tensor();
+        }
+        if (phase->disabled) {
+            noteFallback("phase_disabled", requested_bytes);
+            return at::Tensor();
+        }
+        verifyBacking(*phase);
+        if (device.type() != c10::kCUDA || phase->backing.device() != device) {
+            noteFallback("device_mismatch", requested_bytes);
+            return at::Tensor();
+        }
+        // The scheduled size is a byte-capacity reservation, not an exact
+        // native-request shape.  A smaller typed request can safely use the
+        // same stable slice as long as it starts at a valid element boundary.
+        if (requested_bytes > plan->request_bytes) {
+            noteFallback("capacity_overflow", requested_bytes);
+            return at::Tensor();
+        }
+        if (plan->offset % c10::elementSize(dtype) != 0) {
+            noteFallback("dtype_alignment_mismatch", requested_bytes);
+            return at::Tensor();
+        }
+        if (hasKey(active_leases_, ds_id)) {
+            overlap_count_++;
+            TORCH_CHECK(false, "prefetch arena ds_id already has an active lease");
+        }
+        const auto lease_offset =
+            findAvailableOffset(phase->capacity_bytes, plan->offset, plan->span_bytes);
+        if (!lease_offset) {
+            noteFallback("runtime_capacity", requested_bytes);
+            return at::Tensor();
+        }
+        if (lease_offset.value() != plan->offset) {
+            // Inductor is free to move a side-effecting fused prefetch earlier
+            // than the FX node order used by the static lifetime planner.  If
+            // the preferred slice is consequently still live, keep the fixed
+            // backing allocation and place this lease in another free aligned
+            // slice.  Exhausting the arena is a normal per-request fallback,
+            // not a reason to corrupt an active slice or fail the graph.
+            relocation_count_++;
+        }
+
+        for (auto it = pending_fences_.begin(); it != pending_fences_.end();) {
+            if (overlaps(lease_offset.value(), plan->span_bytes, it->offset, it->span_bytes)) {
+                it->ready_event->block(ag_stream_);
+                event_wait_count_++;
+                it = pending_fences_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        if (ever_acquired_.count(lease_offset.value()) > 0) { reuse_bytes_ += requested_bytes; }
+        ever_acquired_.insert(lease_offset.value());
+        active_leases_.emplace(
+            ds_id,
+            Lease{
+                plan->phase, plan_id, lease_offset.value(), plan->request_bytes, plan->span_bytes});
+        active_bytes_ += plan->span_bytes;
+        high_water_bytes_ = std::max(high_water_bytes_, active_bytes_);
+        high_water_slices_ = std::max(high_water_slices_, active_leases_.size());
+
+        at::Tensor result = torch::empty({0}, at::TensorOptions().dtype(dtype).device(device));
+        result.set_(
+            phase->backing.storage(), lease_offset.value() / c10::elementSize(dtype), {numel}, {1});
+        return result;
+    }
+
+    ReleaseDisposition release(long ds_id, const at::Tensor& gathered_param)
+    {
+        auto lease_it = active_leases_.find(ds_id);
+        if (lease_it == active_leases_.end()) { return ReleaseDisposition::NoLease; }
+        auto phase_it = phases_.find(lease_it->second.phase);
+        TORCH_CHECK(phase_it != phases_.end(), "prefetch arena lease references a missing phase");
+        verifyBacking(phase_it->second);
+        const bool tensor_defined = gathered_param.defined();
+        const auto* actual_storage =
+            tensor_defined ? gathered_param.storage().unsafeGetStorageImpl() : nullptr;
+        const int64_t actual_offset =
+            tensor_defined ? gathered_param.storage_offset() * gathered_param.element_size() : -1;
+        const bool registry_matches_lease = tensor_defined &&
+                                            actual_storage == phase_it->second.storage_identity &&
+                                            actual_offset == lease_it->second.offset;
+        if (!registry_matches_lease) {
+            stale_registry_release_count_++;
+            if (diagnosticEnvEnabled("DEEPSPEED_COMPILE_PREFETCH_ARENA")) {
+                std::cout << "DEEPSPEED_Z3_PREFETCH_ARENA event=stale_registry_release"
+                          << " rank=" << rank_ << " generation=" << generation_
+                          << " graph_id=" << graph_id_ << " ds_id=" << ds_id
+                          << " lease_plan_id=" << lease_it->second.plan_id
+                          << " expected_storage_identity="
+                          << reinterpret_cast<uintptr_t>(phase_it->second.storage_identity)
+                          << " actual_storage_identity="
+                          << reinterpret_cast<uintptr_t>(actual_storage)
+                          << " expected_offset=" << lease_it->second.offset
+                          << " actual_offset=" << actual_offset << " actual_storage_bytes="
+                          << (tensor_defined ? gathered_param.storage().nbytes() : 0) << std::endl;
+            }
+        }
+
+        const auto consumer_stream = at::cuda::getCurrentCUDAStream();
+        phase_it->second.backing.record_stream(consumer_stream);
+        auto ready_event = std::make_shared<at::cuda::CUDAEvent>(cudaEventDisableTiming);
+        ready_event->record(consumer_stream);
+        pending_fences_.push_back({lease_it->second.phase,
+                                   lease_it->second.offset,
+                                   lease_it->second.span_bytes,
+                                   std::move(ready_event)});
+        active_bytes_ -= lease_it->second.span_bytes;
+        active_leases_.erase(lease_it);
+        return registry_matches_lease ? ReleaseDisposition::ReleasedCurrentRegistry
+                                      : ReleaseDisposition::ReleasedStaleRegistry;
+    }
+
+    void cancelAcquire(long ds_id)
+    {
+        auto lease_it = active_leases_.find(ds_id);
+        if (lease_it == active_leases_.end()) { return; }
+        auto phase_it = phases_.find(lease_it->second.phase);
+        TORCH_CHECK(phase_it != phases_.end(), "prefetch arena lease references a missing phase");
+        phase_it->second.backing.record_stream(ag_stream_);
+        auto ready_event = std::make_shared<at::cuda::CUDAEvent>(cudaEventDisableTiming);
+        ready_event->record(ag_stream_);
+        pending_fences_.push_back({lease_it->second.phase,
+                                   lease_it->second.offset,
+                                   lease_it->second.span_bytes,
+                                   std::move(ready_event)});
+        active_bytes_ -= lease_it->second.span_bytes;
+        active_leases_.erase(lease_it);
+    }
+
+    void recordFallback(const std::string& reason, int64_t bytes)
+    {
+        request_bytes_ += std::max<int64_t>(bytes, 0);
+        noteFallback(reason, bytes);
+    }
+
+    void prepareForReset()
+    {
+        logState("reset");
+        TORCH_CHECK(active_leases_.empty(),
+                    "prefetch arena reset attempted with active leases graph_id=",
+                    graph_id_,
+                    " active_leases=",
+                    active_leases_.size());
+    }
+
+    std::vector<int64_t> stateForTest() const
+    {
+        int64_t total_capacity = shared_capacity_bytes_;
+        int64_t planned_max_live = 0;
+        int64_t pointer_stable = 1;
+        for (const auto& [_, phase] : phases_) {
+            planned_max_live = std::max(planned_max_live, phase.max_live_bytes);
+            if (phase.backing.defined() &&
+                (reinterpret_cast<uintptr_t>(phase.backing.data_ptr()) != phase.backing_pointer ||
+                 phase.backing.storage().unsafeGetStorageImpl() != phase.storage_identity)) {
+                pointer_stable = 0;
+            }
+        }
+        return {enabled_ ? 1 : 0,
+                static_cast<int64_t>(phases_.size()),
+                total_capacity,
+                planned_max_live,
+                static_cast<int64_t>(backing_allocation_count_),
+                request_bytes_,
+                reuse_bytes_,
+                fallback_bytes_,
+                active_bytes_,
+                high_water_bytes_,
+                static_cast<int64_t>(active_leases_.size()),
+                static_cast<int64_t>(high_water_slices_),
+                static_cast<int64_t>(event_wait_count_),
+                static_cast<int64_t>(overlap_count_),
+                pointer_stable,
+                static_cast<int64_t>(rank_consistency_checks_),
+                static_cast<int64_t>(rank_plan_mismatches_),
+                static_cast<int64_t>(relocation_count_),
+                static_cast<int64_t>(stale_registry_release_count_)};
+    }
+
+private:
+    static constexpr int64_t kAlignment = 256;
+
+    struct SlicePlan {
+        long phase;
+        int64_t offset;
+        int64_t request_bytes;
+        int64_t span_bytes;
+    };
+
+    struct Phase {
+        at::Tensor backing;
+        int64_t capacity_bytes = 0;
+        int64_t max_live_bytes = 0;
+        int64_t digest = 0;
+        uintptr_t backing_pointer = 0;
+        c10::StorageImpl* storage_identity = nullptr;
+        size_t backing_allocation_count = 0;
+        bool disabled = false;
+        std::unordered_map<PrefetchArenaPlanKey, SlicePlan, PrefetchArenaPlanKeyHash> plans;
+        std::vector<std::array<int64_t, 4>> ordered_entries;
+    };
+
+    struct Lease {
+        long phase;
+        long plan_id;
+        int64_t offset;
+        int64_t request_bytes;
+        int64_t span_bytes;
+    };
+
+    struct Fence {
+        long phase;
+        int64_t offset;
+        int64_t span_bytes;
+        std::shared_ptr<at::cuda::CUDAEvent> ready_event;
+    };
+
+    static int64_t alignUp(int64_t value)
+    {
+        return ((value + kAlignment - 1) / kAlignment) * kAlignment;
+    }
+
+    static bool overlaps(int64_t lhs_offset, int64_t lhs_size, int64_t rhs_offset, int64_t rhs_size)
+    {
+        return lhs_offset < rhs_offset + rhs_size && rhs_offset < lhs_offset + lhs_size;
+    }
+
+    std::optional<int64_t> findAvailableOffset(int64_t capacity_bytes,
+                                               int64_t preferred_offset,
+                                               int64_t span_bytes) const
+    {
+        const auto available = [&](int64_t offset) {
+            if (offset < 0 || offset + span_bytes > capacity_bytes) { return false; }
+            for (const auto& [_, lease] : active_leases_) {
+                if (overlaps(offset, span_bytes, lease.offset, lease.span_bytes)) { return false; }
+            }
+            return true;
+        };
+        if (available(preferred_offset)) { return preferred_offset; }
+
+        std::vector<std::pair<int64_t, int64_t>> occupied;
+        for (const auto& [_, lease] : active_leases_) {
+            occupied.emplace_back(lease.offset, lease.span_bytes);
+        }
+        std::sort(occupied.begin(), occupied.end());
+        int64_t cursor = 0;
+        for (const auto& [offset, size] : occupied) {
+            if (cursor + span_bytes <= offset) { return cursor; }
+            cursor = std::max(cursor, offset + size);
+        }
+        if (cursor + span_bytes <= capacity_bytes) { return cursor; }
+        return std::nullopt;
+    }
+
+    static bool sameConfiguration(const Phase& phase,
+                                  int64_t capacity_bytes,
+                                  int64_t max_live_bytes,
+                                  int64_t digest,
+                                  const std::vector<long>& plan_ids,
+                                  const std::vector<long>& ds_ids,
+                                  const std::vector<int64_t>& offsets,
+                                  const std::vector<int64_t>& request_bytes)
+    {
+        if (phase.capacity_bytes != capacity_bytes || phase.max_live_bytes != max_live_bytes ||
+            phase.digest != digest || phase.ordered_entries.size() != plan_ids.size()) {
+            return false;
+        }
+        for (size_t index = 0; index < plan_ids.size(); ++index) {
+            if (phase.ordered_entries[index] !=
+                std::array<int64_t, 4>{
+                    plan_ids[index], ds_ids[index], offsets[index], request_bytes[index]}) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void verifyBacking(const Phase& phase) const
+    {
+        TORCH_CHECK(phase.backing.defined() &&
+                        phase.backing.storage().nbytes() == shared_capacity_bytes_ &&
+                        phase.capacity_bytes <= shared_capacity_bytes_,
+                    "prefetch arena backing storage size changed");
+        TORCH_CHECK(reinterpret_cast<uintptr_t>(phase.backing.data_ptr()) == phase.backing_pointer,
+                    "prefetch arena backing pointer changed");
+        TORCH_CHECK(phase.backing.storage().unsafeGetStorageImpl() == phase.storage_identity,
+                    "prefetch arena backing storage identity changed");
+        TORCH_CHECK(phase.backing_allocation_count == 1,
+                    "prefetch arena backing allocation count changed");
+    }
+
+    void noteFallback(const std::string& reason, int64_t bytes)
+    {
+        fallback_bytes_ += std::max<int64_t>(bytes, 0);
+        fallback_reasons_[reason]++;
+    }
+
+    void logState(const char* event) const
+    {
+        if (!diagnosticEnvEnabled("DEEPSPEED_COMPILE_PREFETCH_ARENA")) { return; }
+        if (phases_.empty() && rank_consistency_checks_ == 0 && request_bytes_ == 0 &&
+            fallback_bytes_ == 0) {
+            return;
+        }
+        int64_t total_capacity = shared_capacity_bytes_;
+        int64_t planned_max_live = 0;
+        for (const auto& [phase_id, phase] : phases_) {
+            planned_max_live = std::max(planned_max_live, phase.max_live_bytes);
+            if (!phase.backing.defined()) { continue; }
+            std::ostringstream backing_record;
+            backing_record << "DEEPSPEED_Z3_PREFETCH_ARENA_BACKING event=" << event
+                           << " rank=" << rank_
+                           << " device=" << static_cast<int>(phase.backing.device().index())
+                           << " generation=" << generation_ << " graph_id=" << graph_id_
+                           << " phase=" << phase_id << " capacity_bytes=" << phase.capacity_bytes
+                           << " max_live_bytes=" << phase.max_live_bytes
+                           << " pointer=" << phase.backing_pointer << " storage_identity="
+                           << reinterpret_cast<uintptr_t>(phase.storage_identity)
+                           << " digest=" << phase.digest
+                           << " backing_allocation_count=" << phase.backing_allocation_count
+                           << " disabled=" << (phase.disabled ? 1 : 0);
+            std::cout << backing_record.str() << std::endl;
+        }
+        std::ostringstream record;
+        record << "DEEPSPEED_Z3_PREFETCH_ARENA event=" << event << " rank=" << rank_
+               << " enabled=" << (enabled_ ? 1 : 0) << " generation=" << generation_
+               << " graph_id=" << graph_id_ << " capacity_bytes=" << total_capacity
+               << " planned_max_live_bytes=" << planned_max_live
+               << " backing_allocation_count=" << backing_allocation_count_
+               << " request_bytes=" << request_bytes_ << " reuse_bytes=" << reuse_bytes_
+               << " fallback_bytes=" << fallback_bytes_ << " active_bytes=" << active_bytes_
+               << " high_water_bytes=" << high_water_bytes_
+               << " active_slices=" << active_leases_.size()
+               << " high_water_slices=" << high_water_slices_
+               << " free_bytes=" << (total_capacity - active_bytes_)
+               << " internal_fragmentation_bytes=" << (total_capacity - planned_max_live)
+               << " event_waits=" << event_wait_count_ << " overlaps=" << overlap_count_
+               << " relocations=" << relocation_count_
+               << " stale_registry_releases=" << stale_registry_release_count_
+               << " pending_fences=" << pending_fences_.size()
+               << " active_leases=" << active_leases_.size()
+               << " rank_consistency_checked=" << (rank_consistency_checked_ ? 1 : 0)
+               << " rank_consistency_checks=" << rank_consistency_checks_
+               << " rank_plan_mismatches=" << rank_plan_mismatches_;
+        for (const auto& [reason, count] : fallback_reasons_) {
+            record << " fallback_" << reason << "=" << count;
+        }
+        std::cout << record.str() << std::endl;
+    }
+
+    long graph_id_;
+    uint64_t generation_;
+    int rank_;
+    at::cuda::CUDAStream ag_stream_;
+    bool enabled_ = false;
+    std::unordered_map<long, Phase> phases_;
+    at::Tensor shared_backing_;
+    int64_t shared_capacity_bytes_ = 0;
+    uintptr_t shared_backing_pointer_ = 0;
+    c10::StorageImpl* shared_storage_identity_ = nullptr;
+    std::unordered_map<long, Lease> active_leases_;
+    std::vector<Fence> pending_fences_;
+    std::set<int64_t> ever_acquired_;
+    std::unordered_map<std::string, size_t> fallback_reasons_;
+    size_t backing_allocation_count_ = 0;
+    int64_t request_bytes_ = 0;
+    int64_t reuse_bytes_ = 0;
+    int64_t fallback_bytes_ = 0;
+    int64_t active_bytes_ = 0;
+    int64_t high_water_bytes_ = 0;
+    size_t high_water_slices_ = 0;
+    size_t event_wait_count_ = 0;
+    size_t overlap_count_ = 0;
+    size_t relocation_count_ = 0;
+    size_t stale_registry_release_count_ = 0;
+    bool rank_consistency_checked_ = false;
+    size_t rank_consistency_checks_ = 0;
+    size_t rank_plan_mismatches_ = 0;
+};
+
 std::weak_ptr<GatherBufferPool> weak_gather_buffer_pool;
 std::optional<int64_t> gather_buffer_pool_fixed_budget_for_test;
+uint64_t z3_executor_generation = 0;
 
 std::shared_ptr<GatherBufferPool> get_gather_buffer_pool()
 {
@@ -643,6 +1264,8 @@ public:
                        std::shared_ptr<DSParamRegistry> param_registry,
                        std::shared_ptr<DoubleBufferedReduceBucket> reduce_buckets,
                        std::shared_ptr<GatherBufferPool> gather_buffer_pool,
+                       long graph_id,
+                       uint64_t generation,
                        std::vector<long> ds_ids,
                        ncclComm_t nccl_comm,
                        at::cuda::CUDAStream ag_stream,
@@ -662,7 +1285,11 @@ public:
           gather_buffer_pool_(gather_buffer_pool),
           ag_stream_(ag_stream),
           offload_stream_(offload_stream),
-          reload_stream_(reload_stream)
+          reload_stream_(reload_stream),
+          prefetch_arena_(std::make_shared<PrefetchArena>(graph_id,
+                                                          generation,
+                                                          process_group->getRank(),
+                                                          ag_stream))
     {
         for (long ds_id : ds_ids_) {
             ag_comm_done_events_[ds_id] =
@@ -674,6 +1301,32 @@ public:
         }
     }
     ~Z3CustomOpExecutor() {}
+
+    void prepareForReset() override { prefetch_arena_->prepareForReset(); }
+
+    void configurePrefetchArena(long phase,
+                                int64_t capacity_bytes,
+                                int64_t max_live_bytes,
+                                int64_t digest,
+                                const std::vector<long>& plan_ids,
+                                const std::vector<long>& ds_ids,
+                                const std::vector<int64_t>& offsets,
+                                const std::vector<int64_t>& request_bytes)
+    {
+        prefetch_arena_->configure(phase,
+                                   capacity_bytes,
+                                   max_live_bytes,
+                                   digest,
+                                   plan_ids,
+                                   ds_ids,
+                                   offsets,
+                                   request_bytes);
+    }
+
+    std::vector<int64_t> getPrefetchArenaStateForTest() const
+    {
+        return prefetch_arena_->stateForTest();
+    }
 
     void endBackward() override
     {
@@ -796,59 +1449,99 @@ public:
 
     void prefetchParamsFused(const std::vector<long>& ds_ids,
                              const std::optional<std::vector<at::ScalarType>> dtypes,
+                             long arena_plan_id,
                              c10::intrusive_ptr<c10d::symmetric_memory::SymmetricMemory> symm_mem)
     {
+        // All ranks execute a fused-prefetch node in graph order after
+        // compilation.  Verify the complete locally configured plan there, on
+        // the same NCCL communicator and stream as the following gathers,
+        // before any slice can be leased.  Memory profiling is itself part of
+        // asynchronous per-rank compilation, so it must never enter this
+        // collective.
+        if (diagnosticEnvEnabled("DEEPSPEED_COMPILE_PREFETCH_ARENA") && !profile) {
+            prefetch_arena_->ensureRankConsistent(nccl_comm_);
+        }
+
         std::vector<std::tuple<long, std::optional<at::ScalarType>>> invalid_params;
+        std::unordered_set<long> seen_ds_ids;
         for (int i = 0; i < ds_ids.size(); i++) {
-            if (!param_registry_->isValid(ds_ids[i])) {
+            if (!param_registry_->isValid(ds_ids[i]) && seen_ds_ids.insert(ds_ids[i]).second) {
                 auto dtype = dtypes ? dtypes.value()[i] : std::optional<at::ScalarType>();
                 invalid_params.push_back(std::make_tuple(ds_ids[i], dtype));
             }
         }
 
         std::unordered_map<long, at::Tensor> output_bufs;
+        std::unordered_set<long> arena_leases;
         AdmissionExclusionRollback admission_exclusions(gather_buffer_pool_);
-        for (const auto& [ds_id, dtype] : invalid_params) {
-            const DSParam& param = param_registry_->getParam(ds_id);
-            const at::Tensor& ds_tensor = param.getDSTensor();
-            const int world_size = process_group_->getSize();
-            const int64_t shard_elems = ds_tensor.numel();
-            const int64_t padded_numel = static_cast<int64_t>(world_size) * shard_elems;
+        try {
+            for (const auto& [ds_id, dtype] : invalid_params) {
+                const DSParam& param = param_registry_->getParam(ds_id);
+                const at::Tensor& ds_tensor = param.getDSTensor();
+                const int world_size = process_group_->getSize();
+                const int64_t shard_elems = ds_tensor.numel();
+                const int64_t padded_numel = static_cast<int64_t>(world_size) * shard_elems;
+                const auto target_dtype = dtype ? dtype.value() : ds_tensor.scalar_type();
 
-            if (param_registry_->hasGatheredParam(ds_id)) {
-                auto existing = param_registry_->getGatheredParam(ds_id);
-                if (existing.defined() && existing.numel() == padded_numel) {
-                    output_bufs[ds_id] = existing;
+                if (param_registry_->hasGatheredParam(ds_id)) {
+                    auto existing = param_registry_->getGatheredParam(ds_id);
+                    if (existing.defined() && existing.numel() == padded_numel &&
+                        existing.scalar_type() == target_dtype) {
+                        output_bufs[ds_id] = existing;
+                    }
+                }
+                if (!hasKey(output_bufs, ds_id) && !profile && !param.isPersistent() &&
+                    arena_plan_id >= 0) {
+                    if (target_dtype != ds_tensor.scalar_type()) {
+                        prefetch_arena_->recordFallback(
+                            "dtype_mismatch", padded_numel * c10::elementSize(target_dtype));
+                    } else {
+                        auto arena_buffer = prefetch_arena_->acquire(
+                            arena_plan_id, ds_id, padded_numel, target_dtype, ds_tensor.device());
+                        if (arena_buffer.defined()) {
+                            output_bufs[ds_id] = arena_buffer;
+                            arena_leases.insert(ds_id);
+                        }
+                    }
+                }
+                if (!hasKey(output_bufs, ds_id) && !profile && param.isPersistent() &&
+                    arena_plan_id >= 0) {
+                    prefetch_arena_->recordFallback("persistent",
+                                                    padded_numel * c10::elementSize(target_dtype));
+                }
+                if (!hasKey(output_bufs, ds_id)) {
+                    at::cuda::CUDAStreamGuard guard(ag_stream_);
+                    output_bufs[ds_id] =
+                        torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
+                }
+                if (arena_leases.find(ds_id) == arena_leases.end()) {
+                    // Prefetch lifetimes are already controlled by the memory-aware scheduler.
+                    // Bind the exclusion to the selected storage so a stale ds_id generation
+                    // cannot admit a different demand-gather buffer into the independent pool.
+                    admission_exclusions.exclude(output_bufs.at(ds_id));
                 }
             }
-            if (!hasKey(output_bufs, ds_id)) {
-                auto target_dtype = dtype ? dtype.value() : ds_tensor.scalar_type();
-                at::cuda::CUDAStreamGuard guard(ag_stream_);
-                output_bufs[ds_id] =
-                    torch::empty({padded_numel}, ds_tensor.options().dtype(target_dtype));
+
+            for (const auto& [ds_id, _] : invalid_params) {
+                ag_comp_done_events_[ds_id]->record();
+                ag_comp_done_events_[ds_id]->block(ag_stream_);
             }
-            // Prefetch lifetimes are already controlled by the memory-aware scheduler.
-            // Bind the exclusion to the selected storage so a stale ds_id generation
-            // cannot admit a different demand-gather buffer into the independent pool.
-            admission_exclusions.exclude(output_bufs.at(ds_id));
-        }
 
-        for (const auto& [ds_id, _] : invalid_params) {
-            ag_comp_done_events_[ds_id]->record();
-            ag_comp_done_events_[ds_id]->block(ag_stream_);
-        }
+            ncclGroupStart();
+            for (const auto& [ds_id, _] : invalid_params) {
+                assert(hasKey(output_bufs, ds_id));
+                launchAllGather(output_bufs.at(ds_id), ds_id, symm_mem);
+            }
+            ncclGroupEnd();
 
-        ncclGroupStart();
-        for (const auto& [ds_id, _] : invalid_params) {
-            assert(hasKey(output_bufs, ds_id));
-            launchAllGather(output_bufs.at(ds_id), ds_id, symm_mem);
+            for (const auto& [ds_id, _] : invalid_params) {
+                ag_comm_done_events_[ds_id]->record(ag_stream_);
+            }
+            admission_exclusions.commit();
+        } catch (...) {
+            for (long ds_id : arena_leases) { prefetch_arena_->cancelAcquire(ds_id); }
+            throw;
         }
-        ncclGroupEnd();
-
-        for (const auto& [ds_id, _] : invalid_params) {
-            ag_comm_done_events_[ds_id]->record(ag_stream_);
-        }
-        admission_exclusions.commit();
     }
 
     void releaseParam(long ds_id, long n_users)
@@ -860,18 +1553,33 @@ public:
         param_use_count_[ds_id]--;
 
         if (param_use_count_[ds_id] == 0 && !param.isPersistent()) {
-            at::Tensor gathered_param = param_registry_->getGatheredParam(ds_id);
+            const bool registry_has_param = param_registry_->hasGatheredParam(ds_id);
+            at::Tensor gathered_param =
+                registry_has_param ? param_registry_->getGatheredParam(ds_id) : at::Tensor();
+            const auto arena_release = prefetch_arena_->release(ds_id, gathered_param);
+
+            // The registry is shared by all graph executors. During nested or
+            // checkpoint compilation, profiling may invalidate this graph's
+            // gathered tensor and a newer graph may install another tensor for
+            // the same ds_id before this release executes. Retire this
+            // executor's exact arena lease, but leave the newer registry
+            // generation untouched for its own consumers and release nodes.
+            if (arena_release == PrefetchArena::ReleaseDisposition::ReleasedStaleRegistry) {
+                return;
+            }
 
             if (gathered_param.defined()) {  // gathered param is undefined while profiling
                 auto storage = gathered_param.storage();
                 if (storage.nbytes() > 0) {
-                    // Demand gathers may enter the byte-bounded pool. Prefetched gathers
-                    // keep the scheduler's ownership boundary and use the original
-                    // resize-to-zero path after their final consumer.
-                    const auto release_disposition = gather_buffer_pool_->release(gathered_param);
-                    if (release_disposition ==
-                        GatherBufferPool::ReleaseDisposition::ResizeByCaller) {
-                        at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
+                    if (arena_release == PrefetchArena::ReleaseDisposition::NoLease) {
+                        // Demand gathers may enter the byte-bounded pool. Standalone
+                        // prefetch fallbacks preserve the original resize-to-zero path.
+                        const auto release_disposition =
+                            gather_buffer_pool_->release(gathered_param);
+                        if (release_disposition ==
+                            GatherBufferPool::ReleaseDisposition::ResizeByCaller) {
+                            at::native::resize_bytes_cuda(storage.unsafeGetStorageImpl(), 0);
+                        }
                     }
                 }
 
@@ -880,7 +1588,7 @@ public:
                 gathered_param.set_data(empty_buffer);
             }
 
-            param_registry_->unregisterGatheredParam(ds_id);
+            if (registry_has_param) { param_registry_->unregisterGatheredParam(ds_id); }
         }
     }
 
@@ -1067,6 +1775,7 @@ private:
     at::cuda::CUDAStream ag_stream_;
     at::cuda::CUDAStream offload_stream_;
     at::cuda::CUDAStream reload_stream_;
+    std::shared_ptr<PrefetchArena> prefetch_arena_;
 
     std::unordered_map<long, std::shared_ptr<at::cuda::CUDAEvent>> ag_comp_done_events_;
     std::unordered_map<long, std::shared_ptr<at::cuda::CUDAEvent>> ag_comm_done_events_;
@@ -1120,6 +1829,8 @@ void register_graph_z3(long graph_id, const std::vector<long>& ds_ids)
                                                                param_registry,
                                                                reduce_buckets,
                                                                get_gather_buffer_pool(),
+                                                               graph_id,
+                                                               ++z3_executor_generation,
                                                                ds_ids,
                                                                nccl_comm,
                                                                get_ag_stream(),
@@ -1219,17 +1930,40 @@ void set_persistent(long ds_id)
 void prefetch_params_fused(long graph_id,
                            const std::vector<at::Tensor>& params,
                            const std::vector<long>& ds_ids,
-                           const std::optional<std::vector<at::ScalarType>>& dtypes)
+                           const std::optional<std::vector<at::ScalarType>>& dtypes,
+                           long arena_plan_id)
 {
     auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
-    executor->prefetchParamsFused(ds_ids, dtypes, symm_mem);
+    executor->prefetchParamsFused(ds_ids, dtypes, arena_plan_id, symm_mem);
 }
 
 void prefetch_params_fused_meta(long graph_id,
                                 const std::vector<at::Tensor>& params,
                                 const std::vector<long>& ds_ids,
-                                const std::optional<std::vector<at::ScalarType>>& dtypes)
+                                const std::optional<std::vector<at::ScalarType>>& dtypes,
+                                long arena_plan_id)
 {
+}
+
+void configure_z3_prefetch_arena(long graph_id,
+                                 long phase,
+                                 int64_t capacity_bytes,
+                                 int64_t max_live_bytes,
+                                 int64_t digest,
+                                 const std::vector<long>& plan_ids,
+                                 const std::vector<long>& ds_ids,
+                                 const std::vector<int64_t>& offsets,
+                                 const std::vector<int64_t>& request_bytes)
+{
+    auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
+    executor->configurePrefetchArena(
+        phase, capacity_bytes, max_live_bytes, digest, plan_ids, ds_ids, offsets, request_bytes);
+}
+
+std::vector<int64_t> get_z3_prefetch_arena_state_for_test(long graph_id)
+{
+    auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
+    return executor->getPrefetchArenaStateForTest();
 }
 
 // for profiling

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -632,6 +632,7 @@ public:
     }
 
     void configure(long phase,
+                   bool require_backward,
                    int64_t capacity_bytes,
                    int64_t max_live_bytes,
                    int64_t digest,
@@ -646,6 +647,13 @@ public:
         TORCH_CHECK(plan_ids.size() == ds_ids.size() && plan_ids.size() == offsets.size() &&
                         plan_ids.size() == request_bytes.size(),
                     "prefetch arena plan vectors must have equal length");
+
+        require_backward_ = require_backward_ || require_backward;
+        session_pending_logged_ = false;
+        if (session_disabled_) {
+            logState("configure_ignored_session_disabled");
+            return;
+        }
 
         auto existing = phases_.find(phase);
         if (existing != phases_.end()) {
@@ -697,9 +705,90 @@ public:
         logState("plan_configured");
     }
 
+    void disableSession(const std::string& reason)
+    {
+        TORCH_CHECK(active_leases_.empty(),
+                    "prefetch arena session disable attempted with active leases graph_id=",
+                    graph_id_,
+                    " active_leases=",
+                    active_leases_.size());
+        if (rank_consistency_checked_) {
+            TORCH_CHECK(
+                session_disabled_,
+                "prefetch arena session disable attempted after terminal rank consensus graph_id=",
+                graph_id_);
+            logState("session_disable_idempotent");
+            return;
+        }
+        session_disabled_ = true;
+        enabled_ = false;
+        // This is only a rank-local compiler decision until the next fused
+        // prefetch. Peers must observe it before any rank can safely return or
+        // enter the full plan collectives.
+        rank_consistency_checked_ = false;
+        for (auto& [_, phase] : phases_) { phase.disabled = true; }
+        noteFallback("session_" + reason, 0);
+        logState("session_disable_pending_consensus");
+    }
+
     void ensureRankConsistent(ncclComm_t nccl_comm)
     {
         if (rank_consistency_checked_) { return; }
+
+        // AOTAutograd compiles and executes forward before it lazily compiles
+        // backward.  A training arena must therefore wait for both phase plans
+        // before allocating its shared backing.  Otherwise a later backward
+        // budget rejection leaves a forward-only arena resident for the rest
+        // of the compile session.
+        constexpr int64_t kSessionDisabled = 0;
+        constexpr int64_t kTrainingPending = 1;
+        constexpr int64_t kSessionReady = 2;
+        int64_t local_session_state = kSessionReady;
+        if (session_disabled_) {
+            local_session_state = kSessionDisabled;
+        } else if (require_backward_ && (phases_.count(0) == 0 || phases_.count(1) == 0)) {
+            local_session_state = kTrainingPending;
+        }
+
+        at::Tensor session_state;
+        {
+            at::cuda::CUDAStreamGuard guard(ag_stream_);
+            session_state =
+                torch::tensor({local_session_state}, at::TensorOptions().dtype(at::kLong))
+                    .to(at::TensorOptions().dtype(at::kLong).device(at::kCUDA));
+            const auto session_result = ncclAllReduce(session_state.data_ptr(),
+                                                      session_state.data_ptr(),
+                                                      session_state.numel(),
+                                                      ncclInt64,
+                                                      ncclMin,
+                                                      nccl_comm,
+                                                      ag_stream_);
+            TORCH_CHECK(session_result == ncclSuccess,
+                        "prefetch arena session-state reduction failed: ",
+                        ncclGetErrorString(session_result));
+        }
+        at::cuda::stream_synchronize(ag_stream_);
+        rank_consistency_checks_++;
+
+        const int64_t global_session_state = session_state.cpu().item<int64_t>();
+        if (global_session_state == kSessionDisabled) {
+            const bool disabled_locally = session_disabled_;
+            session_disabled_ = true;
+            enabled_ = false;
+            rank_consistency_checked_ = true;
+            for (auto& [_, phase] : phases_) { phase.disabled = true; }
+            if (!disabled_locally) { noteFallback("session_peer_disabled", 0); }
+            logState("session_disabled_globally");
+            return;
+        }
+        if (global_session_state == kTrainingPending) {
+            enabled_ = false;
+            if (!session_pending_logged_) {
+                logState("session_pending_backward");
+                session_pending_logged_ = true;
+            }
+            return;
+        }
 
         std::vector<long> phase_ids;
         phase_ids.reserve(phases_.size());
@@ -764,7 +853,6 @@ public:
         }
         at::cuda::stream_synchronize(ag_stream_);
 
-        rank_consistency_checks_++;
         rank_consistency_checked_ = true;
         if (!minimum.cpu().equal(maximum.cpu())) {
             enabled_ = false;
@@ -813,6 +901,14 @@ public:
         const int64_t requested_bytes = numel * c10::elementSize(dtype);
         request_bytes_ += requested_bytes;
         if (!enabled_) {
+            // The first optimized forward necessarily executes before
+            // AOTAutograd has compiled the backward plan.  Using the normal
+            // gather pool during this metadata-only pending interval is the
+            // designed warmup path, not a failed arena admission.
+            if (require_backward_ && !session_disabled_ &&
+                (phases_.count(0) == 0 || phases_.count(1) == 0)) {
+                return at::Tensor();
+            }
             noteFallback("not_configured", requested_bytes);
             return at::Tensor();
         }
@@ -1187,6 +1283,9 @@ private:
     int rank_;
     at::cuda::CUDAStream ag_stream_;
     bool enabled_ = false;
+    bool require_backward_ = false;
+    bool session_disabled_ = false;
+    bool session_pending_logged_ = false;
     std::unordered_map<long, Phase> phases_;
     at::Tensor shared_backing_;
     int64_t shared_capacity_bytes_ = 0;
@@ -1305,6 +1404,7 @@ public:
     void prepareForReset() override { prefetch_arena_->prepareForReset(); }
 
     void configurePrefetchArena(long phase,
+                                bool require_backward,
                                 int64_t capacity_bytes,
                                 int64_t max_live_bytes,
                                 int64_t digest,
@@ -1314,6 +1414,7 @@ public:
                                 const std::vector<int64_t>& request_bytes)
     {
         prefetch_arena_->configure(phase,
+                                   require_backward,
                                    capacity_bytes,
                                    max_live_bytes,
                                    digest,
@@ -1321,6 +1422,11 @@ public:
                                    ds_ids,
                                    offsets,
                                    request_bytes);
+    }
+
+    void disablePrefetchArena(const std::string& reason)
+    {
+        prefetch_arena_->disableSession(reason);
     }
 
     std::vector<int64_t> getPrefetchArenaStateForTest() const
@@ -1947,6 +2053,7 @@ void prefetch_params_fused_meta(long graph_id,
 
 void configure_z3_prefetch_arena(long graph_id,
                                  long phase,
+                                 bool require_backward,
                                  int64_t capacity_bytes,
                                  int64_t max_live_bytes,
                                  int64_t digest,
@@ -1956,8 +2063,21 @@ void configure_z3_prefetch_arena(long graph_id,
                                  const std::vector<int64_t>& request_bytes)
 {
     auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
-    executor->configurePrefetchArena(
-        phase, capacity_bytes, max_live_bytes, digest, plan_ids, ds_ids, offsets, request_bytes);
+    executor->configurePrefetchArena(phase,
+                                     require_backward,
+                                     capacity_bytes,
+                                     max_live_bytes,
+                                     digest,
+                                     plan_ids,
+                                     ds_ids,
+                                     offsets,
+                                     request_bytes);
+}
+
+void disable_z3_prefetch_arena(long graph_id, const std::string& reason)
+{
+    auto executor = getExecutor<Z3CustomOpExecutor>(graph_id, executors);
+    executor->disablePrefetchArena(reason);
 }
 
 std::vector<int64_t> get_z3_prefetch_arena_state_for_test(long graph_id)

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -10,6 +10,12 @@
 namespace dc {
 
 void register_graph_z3(long graph_id, const std::vector<long>& ds_ids);
+void set_z3_gather_buffer_pool_fixed_budget_for_test(int64_t fixed_budget_bytes);
+void update_z3_gather_buffer_pool_allocator_pressure_for_test(int64_t retries,
+                                                              int64_t free_bytes,
+                                                              int64_t total_bytes);
+std::vector<int64_t> get_z3_gather_buffer_pool_state_for_test();
+void reset_z3_gather_buffer_pool();
 void register_graph_ops_z3(long graph_id,
                            const std::vector<std::string>& op_names,
                            const std::vector<long>& n_args);

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -15,6 +15,8 @@ void update_z3_gather_buffer_pool_allocator_pressure_for_test(int64_t retries,
                                                               int64_t free_bytes,
                                                               int64_t total_bytes);
 std::vector<int64_t> get_z3_gather_buffer_pool_state_for_test();
+int64_t get_z3_gather_buffer_pool_reclaimable_bytes();
+int64_t get_z3_gather_buffer_pool_transition_reclaimable_bytes();
 void reset_z3_gather_buffer_pool();
 void register_graph_ops_z3(long graph_id,
                            const std::vector<std::string>& op_names,

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -45,6 +45,7 @@ void prefetch_params_fused_meta(long graph_id,
                                 long arena_plan_id);
 void configure_z3_prefetch_arena(long graph_id,
                                  long phase,
+                                 bool require_backward,
                                  int64_t capacity_bytes,
                                  int64_t max_live_bytes,
                                  int64_t digest,
@@ -52,6 +53,7 @@ void configure_z3_prefetch_arena(long graph_id,
                                  const std::vector<long>& ds_ids,
                                  const std::vector<int64_t>& offsets,
                                  const std::vector<int64_t>& request_bytes);
+void disable_z3_prefetch_arena(long graph_id, const std::string& reason);
 std::vector<int64_t> get_z3_prefetch_arena_state_for_test(long graph_id);
 // for profiling
 void invalidate_gathered_param(long ds_id);

--- a/csrc/compile/z3.h
+++ b/csrc/compile/z3.h
@@ -36,11 +36,23 @@ void set_persistent(long ds_id);
 void prefetch_params_fused(long graph_id,
                            const std::vector<at::Tensor>& params,
                            const std::vector<long>& ds_ids,
-                           const std::optional<std::vector<at::ScalarType>>& dtypes);
+                           const std::optional<std::vector<at::ScalarType>>& dtypes,
+                           long arena_plan_id);
 void prefetch_params_fused_meta(long graph_id,
                                 const std::vector<at::Tensor>& params,
                                 const std::vector<long>& ds_ids,
-                                const std::optional<std::vector<at::ScalarType>>& dtypes);
+                                const std::optional<std::vector<at::ScalarType>>& dtypes,
+                                long arena_plan_id);
+void configure_z3_prefetch_arena(long graph_id,
+                                 long phase,
+                                 int64_t capacity_bytes,
+                                 int64_t max_live_bytes,
+                                 int64_t digest,
+                                 const std::vector<long>& plan_ids,
+                                 const std::vector<long>& ds_ids,
+                                 const std::vector<int64_t>& offsets,
+                                 const std::vector<int64_t>& request_bytes);
+std::vector<int64_t> get_z3_prefetch_arena_state_for_test(long graph_id);
 // for profiling
 void invalidate_gathered_param(long ds_id);
 void clear_all_gathered_params();

--- a/csrc/includes/deepcompile.h
+++ b/csrc/includes/deepcompile.h
@@ -417,7 +417,7 @@ public:
 
     void registerGatheredParam(long ds_id, at::Tensor ds_tensor)
     {
-        gathered_params_.emplace(ds_id, ds_tensor);
+        gathered_params_.insert_or_assign(ds_id, std::move(ds_tensor));
     }
 
     void unregisterGatheredParam(long ds_id)
@@ -498,6 +498,8 @@ public:
         // This synchronization ensures all of reduce calls are done before optimizer's step.
         at::cuda::stream_synchronize(rs_stream_);
     }
+
+    virtual void prepareForReset() {}
 
     virtual at::Tensor reduceGrad(at::Tensor grad_tensor, long ds_id)
     {

--- a/deepspeed/compile/backend.py
+++ b/deepspeed/compile/backend.py
@@ -27,12 +27,12 @@ from deepspeed.accelerator import get_accelerator
 from .fx import add_free_activations
 from .graph_param import DSGraphParamManager
 from .profilers import ProfilingResult
-from .profilers.graph_profile import MemoryProfilingInterpreter
+from .profilers.graph_profile import MemoryProfilingInterpreter, is_profile_incomplete
 from .patch_compiled_func import (clear_backward_inputs, patch_compiled_func, pop_backward_input,
                                   register_backward_frame, unpatch_compiled_func)
 from .util import get_input_nodes, get_activation_node_names, get_index_by_graph_id, get_deepcompile_handle, log_rank0, is_backend_inductor
 from .partitioner import get_wrapped_partitioner
-from .inductor import register_custom_ops, patch_create_aot_dispatcher_function
+from .inductor import register_custom_ops, patch_create_aot_dispatcher_function, deepcompile_z3_inductor_config_patch
 from .input_storage import InputStorage
 
 remaining_schedule = None
@@ -158,12 +158,15 @@ def set_time_and_tensor_size(graph_id, graph: Graph, mem, bwd, profiling_results
         profiling_results[graph_id].fwd_mem_complete = mem_complete
 
 
-def _sync_memory_profile_complete(profile_complete: bool) -> bool:
+def _sync_memory_profile_complete(profile_complete: bool, process_group=None) -> bool:
     if not dist.is_initialized():
         return profile_complete
 
     complete = torch.tensor([1 if profile_complete else 0], device=torch.device(get_accelerator().current_device()))
-    dist.all_reduce(complete, dist.ReduceOp.MIN)
+    if process_group is None:
+        dist.all_reduce(complete, dist.ReduceOp.MIN)
+    else:
+        dist.all_reduce(complete, dist.ReduceOp.MIN, group=process_group)
     return bool(complete.item())
 
 
@@ -174,16 +177,28 @@ def evaluate_symint_from_shape_env(sym_int_v):
     return sym_int_v.node.hint
 
 
-def set_example_values_to_symints(real_inputs, param_indices=None):
+_ZERO_PARAMETER_COMPILE_METADATA = ("ds_id", "ds_shape", "ds_persist", "ds_status", "ds_target_dtype")
+
+
+def set_example_values_to_symints(real_inputs, param_indices=None, real_zero_params=None):
     real_inputs_ret = []
 
     # Create a set of parameter indices for quick lookup
     param_idx_set = set()
     if param_indices is not None:
         param_idx_set = {i for i, _, _ in param_indices}
+    param_ds_ids = {i: ds_id for i, ds_id, _ in (param_indices or [])}
+    real_zero_params = real_zero_params or {}
 
     for i, v in enumerate(real_inputs):
         if isinstance(v, torch.Tensor):
+            real_zero_param = real_zero_params.get(param_ds_ids.get(i))
+            if i in param_idx_set and real_zero_param is not None:
+                # Stored and fake profiling inputs both discard instance-bound
+                # ZeRO methods, so recover the original before materialization.
+                real_inputs_ret.append(real_zero_param)
+                continue
+
             if is_fake(v):
                 shape = []
                 for fs in v.shape:
@@ -207,10 +222,12 @@ def set_example_values_to_symints(real_inputs, param_indices=None):
 
                     # Create Parameter if this input index corresponds to a parameter
                     if i in param_idx_set:
-                        dummy_v = torch.nn.Parameter(dummy_v)
-                        # Copy any additional attributes from the original if they exist
-                        if hasattr(v, 'ds_id'):
-                            dummy_v.ds_id = v.ds_id
+                        dummy_v = torch.nn.Parameter(dummy_v, requires_grad=v.requires_grad)
+                        # Profiling and graph-parameter consumers use these ZeRO
+                        # attributes after symbolic fake inputs are materialized.
+                        for attr in _ZERO_PARAMETER_COMPILE_METADATA:
+                            if hasattr(v, attr):
+                                setattr(dummy_v, attr, getattr(v, attr))
 
                     real_inputs_ret.append(dummy_v)
             else:
@@ -248,7 +265,9 @@ def run_opt_passes(opt_passes: List[Callable],
                    mem_budget: float,
                    param_manager,
                    bwd: bool,
-                   debug_log=False) -> None:
+                   debug_log=False,
+                   process_group=None) -> None:
+    """Apply scheduled graph passes and retain only complete post-pass memory profiles."""
 
     with unset_fake_temporarily():
         get_accelerator().synchronize()
@@ -265,13 +284,23 @@ def run_opt_passes(opt_passes: List[Callable],
             gm.graph.lint()
             gm.recompile()
 
-            mem_prof = MemoryProfilingInterpreter(gm, debug_log=debug_log)
-            mem_prof.run(*create_inputs_fn())
-            profile_complete = _sync_memory_profile_complete(mem_prof.profile_complete)
-            if profile_complete:
-                mem = [(name, current_alloc, delta, peak) for name, current_alloc, delta, peak in mem_prof.mem_record]
-            else:
+            # Re-profiling an already incomplete graph would turn synthetic
+            # backfilled metadata into a seemingly valid memory profile.
+            operator_profile_complete = _sync_memory_profile_complete(not is_profile_incomplete(gm.graph),
+                                                                      process_group)
+            if not operator_profile_complete:
+                profile_complete = False
                 mem = []
+            else:
+                mem_prof = MemoryProfilingInterpreter(gm, debug_log=debug_log, process_group=process_group)
+                mem_prof.run(*create_inputs_fn())
+                profile_complete = _sync_memory_profile_complete(mem_prof.profile_complete, process_group)
+                if profile_complete:
+                    mem = [(name, current_alloc, delta, peak)
+                           for name, current_alloc, delta, peak in mem_prof.mem_record]
+                else:
+                    mem = []
+                del mem_prof
 
             set_time_and_tensor_size(graph_id, gm.graph, mem, bwd, profiling_results, profile_complete)
 
@@ -281,7 +310,7 @@ def run_opt_passes(opt_passes: List[Callable],
             get_accelerator().empty_cache()
 
 
-def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
+def make_backend(backend, compile_config, compile_kwargs={}, process_group=None, owned_frames=None):
 
     register_custom_ops()
 
@@ -312,11 +341,17 @@ def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
         if z3_partition:
             param_indices = [(i, input_val.ds_id, input_val.ds_shape) for i, input_val in enumerate(real_inputs)
                              if isinstance(input_val, torch.nn.Parameter)]
+            real_zero_params = {
+                input_val.ds_id: input_val
+                for input_val in real_inputs if isinstance(input_val, torch.nn.Parameter)
+                and hasattr(input_val, "all_gather") and hasattr(input_val, "partition")
+            }
         else:
             assert all(hasattr(v, "param_id") for v in real_inputs
                        if isinstance(v, torch.nn.Parameter)), "All param inputs should have param_id"
             param_indices = [(i, input_val.param_id, input_val.shape) for i, input_val in enumerate(real_inputs)
                              if isinstance(input_val, torch.nn.Parameter)]
+            real_zero_params = {}
 
         # Create an InputStorage instance for this specific graph
         # It will be captured by the make_fw_graph closure, eliminating the need for graph ID management
@@ -331,7 +366,7 @@ def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
 
         global profiling_results
         if graph_id not in profiling_results:
-            profiling_results[graph_id] = ProfilingResult()
+            profiling_results[graph_id] = ProfilingResult(process_group=process_group)
             profiling_results[graph_id].param_indices = param_indices
 
         def make_fw_graph(gm, sample_inputs):
@@ -350,7 +385,7 @@ def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
                 register_backward_frame(frame_key)
 
             real_inputs = _get_fw_real_inputs(local_fwd_real_inputs, input_storage, graph_id, debug_log=debug_log)
-            real_inputs = set_example_values_to_symints(real_inputs)
+            real_inputs = set_example_values_to_symints(real_inputs, param_indices, real_zero_params=real_zero_params)
 
             param_manager[graph_id] = DSGraphParamManager(gm.graph, real_inputs, param_indices)
 
@@ -365,7 +400,8 @@ def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
                 mem_budget=.0,  # unused
                 param_manager=param_manager,
                 bwd=False,
-                debug_log=debug_log)
+                debug_log=debug_log,
+                process_group=process_group)
 
             opt_pass_times.append(("fwd", graph_index, graph_id, time.time() - time_start))
 
@@ -404,7 +440,8 @@ def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
                 mem_budget=.0,  # unused
                 param_manager=param_manager,
                 bwd=True,
-                debug_log=debug_log)
+                debug_log=debug_log,
+                process_group=process_group)
 
             # assert graph_id in param_manager, f"Graph {graph_id} not found in param_manager"
 
@@ -446,7 +483,8 @@ def make_backend(backend, compile_config, compile_kwargs={}, owned_frames=None):
                                                                        make_bw_graph, real_inputs, param_indices,
                                                                        param_manager, frame_id, frames_partitioned)
             try:
-                return torch._inductor.compile(gm, real_inputs)
+                with deepcompile_z3_inductor_config_patch(z3_partition):
+                    return torch._inductor.compile(gm, real_inputs)
             finally:
                 # AotAutograd.__init__ is process-global; never leak this
                 # graph-specific compiler wiring into a later compilation.

--- a/deepspeed/compile/inductor.py
+++ b/deepspeed/compile/inductor.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+from contextlib import nullcontext
 from typing import Set
 
 import torch
@@ -20,6 +21,43 @@ from deepspeed.utils.torch import required_torch_version
 from .util import get_input_nodes
 from .graph_param import DSGraphParamManager
 from .partitioner import get_wrapped_partitioner
+
+# With PyTorch 2.10, Inductor was observed to generate a mix-order persistent
+# reduction for a DeepCompile ZeRO-3 backward graph, and Triton rejected the
+# kernel for exceeding the hardware's per-kernel resource limit. Setting
+# persistent_reductions=False alone is insufficient because mix-order codegen
+# passes override_persistent_reduction=True. Revisit this ZeRO-3 compile
+# workaround when PyTorch's Inductor reduction heuristics change.
+_DEEP_COMPILE_Z3_INDUCTOR_REDUCTION_CONFIG = {
+    "triton.mix_order_reduction": False,
+    "triton.persistent_reductions": False,
+}
+
+
+def deepcompile_z3_inductor_config_patch(enabled: bool):
+    """Disable reduction heuristics that create oversized kernels for DeepCompile ZeRO-3 graphs."""
+    if not enabled:
+        return nullcontext()
+
+    inductor = getattr(torch, "_inductor", None)
+    config = getattr(inductor, "config", None)
+    if config is None or not hasattr(config, "patch"):
+        return nullcontext()
+
+    triton_config = getattr(config, "triton", None)
+    if triton_config is None:
+        return nullcontext()
+
+    overrides = {
+        config_name: value
+        for config_name, value in _DEEP_COMPILE_Z3_INDUCTOR_REDUCTION_CONFIG.items()
+        if hasattr(triton_config,
+                   config_name.split(".", 1)[1])
+    }
+    if not overrides:
+        return nullcontext()
+
+    return config.patch(overrides)
 
 
 def _get_graphsafe_run_with_rng_state():
@@ -46,6 +84,7 @@ def _mark_output_never_reuse(out, *, enabled):
 
 
 def patch_compiler(original_compiler, dc_compiler, z3_partition: bool, graph_id, graph_param_manager, bwd: bool):
+    """Wrap an AOT compiler with DeepCompile rewrites and ZeRO-3 fake-shape repair."""
 
     def wrapped_compiler(gm, fake_inputs):
         mod_graph = dc_compiler(gm, fake_inputs)
@@ -80,7 +119,8 @@ def patch_compiler(original_compiler, dc_compiler, z3_partition: bool, graph_id,
         else:
             patched_inputs = fake_inputs
 
-        return original_compiler(gm, patched_inputs)
+        with deepcompile_z3_inductor_config_patch(z3_partition):
+            return original_compiler(gm, patched_inputs)
 
     return wrapped_compiler
 

--- a/deepspeed/compile/init_z1.py
+++ b/deepspeed/compile/init_z1.py
@@ -11,7 +11,7 @@ import torch
 from deepspeed.accelerator import get_accelerator
 from .passes import zero1_compile, zero3_compile
 from .backend import make_backend, launch_compile_passes, init_schedule
-from .util import get_deepcompile_handle, add_pre_backward_hook
+from .util import add_pre_backward_hook
 
 WARMUP = 5
 
@@ -96,8 +96,7 @@ def init_z1(engine, backend, compile_config, compile_kwargs, schedule=None, use_
         hook.remove()
     optimizer._grad_acc_hooks.clear()
 
-    dc = get_deepcompile_handle()
-    dc.init(engine.data_parallel_group, compile_config, engine.zero_reduce_bucket_size())
+    dc = engine._initialize_deepcompile_native(compile_config)
 
     if use_z2:
         grad_buffer = {}

--- a/deepspeed/compile/init_z3.py
+++ b/deepspeed/compile/init_z3.py
@@ -16,7 +16,7 @@ from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload
 from .passes import zero3_compile, prefetch, selective_gather, offload_parameters
 from .backend import make_backend, launch_compile_passes, init_schedule
 from .patch_fake_tensor import patch_fake_tensor
-from .util import get_deepcompile_handle, add_pre_backward_hook, add_post_backward_hook
+from .util import add_pre_backward_hook, add_post_backward_hook
 from .z3_eager_fallback import DeepCompileZ3EagerFallback
 
 WARMUP = 5
@@ -104,8 +104,7 @@ def init_z3(engine, backend, compile_config, compile_kwargs, schedule=None):
         optimizer.ipg_buckets.clear()
         get_accelerator().empty_cache()
 
-    dc = get_deepcompile_handle()
-    dc.init(engine.data_parallel_group, compile_config, engine.zero_reduce_bucket_size())
+    dc = engine._initialize_deepcompile_native(compile_config)
 
     engine._deepcompile_z3_eager_fallback = DeepCompileZ3EagerFallback(engine)
     add_post_backward_hook(engine._deepcompile_z3_eager_fallback.complete_backward)
@@ -194,4 +193,5 @@ def init_z3(engine, backend, compile_config, compile_kwargs, schedule=None):
     return make_backend(backend,
                         compile_config,
                         compile_kwargs=compile_kwargs,
+                        process_group=engine.data_parallel_group,
                         owned_frames=engine._deepcompile_owned_frames)

--- a/deepspeed/compile/list_schedule.py
+++ b/deepspeed/compile/list_schedule.py
@@ -4,9 +4,9 @@
 # DeepSpeed Team
 
 from collections import defaultdict
-from typing import List, Dict
+from typing import List, Dict, Optional
 from copy import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import torch
 from torch.fx import Graph, Node
@@ -258,6 +258,223 @@ def get_node_requirements(target_node: Node, scheduled: List[Node]):
     return ordered_nodes
 
 
+SCHEDULER_MEMORY_MARGIN = 0.1
+DS_SCHEDULER_BUDGET_DIAGNOSTICS_ATTR = "_ds_deepcompile_scheduler_budget_diagnostics"
+
+
+@dataclass(frozen=True)
+class SchedulerMemoryBudget:
+    """Rank-consistent allowance for scheduler-managed gathered parameter buffers.
+
+    ``max_gathered_bytes`` is the headroom remaining after any profiled
+    non-gathered peak, output reservation, and safety margin are removed, or
+    an explicit gather-residency cap when no complete memory profile exists.
+    """
+
+    max_gathered_bytes: int
+    source: str
+    available_mem: int = 0
+    output_size: int = 0
+    safety_margin: int = 0
+    total_mem: int = 0
+    profiled_non_gathered_peak_mem: int = 0
+
+    @classmethod
+    def minimum_gather_residency(cls, max_single_allgather_bytes: int):
+        """Limit an incomplete-profile schedule to one largest-gather-sized residency.
+
+        This is not an estimate of available memory or of an unobserved
+        non-gather peak. It only constrains the memory the scheduler controls:
+        simultaneously resident gathered parameter buffers.
+        """
+        max_single_allgather_bytes = int(max_single_allgather_bytes or 0)
+        if max_single_allgather_bytes <= 0:
+            return None
+        return cls(max_gathered_bytes=max_single_allgather_bytes, source="incomplete_profile_minimum_gather_residency")
+
+    def clamped_to_minimum_gather_residency(self, max_single_allgather_bytes: int):
+        """Keep an enabled budget large enough for one unavoidable gather.
+
+        A smaller budget cannot be satisfied by any schedule and forces the
+        scheduler into its over-budget fallback. This floor changes only the
+        gathered residency controlled by the scheduler; it does not revise the
+        profiled non-gather memory estimate.
+        """
+        max_single_allgather_bytes = int(max_single_allgather_bytes or 0)
+        if max_single_allgather_bytes <= self.max_gathered_bytes:
+            return self
+        return replace(self,
+                       max_gathered_bytes=max_single_allgather_bytes,
+                       source=f"{self.source}_clamped_to_minimum_gather_residency")
+
+    @classmethod
+    def from_profiled_non_gathered_peak(cls, total_mem: int, profiled_non_gathered_peak_mem: int, output_size: int):
+        """Reserve profiled non-gather memory before budgeting transient gathers."""
+        if total_mem is None or total_mem <= 0 or profiled_non_gathered_peak_mem is None or profiled_non_gathered_peak_mem <= 0:
+            return None
+        total_mem = int(total_mem)
+        profiled_non_gathered_peak_mem = int(profiled_non_gathered_peak_mem)
+        output_size = max(0, int(output_size or 0))
+        safety_margin = int(total_mem * SCHEDULER_MEMORY_MARGIN)
+        max_gathered_bytes = max(0, total_mem - profiled_non_gathered_peak_mem - output_size - safety_margin)
+        return cls(max_gathered_bytes=max_gathered_bytes,
+                   source="profiled_non_gathered_peak_memory",
+                   available_mem=max_gathered_bytes,
+                   output_size=output_size,
+                   safety_margin=safety_margin,
+                   total_mem=total_mem,
+                   profiled_non_gathered_peak_mem=profiled_non_gathered_peak_mem)
+
+
+class _GatheredParamTracker:
+    """Simulate gathered-buffer residency for a committed schedule prefix.
+
+    A gathered buffer remains live until the final release for its ``ds_id``;
+    repeated gathers while it is live only increase the tracked allocation.
+    """
+
+    def __init__(self,
+                 release_expected: Dict[int, int],
+                 live_bytes_by_ds_id: Optional[Dict[int, int]] = None,
+                 release_seen_by_ds_id: Optional[Dict[int, int]] = None,
+                 live_bytes: int = 0,
+                 peak_bytes: int = 0):
+        self.release_expected = release_expected
+        self.live_bytes_by_ds_id = dict(live_bytes_by_ds_id or {})
+        self.release_seen_by_ds_id = dict(release_seen_by_ds_id or {})
+        self.live_bytes = live_bytes
+        self.peak_bytes = peak_bytes
+
+    def copy(self, *, reset_peak: bool = False):
+        """Copy residency state, optionally starting a candidate-local peak."""
+        return _GatheredParamTracker(
+            self.release_expected,
+            self.live_bytes_by_ds_id,
+            self.release_seen_by_ds_id,
+            self.live_bytes,
+            self.live_bytes if reset_peak else self.peak_bytes,
+        )
+
+    def apply(self, node: Node):
+        """Advance residency through one node without treating reduce_grad as a release."""
+        if node.target == torch.ops.dc.allgather_param.default:
+            ds_id = _get_ds_id(node)
+            size = _allgather_allocation_bytes(node)
+            current_size = self.live_bytes_by_ds_id.get(ds_id)
+            if current_size is None:
+                self.live_bytes_by_ds_id[ds_id] = size
+                self.live_bytes += size
+            elif size > current_size:
+                self.live_bytes_by_ds_id[ds_id] = size
+                self.live_bytes += size - current_size
+            self.release_seen_by_ds_id[ds_id] = 0
+        elif is_release_node(node):
+            ds_id = _get_ds_id(node)
+            if ds_id in self.live_bytes_by_ds_id:
+                release_seen = self.release_seen_by_ds_id.get(ds_id, 0) + 1
+                release_expected = max(1, self.release_expected.get(ds_id, _release_n_users(node)))
+                if release_seen >= release_expected:
+                    self.live_bytes -= self.live_bytes_by_ds_id.pop(ds_id)
+                    self.release_seen_by_ds_id.pop(ds_id, None)
+                else:
+                    self.release_seen_by_ds_id[ds_id] = release_seen
+
+        self.peak_bytes = max(self.peak_bytes, self.live_bytes)
+
+
+def _get_ds_id(node: Node):
+    return node.args[2]
+
+
+def _release_n_users(node: Node):
+    if len(node.args) > 3:
+        return int(node.args[3])
+    return 1
+
+
+def _dtype_element_size(dtype):
+    if dtype is None:
+        return None
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def allgather_allocation_bytes(tensor_size: int, dtype, world_size: int):
+    """Return the padded allocation size used by a process-group all-gather."""
+    element_size = _dtype_element_size(dtype)
+    tensor_size = int(tensor_size)
+    if tensor_size <= 0 or element_size is None or element_size <= 0 or world_size <= 1:
+        return tensor_size
+    true_numel, remainder = divmod(tensor_size, element_size)
+    if remainder != 0:
+        return tensor_size
+    padded_per_rank = (true_numel + world_size - 1) // world_size
+    return padded_per_rank * world_size * element_size
+
+
+def _allgather_allocation_bytes(node: Node):
+    return int(node.meta.get("allgather_allocation_bytes", node.meta.get("tensor_size", 0)))
+
+
+def _allgather_ranking_bytes(node: Node):
+    """Use legacy logical bytes for deterministic candidate ranking."""
+    return int(node.meta.get("tensor_size", 0))
+
+
+def max_possible_gathered_bytes(graph: Graph):
+    """Upper-bound simultaneous gather residency, counting each ``ds_id`` once."""
+    gathered_bytes_by_ds_id = {}
+    for node in graph.nodes:
+        if node.target != torch.ops.dc.allgather_param.default:
+            continue
+        ds_id = _get_ds_id(node)
+        gathered_bytes_by_ds_id[ds_id] = max(gathered_bytes_by_ds_id.get(ds_id, 0), _allgather_allocation_bytes(node))
+    return sum(gathered_bytes_by_ds_id.values())
+
+
+def _build_release_expected(nodes: List[Node]):
+    """Derive the final-release count for every gathered parameter interval."""
+    release_expected = defaultdict(int)
+    release_counts = defaultdict(int)
+    for node in nodes:
+        if is_release_node(node):
+            ds_id = _get_ds_id(node)
+            release_expected[ds_id] = max(release_expected[ds_id], _release_n_users(node))
+            release_counts[ds_id] += 1
+
+    for ds_id, release_count in release_counts.items():
+        release_expected[ds_id] = max(release_expected[ds_id], release_count)
+
+    return dict(release_expected)
+
+
+def _simulate_path_stats(tracker: _GatheredParamTracker, nodes: List[Node]):
+    """Return this candidate's peak and ending residency without mutating the prefix.
+
+    The committed tracker keeps a cumulative diagnostic peak, but an earlier
+    overflow must not make every later candidate appear over budget after its
+    buffers have been released.
+    """
+    candidate_tracker = tracker.copy(reset_peak=True)
+    for node in nodes:
+        candidate_tracker.apply(node)
+    return candidate_tracker.peak_bytes, candidate_tracker.live_bytes
+
+
+def profiled_non_gathered_peak(graph: Graph, mem_records):
+    """Return a conservative peak for scheduler-budget headroom.
+
+    Operator profiling invalidates gathered parameters between nodes, so a
+    source-order residency replay is not guaranteed to be present in each
+    recorded peak.  Keep the observed peak intact rather than subtracting
+    hypothetical gathered residency and risking an unsafe budget.
+    """
+    return max((int(peak_mem) for _, _, _, peak_mem in mem_records), default=0)
+
+
+def _fits_budget(scheduler_budget: Optional[SchedulerMemoryBudget], peak_bytes: int):
+    return scheduler_budget is None or peak_bytes <= scheduler_budget.max_gathered_bytes
+
+
 @dataclass
 class AllgatherTask:
     node: Node
@@ -270,6 +487,10 @@ class AllgatherTask:
     n_scheduled_ags: int
     schedule_until_ag: List[Node]
     schedule_until_free: List[Node]
+    schedule_until_ag_peak_mem: int
+    schedule_until_free_peak_mem: int
+    schedule_until_ag_live_mem: int
+    schedule_until_free_live_mem: int
 
 
 def _free_path_allgather_key(task: AllgatherTask):
@@ -280,8 +501,102 @@ def _fallback_allgather_key(task: AllgatherTask):
     return (task.free_acc_mem, task.n_scheduled_ags, task.allgather_acc_mem, task.free_cost, task.node.name)
 
 
-def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug_log: bool) -> Graph:
+def _select_allgather_task(runnable_ags: List[AllgatherTask], scheduler_budget: Optional[SchedulerMemoryBudget]):
+    """Select the best fitting release path, then the best fitting gather-only path."""
+    ags_with_no_additional_ag = [
+        ag for ag in runnable_ags
+        if ag.free_acc_mem == 0 and _fits_budget(scheduler_budget, ag.schedule_until_free_peak_mem)
+    ]
+    if len(ags_with_no_additional_ag) > 0:
+        next_ag = sorted(ags_with_no_additional_ag, key=_free_path_allgather_key)[0]
+        return next_ag, next_ag.schedule_until_free
+
+    fallback_ags = [ag for ag in runnable_ags if _fits_budget(scheduler_budget, ag.schedule_until_ag_peak_mem)]
+    if len(fallback_ags) == 0:
+        return None, None
+    next_ag = sorted(fallback_ags, key=_fallback_allgather_key)[0]
+    return next_ag, next_ag.schedule_until_ag
+
+
+def _rejected_budget_candidates(runnable_ags: List[AllgatherTask], scheduler_budget: Optional[SchedulerMemoryBudget]):
+    """Describe tasks for which neither scheduler-eligible path fits the budget."""
+    if scheduler_budget is None:
+        return []
+    rejected = []
+    for task in runnable_ags:
+        path_options = list(_over_budget_path_options(task, scheduler_budget))
+        if any(_fits_budget(scheduler_budget, peak_bytes) for _, _, peak_bytes, _ in path_options):
+            continue
+        _, _, peak_bytes, _ = min(path_options,
+                                  key=lambda option:
+                                  (max(0, option[2] - scheduler_budget.max_gathered_bytes), option[2]))
+        rejected.append({
+            "node": task.node.name,
+            "schedule_until_ag_peak_mem": task.schedule_until_ag_peak_mem,
+            "schedule_until_free_peak_mem": task.schedule_until_free_peak_mem,
+            "over_budget_bytes": max(0, peak_bytes - scheduler_budget.max_gathered_bytes),
+        })
+    return rejected
+
+
+def _over_budget_path_options(task: AllgatherTask, scheduler_budget: SchedulerMemoryBudget):
+    if task.free_acc_mem == 0:
+        yield ("until_free", task.schedule_until_free, task.schedule_until_free_peak_mem,
+               task.schedule_until_free_live_mem)
+        return
+    yield ("until_ag", task.schedule_until_ag, task.schedule_until_ag_peak_mem, task.schedule_until_ag_live_mem)
+    yield ("until_free", task.schedule_until_free, task.schedule_until_free_peak_mem,
+           task.schedule_until_free_live_mem)
+
+
+def _select_over_budget_allgather_task(runnable_ags: List[AllgatherTask], scheduler_budget: SchedulerMemoryBudget):
+    """Choose the smallest deterministic peak overage when no candidate fits."""
+    options = []
+    for task in runnable_ags:
+        for path, nodes, peak_bytes, live_bytes in _over_budget_path_options(task, scheduler_budget):
+            overage_bytes = max(0, peak_bytes - scheduler_budget.max_gathered_bytes)
+            options.append((overage_bytes, peak_bytes, live_bytes, task.free_acc_mem, task.n_scheduled_ags,
+                            task.allgather_acc_mem, task.free_cost, task.node.name, path, task, nodes))
+    *_, task, nodes = min(options)
+    return task, nodes
+
+
+def _budget_overflow_diagnostic(scheduler_budget: SchedulerMemoryBudget, task: AllgatherTask, path: str,
+                                live_gathered_bytes: int):
+    peak_bytes = task.schedule_until_free_peak_mem if path == "until_free" else task.schedule_until_ag_peak_mem
+    return {
+        "source": scheduler_budget.source,
+        "max_gathered_bytes": scheduler_budget.max_gathered_bytes,
+        "live_gathered_bytes": live_gathered_bytes,
+        "selected_candidate": task.node.name,
+        "path": path,
+        "candidate_allgather_bytes": task.allgathered_mem,
+        "candidate_peak_bytes": peak_bytes,
+        "over_budget_bytes": max(0, peak_bytes - scheduler_budget.max_gathered_bytes),
+    }
+
+
+def fast_free_schedule(graph: Graph,
+                       available_mem: int,
+                       output_size: int,
+                       debug_log: bool,
+                       *,
+                       scheduler_budget: Optional[SchedulerMemoryBudget] = None) -> Graph:
+    """Order a ZeRO-3 graph while limiting scheduler-managed gather residency.
+
+    The optional budget is already reduced across ranks by the caller.  With no
+    budget, this preserves the legacy candidate ordering.  With a budget, only
+    candidate simulations that fit are considered until all dependency levels
+    are exhausted; a deterministic least-over-budget path guarantees progress.
+    """
     node_to_last_use, user_to_last_uses = get_last_uses(graph)
+    diagnostics = {
+        "budget": scheduler_budget,
+        "budget_rejections": 0,
+        "budget_rejected_candidates": [],
+        "budget_overflows": [],
+        "selected": [],
+    }
 
     # check tensor size
     for node in graph.nodes:
@@ -293,6 +608,8 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
         graph)
 
     unscheduled_ags = [n for n in unscheduled if n.target == torch.ops.dc.allgather_param.default]
+    gathered_tracker = (_GatheredParamTracker(_build_release_expected(list(graph.nodes)))
+                        if scheduler_budget is not None else None)
 
     release_nodes = defaultdict(list)
     for n in unscheduled:
@@ -303,6 +620,9 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
     for ag_node in unscheduled_ags:
         last_use = node_to_last_use[ag_node]
         required_nodes = get_node_requirements(last_use, scheduled)
+        # Dependency gather count is the primary scheduling tier.  Searching
+        # higher tiers is allowed only when every candidate in a lower tier is
+        # infeasible under the shared memory budget.
         ag_nodes_in_path[ag_node] = set(n for n in required_nodes if n.target == torch.ops.dc.allgather_param.default)
 
     reduce_nodes = [n for n in unscheduled if n.target == torch.ops.dc.reduce_grad.default]
@@ -325,9 +645,12 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
         ag_nodes_count = {ag_node: len(nodes) for ag_node, nodes in ag_nodes_in_path.items()}
         count_list = sorted(set(ag_nodes_count.values()))
 
-        runnable_ags = []
+        over_budget_ags = []
+        next_ag = None
+        nodes_to_schedule = None
         for ag_count in count_list:
 
+            runnable_ags = []
             target_unscheduled_ags = [ag for ag in unscheduled_ags if ag_nodes_count[ag] == ag_count]
 
             for node in target_unscheduled_ags:
@@ -343,11 +666,13 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
 
                 allgather_cost = sum(n.meta["device_time"] for n in schedule_until_ag)
                 free_cost = sum(n.meta["device_time"] for n in diff_required_nodes)
-                allgathered_mem = node.meta["tensor_size"]
-                allgather_acc_mem = sum(n.meta["tensor_size"] for n in schedule_until_ag
-                                        if n.target == torch.ops.dc.allgather_param.default)
-                free_acc_mem = sum(n.meta["tensor_size"] for n in diff_required_nodes
-                                   if n.target == torch.ops.dc.allgather_param.default)
+                allgathered_mem = _allgather_allocation_bytes(node)
+                allgather_acc_mem = sum(
+                    _allgather_ranking_bytes(n) for n in schedule_until_ag
+                    if n.target == torch.ops.dc.allgather_param.default)
+                free_acc_mem = sum(
+                    _allgather_ranking_bytes(n) for n in diff_required_nodes
+                    if n.target == torch.ops.dc.allgather_param.default)
 
                 schedule_until_free = schedule_until_ag + diff_required_nodes
                 for release_node in release_nodes[ds_id]:
@@ -358,72 +683,124 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
                 n_scheduled_ags = len(
                     [n for n in schedule_until_free if n.target == torch.ops.dc.allgather_param.default])
 
+                if scheduler_budget is not None:
+                    # Candidate simulation starts from the residency committed
+                    # by earlier iterations and never mutates that prefix.
+                    schedule_until_ag_peak_mem, schedule_until_ag_live_mem = _simulate_path_stats(
+                        gathered_tracker, schedule_until_ag)
+                    schedule_until_free_peak_mem, schedule_until_free_live_mem = _simulate_path_stats(
+                        gathered_tracker, schedule_until_free)
+                else:
+                    schedule_until_ag_peak_mem = 0
+                    schedule_until_free_peak_mem = 0
+                    schedule_until_ag_live_mem = 0
+                    schedule_until_free_live_mem = 0
+
                 task = AllgatherTask(node, allgather_cost, free_cost, allgathered_mem, allgather_acc_mem, free_acc_mem,
-                                     last_use, n_scheduled_ags, schedule_until_ag, schedule_until_free)
+                                     last_use, n_scheduled_ags, schedule_until_ag, schedule_until_free,
+                                     schedule_until_ag_peak_mem, schedule_until_free_peak_mem,
+                                     schedule_until_ag_live_mem, schedule_until_free_live_mem)
 
                 # print(f" ag_count {ag_count} allgather runnable {i}: {node} last_use: {node_to_last_use[node]} t: {t2-t1:.2f}")
                 runnable_ags.append(task)
 
             if len(runnable_ags) > 0:
-                break
+                if scheduler_budget is None:
+                    next_ag, nodes_to_schedule = _select_allgather_task(runnable_ags, None)
+                    break
+                else:
+                    rejected = _rejected_budget_candidates(runnable_ags, scheduler_budget)
+                    diagnostics["budget_rejections"] += len(rejected)
+                    diagnostics["budget_rejected_candidates"].extend(rejected)
+                    next_ag, nodes_to_schedule = _select_allgather_task(runnable_ags, scheduler_budget)
+                    if next_ag is not None:
+                        assert not debug_log or nodes_to_schedule is not next_ag.schedule_until_free or next_ag.free_acc_mem == 0
+                        break
+                    over_budget_ags.extend(runnable_ags)
 
-        assert len(runnable_ags) > 0, "No runnable allgather nodes"
-
-        # Criteria of the choice:
-        # We want to choose allgather that does not require additional allgather until releasing the param.
-        # When we can find such a node, free_acc_mem will be zero. In that case, we choose the one with the smallest cost until free to minimize the period of occupying memory for the gathered param.
-        # If there is no such node, we choose the one with the smallest free_cost to minimize the period of occupying memory for the gathered param.
-        ags_with_no_additional_ag = [ag for ag in runnable_ags if ag.free_acc_mem == 0]
-        if len(ags_with_no_additional_ag) > 0:
-            sorted_ags = sorted(ags_with_no_additional_ag, key=_free_path_allgather_key)
-            next_ag = sorted_ags[0]
-            assert not debug_log or next_ag.free_acc_mem == 0
-            nodes_to_schedule = next_ag.schedule_until_free
-        else:
-            # sorted_ags = sorted(runnable_ags, key=lambda x: x.allgathered_mem)
-            sorted_ags = sorted(runnable_ags, key=_fallback_allgather_key)
-            next_ag = sorted_ags[0]
-            nodes_to_schedule = next_ag.schedule_until_ag
+        if next_ag is None:
+            if scheduler_budget is not None and len(over_budget_ags) > 0:
+                # Failing compilation cannot improve memory pressure. Commit
+                # the deterministic path with the smallest peak overage and
+                # retain the overflow in diagnostics instead.
+                next_ag, nodes_to_schedule = _select_over_budget_allgather_task(over_budget_ags, scheduler_budget)
+            else:
+                raise AssertionError("No runnable allgather nodes")
 
         # print(f" next_ag {next_ag}")
         for n in nodes_to_schedule:
+            # Only the selected path advances the committed residency model;
+            # rejected simulations operated on tracker copies above.
             scheduled.append(n)
             unscheduled.remove(n)
+            if gathered_tracker is not None:
+                gathered_tracker.apply(n)
 
-        unscheduled_ags.remove(next_ag.node)
+        scheduled_ags = [n for n in nodes_to_schedule if n.target == torch.ops.dc.allgather_param.default]
+        for scheduled_ag in scheduled_ags:
+            if scheduled_ag in unscheduled_ags:
+                unscheduled_ags.remove(scheduled_ag)
 
-        ag_nodes_in_path.pop(next_ag.node)
-        for ag_node, nodes in ag_nodes_in_path.items():
-            if next_ag.node in nodes:
-                nodes.remove(next_ag.node)
+            ag_nodes_in_path.pop(scheduled_ag, None)
+            for ag_node, nodes in ag_nodes_in_path.items():
+                if scheduled_ag in nodes:
+                    nodes.remove(scheduled_ag)
+
+        selected_diagnostic = {
+            "node": next_ag.node.name,
+            "path": "until_free" if nodes_to_schedule is next_ag.schedule_until_free else "until_ag",
+        }
+        if scheduler_budget is not None:
+            selected_diagnostic.update({
+                "live_gathered_bytes": gathered_tracker.live_bytes,
+                "peak_gathered_bytes": gathered_tracker.peak_bytes,
+                "schedule_until_ag_peak_mem": next_ag.schedule_until_ag_peak_mem,
+                "schedule_until_free_peak_mem": next_ag.schedule_until_free_peak_mem,
+                "schedule_until_ag_live_mem": next_ag.schedule_until_ag_live_mem,
+                "schedule_until_free_live_mem": next_ag.schedule_until_free_live_mem,
+            })
+        diagnostics["selected"].append(selected_diagnostic)
+        if scheduler_budget is not None:
+            selected_peak_bytes = (next_ag.schedule_until_free_peak_mem if nodes_to_schedule
+                                   is next_ag.schedule_until_free else next_ag.schedule_until_ag_peak_mem)
+            if selected_peak_bytes > scheduler_budget.max_gathered_bytes:
+                diagnostics["budget_overflows"].append(
+                    _budget_overflow_diagnostic(scheduler_budget, next_ag, diagnostics["selected"][-1]["path"],
+                                                diagnostics["selected"][-1]["live_gathered_bytes"]))
 
         # Schedule reduce nodes when possible to free memory earlier
         reduces_to_schedule = []
         for reduce_node in reduce_nodes:
-            if next_ag.node in ag_nodes_in_path_to_reduce_nodes[reduce_node]:
-                ag_nodes_in_path_to_reduce_nodes[reduce_node].remove(next_ag.node)
-                if len(ag_nodes_in_path_to_reduce_nodes[reduce_node]) == 0:
-                    reduces_to_schedule.append(reduce_node)
+            for scheduled_ag in scheduled_ags:
+                if scheduled_ag in ag_nodes_in_path_to_reduce_nodes[reduce_node]:
+                    ag_nodes_in_path_to_reduce_nodes[reduce_node].remove(scheduled_ag)
+            if len(ag_nodes_in_path_to_reduce_nodes[reduce_node]) == 0:
+                reduces_to_schedule.append(reduce_node)
 
         for n in reduces_to_schedule:
             need_to_schedule = get_node_requirements(n, scheduled)
             for nn in need_to_schedule:
                 scheduled.append(nn)
                 unscheduled.remove(nn)
+                if gathered_tracker is not None:
+                    gathered_tracker.apply(nn)
 
         # Do the same for output nodes
         outputs_to_schedule = []
         for output_node in output_nodes:
-            if next_ag.node in ag_nodes_in_path_to_output_nodes[output_node]:
-                ag_nodes_in_path_to_output_nodes[output_node].remove(next_ag.node)
-                if len(ag_nodes_in_path_to_output_nodes[output_node]) == 0:
-                    outputs_to_schedule.append(output_node)
+            for scheduled_ag in scheduled_ags:
+                if scheduled_ag in ag_nodes_in_path_to_output_nodes[output_node]:
+                    ag_nodes_in_path_to_output_nodes[output_node].remove(scheduled_ag)
+            if len(ag_nodes_in_path_to_output_nodes[output_node]) == 0:
+                outputs_to_schedule.append(output_node)
 
         for n in outputs_to_schedule:
             need_to_schedule = get_node_requirements(n, scheduled)
             for nn in need_to_schedule:
                 scheduled.append(nn)
                 unscheduled.remove(nn)
+                if gathered_tracker is not None:
+                    gathered_tracker.apply(nn)
 
     # print(f"After ag scheduled: scheduled: {scheduled}")
 
@@ -433,9 +810,12 @@ def fast_free_schedule(graph: Graph, available_mem: int, output_size: int, debug
             continue
         scheduled.append(node)
         unscheduled.remove(node)
+        if gathered_tracker is not None:
+            gathered_tracker.apply(node)
 
     assert len(unscheduled) == 0, f"There are unscheduled nodes: {unscheduled}"
 
     ret_graph = make_graph_from_schedule(scheduled)
+    setattr(ret_graph, DS_SCHEDULER_BUDGET_DIAGNOSTICS_ATTR, diagnostics)
     ret_graph.lint()
     return ret_graph

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -43,6 +43,7 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                       bwd: bool) -> GraphModule:
 
     profile = profiling_results[graph_id]
+    process_group = getattr(profile, "process_group", None)
     profile_graph = profile.bwd_graph if bwd else profile.fwd_graph
     mem_complete = profile.bwd_mem_complete if bwd else profile.fwd_mem_complete
     if is_profile_incomplete(profile_graph) or not mem_complete:
@@ -51,7 +52,7 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
 
     max_mem = get_accelerator().total_memory() * (1 - MARGIN)
     vals_to_bcast = torch.tensor([max_mem], device=torch.device(get_accelerator().current_device()))
-    dist.all_reduce(vals_to_bcast, dist.ReduceOp.MIN)
+    dist.all_reduce(vals_to_bcast, dist.ReduceOp.MIN, group=process_group)
     max_mem = vals_to_bcast[0].item()
 
     mem = profiling_results[graph_id].bwd_mem if bwd else profiling_results[graph_id].fwd_mem

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -246,19 +246,118 @@ def _add_prefetch_arena_release_dependencies(graph: Graph) -> None:
         pending_releases.clear()
 
 
-def _configure_prefetch_arena(graph: Graph, graph_id: int, param_manager: DSGraphParamManager, bwd: bool,
-                              process_group) -> None:
-    if not _env_enabled(PREFETCH_ARENA_ENV):
-        return
-    if not dist.is_initialized():
-        print_rank_0(f"prefetch_arena graph_id={graph_id} fallback=distributed_uninitialized")
-        return
+def _prefetch_arena_budget_admission(graph: Graph, plan: Dict, mem_dict: Dict[str, Tuple[int, int]],
+                                     reserved_mem_dict: Dict[str, int], max_mem: int):
+    """Check the fixed backing against the same profiled peaks as prefetch.
 
-    plan, reason = _build_prefetch_arena_plan(graph, param_manager, dist.get_world_size(group=process_group), bwd)
-    if plan is None:
-        print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} fallback={reason}")
-        return
+    The existing scheduler charges each gathered tensor only while it is live.
+    A flat arena instead keeps its full aligned capacity from the first arena
+    prefetch through graph completion.  Admission therefore replaces the live
+    eligible-gather charge with the fixed capacity; it must not add capacity on
+    top of those same live bytes.
+    """
+    intervals = plan["intervals"]
+    previous_peak = 0
+    original_allocated_peak = 0
+    arena_allocated_peak = 0
+    original_reserved_peak = 0
+    arena_reserved_peak = 0
+    original_modeled_peak = 0
+    arena_modeled_peak = 0
+    limiting_node = None
+    limiting_metric = None
+    previous_reserved_peak = 0
 
+    for index, node in enumerate(graph.nodes):
+        if node.name in mem_dict:
+            previous_peak = int(mem_dict[node.name][1])
+        if node.name in reserved_mem_dict:
+            previous_reserved_peak = int(reserved_mem_dict[node.name])
+        live_gather_bytes = sum(
+            int(interval["bytes"]) for interval in intervals if interval["start"] <= index <= interval["end"])
+        # Keep the scheduler's existing conservative model: the profiled peak
+        # is treated as non-gather residency and scheduled gathers are charged
+        # separately according to the final prefetch lifetimes.
+        original_at_node = previous_peak + live_gather_bytes
+        # Native backing survives executor reuse and is shared by forward and
+        # backward, so after warmup it is resident for the complete graph, not
+        # merely between the first and last interval in this invocation.
+        arena_at_node = previous_peak + int(plan["capacity"])
+        original_allocated_peak = max(original_allocated_peak, original_at_node)
+        original_reserved_at_node = previous_reserved_peak
+        # Cached fragmentation and every unrelated reservation remain charged.
+        # Do not assume that fragmented cached blocks can satisfy the arena's
+        # single contiguous backing allocation.
+        arena_reserved_at_node = previous_reserved_peak + int(plan["capacity"])
+        original_reserved_peak = max(original_reserved_peak, original_reserved_at_node)
+        arena_reserved_peak = max(arena_reserved_peak, arena_reserved_at_node)
+        original_modeled_peak = max(original_modeled_peak, original_at_node, original_reserved_at_node)
+        arena_allocated_peak = max(arena_allocated_peak, arena_at_node)
+        effective_arena_peak = max(arena_at_node, arena_reserved_at_node)
+        if effective_arena_peak > arena_modeled_peak:
+            arena_modeled_peak = effective_arena_peak
+            limiting_node = node.name
+            limiting_metric = "reserved" if arena_reserved_at_node >= arena_at_node else "allocated"
+
+    return {
+        "accepted": arena_modeled_peak <= int(max_mem),
+        "max_mem": int(max_mem),
+        "capacity": int(plan["capacity"]),
+        "original_allocated_peak": original_allocated_peak,
+        "arena_allocated_peak": arena_allocated_peak,
+        "original_modeled_peak": original_modeled_peak,
+        "arena_modeled_peak": arena_modeled_peak,
+        "original_reserved_peak": original_reserved_peak,
+        "arena_reserved_peak": arena_reserved_peak,
+        "incremental_peak": arena_modeled_peak - original_modeled_peak,
+        "limiting_node": limiting_node,
+        "limiting_metric": limiting_metric,
+    }
+
+
+def _training_session_budget_admission(forward_graph: Graph, forward_plan: Dict, forward_mem_dict: Dict[str,
+                                                                                                        Tuple[int,
+                                                                                                              int]],
+                                       forward_reserved_mem_dict: Dict[str, int], backward_graph: Graph,
+                                       backward_plan: Dict, backward_mem_dict: Dict[str, Tuple[int, int]],
+                                       backward_reserved_mem_dict: Dict[str, int], max_mem: int):
+    """Admit the final shared backing against both actual phase plans.
+
+    The forward plan is metadata-only until AOTAutograd lazily invokes the
+    backward compiler.  At that point both interval packs and both original
+    memory profiles are known, so the shared capacity can be charged to each
+    phase without either a forward-only allocation or a pessimistic estimate.
+    """
+    capacity_bound = max(int(forward_plan["capacity"]), int(backward_plan["capacity"]))
+    bounded_forward_plan = dict(forward_plan, capacity=capacity_bound)
+    bounded_backward_plan = dict(backward_plan, capacity=capacity_bound)
+    forward = _prefetch_arena_budget_admission(forward_graph, bounded_forward_plan, forward_mem_dict,
+                                               forward_reserved_mem_dict, max_mem)
+    backward = _prefetch_arena_budget_admission(backward_graph, bounded_backward_plan, backward_mem_dict,
+                                                backward_reserved_mem_dict, max_mem)
+    return {
+        "accepted": forward["accepted"] and backward["accepted"],
+        "max_mem": int(max_mem),
+        "capacity_bound": capacity_bound,
+        "forward_arena_peak": int(forward["arena_modeled_peak"]),
+        "backward_arena_peak": int(backward["arena_modeled_peak"]),
+        "forward_original_peak": int(forward["original_modeled_peak"]),
+        "backward_original_peak": int(backward["original_modeled_peak"]),
+    }
+
+
+def _disable_prefetch_arena(graph: Graph) -> None:
+    """Restore the exact original fused-prefetch call shape before lowering."""
+    for node in graph.nodes:
+        if node.target != torch.ops.dc.prefetch_params_fused.default or len(node.args) < 5:
+            continue
+        node.args = tuple(node.args[:3])
+        node.meta.pop("prefetch_arena_eligible_ds_ids", None)
+        node.meta.pop("prefetch_arena_bytes_by_ds_id", None)
+        node.meta.pop("prefetch_arena_ordering_dependencies", None)
+
+
+def _configure_prefetch_arena(graph: Graph, graph_id: int, plan: Dict, require_backward: bool) -> None:
     entries = plan["entries"]
     # Configure the rank-local immutable plan here, but defer cross-rank
     # consensus until the first fused-prefetch execution.  Compilation can run
@@ -266,7 +365,7 @@ def _configure_prefetch_arena(graph: Graph, graph_id: int, param_manager: DSGrap
     # process-group collective in this pass can cross graph-compilation
     # lifetimes and deadlock.  The native executor verifies the complete plan
     # digest on its communication stream before admitting any arena slice.
-    get_deepcompile_handle().configure_z3_prefetch_arena(graph_id, plan["phase"], plan["capacity"],
+    get_deepcompile_handle().configure_z3_prefetch_arena(graph_id, plan["phase"], require_backward, plan["capacity"],
                                                          plan["max_live_bytes"], plan["digest"],
                                                          [entry["plan_id"]
                                                           for entry in entries], [entry["ds_id"] for entry in entries],
@@ -275,7 +374,8 @@ def _configure_prefetch_arena(graph: Graph, graph_id: int, param_manager: DSGrap
     ordering_dependencies = sum(
         len(node.meta.get("prefetch_arena_ordering_dependencies", ())) for node in graph.nodes
         if node.target == torch.ops.dc.prefetch_params_fused.default)
-    print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} capacity={plan['capacity']} "
+    print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if plan['phase'] else 'fwd'} "
+                 f"capacity={plan['capacity']} "
                  f"max_live_bytes={plan['max_live_bytes']} internal_fragmentation={plan['internal_fragmentation']} "
                  f"entries={len(entries)} ordering_dependencies={ordering_dependencies} digest={plan['digest']}")
 
@@ -295,6 +395,7 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                       bwd: bool) -> GraphModule:
 
     profile = profiling_results[graph_id]
+    require_backward = bool(profile.needs_backward)
     process_group = getattr(profile, "process_group", None)
     profile_graph = profile.bwd_graph if bwd else profile.fwd_graph
     mem_complete = profile.bwd_mem_complete if bwd else profile.fwd_mem_complete
@@ -312,6 +413,10 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
     tensor_sizes = profiling_results[graph_id].bwd_tensor_sizes if bwd else profiling_results[graph_id].fwd_tensor_sizes
 
     mem_dict = {name: (alloc_mem, peak) for name, alloc_mem, delta, peak in mem}
+    reserved_mem_dict = {
+        node.name: int(node.meta["profile_reserved_peak"])
+        for node in profile_graph.nodes if "profile_reserved_peak" in node.meta
+    }
     time_dict = {name: (device_time, wall_time) for name, device_time, wall_time in op_time}
     tensor_size_dict = {name: size for name, size in tensor_sizes}
 
@@ -455,12 +560,99 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
             else:
                 new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
                                         args=(graph_id, param_nodes_copy, ds_ids))
+    arena_plan = None
     if arena_enabled:
-        _add_prefetch_arena_release_dependencies(new_graph)
+        if not dist.is_initialized():
+            arena_reason = "distributed_uninitialized"
+        else:
+            arena_plan, arena_reason = _build_prefetch_arena_plan(new_graph, graph_param_manager,
+                                                                  dist.get_world_size(group=process_group), bwd)
+        if arena_plan is not None:
+            if len(reserved_mem_dict) != len(list(profile_graph.nodes)):
+                arena_plan = None
+                arena_reason = "incomplete_reserved_profile"
+            else:
+                admission = _prefetch_arena_budget_admission(new_graph, arena_plan, mem_dict, reserved_mem_dict,
+                                                             max_mem)
+        if arena_plan is not None:
+            print_rank_0(f"prefetch_arena_admission graph_id={graph_id} "
+                         f"phase={'bwd' if bwd else 'fwd'} accepted={int(admission['accepted'])} "
+                         f"max_mem={admission['max_mem']} capacity={admission['capacity']} "
+                         f"original_allocated_peak={admission['original_allocated_peak']} "
+                         f"arena_allocated_peak={admission['arena_allocated_peak']} "
+                         f"original_modeled_peak={admission['original_modeled_peak']} "
+                         f"arena_modeled_peak={admission['arena_modeled_peak']} "
+                         f"original_reserved_peak={admission['original_reserved_peak']} "
+                         f"arena_reserved_peak={admission['arena_reserved_peak']} "
+                         f"incremental_peak={admission['incremental_peak']} "
+                         f"limiting_node={admission['limiting_node']} "
+                         f"limiting_metric={admission['limiting_metric']}")
+            if not admission["accepted"]:
+                if require_backward and not bwd:
+                    profile.prefetch_arena_session_accepted = False
+                    profile.prefetch_arena_session_reason = "shared_budget"
+                arena_plan = None
+                arena_reason = "shared_budget"
+        if arena_plan is not None and require_backward:
+            if not bwd:
+                # The optimized backward does not exist yet.  Keep the final
+                # forward plan as native metadata, but native execution will
+                # deliberately use the normal gather pool until the backward
+                # compiler registers its plan and decides the shared budget.
+                profile.prefetch_arena_forward_graph = new_graph
+                profile.prefetch_arena_forward_plan = arena_plan
+                profile.prefetch_arena_forward_mem = dict(mem_dict)
+                profile.prefetch_arena_forward_reserved_mem = dict(reserved_mem_dict)
+                profile.prefetch_arena_session_accepted = None
+                profile.prefetch_arena_session_capacity_bound = 0
+                profile.prefetch_arena_session_reason = None
+                print_rank_0(f"prefetch_arena_session_pending graph_id={graph_id} "
+                             f"forward_capacity={arena_plan['capacity']}")
+            elif profile.prefetch_arena_session_accepted is False:
+                arena_plan = None
+                arena_reason = profile.prefetch_arena_session_reason or "session_not_admitted"
+            elif (profile.prefetch_arena_forward_graph is None or profile.prefetch_arena_forward_plan is None
+                  or profile.prefetch_arena_forward_mem is None
+                  or profile.prefetch_arena_forward_reserved_mem is None):
+                arena_plan = None
+                arena_reason = "incomplete_forward_arena_profile"
+            else:
+                session_admission = _training_session_budget_admission(profile.prefetch_arena_forward_graph,
+                                                                       profile.prefetch_arena_forward_plan,
+                                                                       profile.prefetch_arena_forward_mem,
+                                                                       profile.prefetch_arena_forward_reserved_mem,
+                                                                       new_graph, arena_plan, mem_dict,
+                                                                       reserved_mem_dict, max_mem)
+                profile.prefetch_arena_session_accepted = bool(session_admission["accepted"])
+                profile.prefetch_arena_session_capacity_bound = int(session_admission["capacity_bound"])
+                profile.prefetch_arena_session_reason = (None if session_admission["accepted"] else "shared_budget")
+                print_rank_0(f"prefetch_arena_session_admission graph_id={graph_id} "
+                             f"accepted={int(session_admission['accepted'])} "
+                             f"max_mem={session_admission['max_mem']} "
+                             f"capacity_bound={session_admission['capacity_bound']} "
+                             f"forward_original_peak={session_admission['forward_original_peak']} "
+                             f"forward_arena_peak={session_admission['forward_arena_peak']} "
+                             f"backward_original_peak={session_admission['backward_original_peak']} "
+                             f"backward_arena_peak={session_admission['backward_arena_peak']}")
+                if not session_admission["accepted"]:
+                    arena_plan = None
+                    arena_reason = "shared_budget"
+        if arena_plan is None:
+            print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} "
+                         f"fallback={arena_reason}")
+            _disable_prefetch_arena(new_graph)
+            # Forward may already have registered a pending training-session
+            # plan.  A later backward rejection must invalidate that native
+            # metadata as one session decision, not leave a forward-only arena
+            # available on a subsequent compile/execution.
+            if bwd and require_backward:
+                get_deepcompile_handle().disable_z3_prefetch_arena(graph_id, arena_reason)
+        else:
+            _add_prefetch_arena_release_dependencies(new_graph)
     new_graph.lint()
     gm.graph = new_graph
 
-    if arena_enabled:
-        _configure_prefetch_arena(new_graph, graph_id, graph_param_manager, bwd, process_group)
+    if arena_plan is not None:
+        _configure_prefetch_arena(new_graph, graph_id, arena_plan, require_backward)
 
     return gm

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -3,7 +3,10 @@
 
 # DeepSpeed Team
 
-from typing import List, Tuple
+import hashlib
+import math
+import os
+from typing import Dict, List, Tuple
 
 import torch
 from torch.fx import Graph, Node, GraphModule
@@ -14,6 +17,7 @@ import deepspeed.comm as dist
 from ..profilers.comm_profile import create_predictor
 from ..profilers.graph_profile import is_profile_incomplete
 from ..graph_param import DSGraphParamManager
+from ..util import get_deepcompile_handle
 from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 NAME = "prefetch"
@@ -27,6 +31,254 @@ MAX_BUFFERED_SIZE = 4e9
 
 run_prefetch_pass = False
 
+PREFETCH_ARENA_ENV = "DEEPSPEED_COMPILE_PREFETCH_ARENA"
+PREFETCH_ARENA_ALIGNMENT = 256
+
+
+def _env_enabled(name: str) -> bool:
+    value = os.environ.get(name, "").strip().lower()
+    return value not in ("", "0", "false", "no")
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return ((int(value) + alignment - 1) // alignment) * alignment
+
+
+def _release_n_users(node: Node) -> int:
+    return int(node.args[3]) if len(node.args) > 3 else 1
+
+
+def _pack_prefetch_intervals(intervals: List[Dict], alignment: int = PREFETCH_ARENA_ALIGNMENT):
+    """Pack fixed scheduled lifetimes into aligned slices of one stable backing."""
+    if alignment <= 0:
+        return None, "invalid_alignment"
+
+    packed = []
+    active = []
+    free_blocks = []
+    capacity = 0
+    live_bytes = 0
+    max_live_bytes = 0
+
+    def add_free_block(offset, size):
+        free_blocks.append((offset, size))
+        free_blocks.sort()
+        merged = []
+        for block_offset, block_size in free_blocks:
+            if merged and merged[-1][0] + merged[-1][1] == block_offset:
+                prev_offset, prev_size = merged[-1]
+                merged[-1] = (prev_offset, prev_size + block_size)
+            else:
+                merged.append((block_offset, block_size))
+        free_blocks[:] = merged
+
+    for interval in sorted(intervals, key=lambda item: (item["start"], item["end"], item["ds_id"])):
+        size = _align_up(interval["bytes"], alignment)
+        still_active = []
+        for active_interval in active:
+            if active_interval["end"] < interval["start"]:
+                add_free_block(active_interval["offset"], active_interval["size"])
+                live_bytes -= active_interval["size"]
+            else:
+                still_active.append(active_interval)
+        active = still_active
+
+        offset = None
+        for index, (block_offset, block_size) in enumerate(free_blocks):
+            if block_size < size:
+                continue
+            offset = block_offset
+            if block_size == size:
+                free_blocks.pop(index)
+            else:
+                free_blocks[index] = (block_offset + size, block_size - size)
+            break
+        if offset is None:
+            offset = capacity
+            capacity += size
+
+        packed_interval = dict(interval, offset=offset, size=size)
+        packed.append(packed_interval)
+        active.append(packed_interval)
+        live_bytes += size
+        max_live_bytes = max(max_live_bytes, live_bytes)
+
+    return {
+        "capacity": capacity,
+        "max_live_bytes": max_live_bytes,
+        "internal_fragmentation": capacity - max_live_bytes,
+        "intervals": packed,
+    }, None
+
+
+def _build_prefetch_arena_plan(graph: Graph,
+                               param_manager: DSGraphParamManager,
+                               world_size: int,
+                               bwd: bool,
+                               alignment: int = PREFETCH_ARENA_ALIGNMENT):
+    """Derive attempt-0 arena slices solely from final fused-prefetch lifetimes."""
+    if world_size <= 0:
+        return None, "invalid_world_size"
+
+    params_by_ds_id = {}
+    for name, param in param_manager.params.items():
+        ds_id = int(param_manager.ds_ids[name])
+        previous = params_by_ds_id.get(ds_id)
+        if previous is not None and (previous.shape != param.shape or previous.dtype != param.dtype):
+            return None, "repeated_id_metadata_mismatch"
+        params_by_ds_id[ds_id] = param
+
+    nodes = list(graph.nodes)
+    intervals = []
+    active = {}
+    for index, node in enumerate(nodes):
+        if node.target == torch.ops.dc.prefetch_params_fused.default:
+            plan_id = int(node.args[4]) if len(node.args) > 4 else -1
+            eligible = set(node.meta.get("prefetch_arena_eligible_ds_ids", ()))
+            scheduled_bytes = dict(node.meta.get("prefetch_arena_bytes_by_ds_id", ()))
+            seen_in_prefetch = set()
+            for ds_id_value in node.args[2]:
+                ds_id = int(ds_id_value)
+                if plan_id < 0 or ds_id not in eligible or ds_id in seen_in_prefetch:
+                    continue
+                seen_in_prefetch.add(ds_id)
+                param = params_by_ds_id.get(ds_id)
+                if param is None:
+                    return None, "missing_param_metadata"
+                try:
+                    true_numel = math.prod(int(dim) for dim in param.shape)
+                except (TypeError, ValueError):
+                    return None, "dynamic_shape"
+                if true_numel <= 0:
+                    return None, "dynamic_shape"
+                element_size = torch.empty((), dtype=param.dtype).element_size()
+                padded_numel = ((true_numel + world_size - 1) // world_size) * world_size
+                computed_bytes = padded_numel * element_size
+                request_bytes = int(scheduled_bytes.get(ds_id, 0))
+                if request_bytes <= 0:
+                    return None, "missing_scheduled_bytes"
+                if request_bytes != computed_bytes:
+                    return None, "scheduled_bytes_mismatch"
+
+                interval = active.get(ds_id)
+                if interval is None:
+                    interval = {
+                        "ds_id": ds_id,
+                        "start": index,
+                        "end": None,
+                        "bytes": request_bytes,
+                        "requests": [],
+                        "release_expected": None,
+                        "release_seen": 0,
+                    }
+                    active[ds_id] = interval
+                    intervals.append(interval)
+                elif interval["bytes"] != request_bytes:
+                    return None, "repeated_id_size_mismatch"
+                interval["requests"].append((plan_id, ds_id))
+
+        elif node.target == torch.ops.dc.release_param.default:
+            ds_id = int(node.args[2])
+            if ds_id not in active:
+                continue
+            interval = active[ds_id]
+            if interval["release_expected"] is None:
+                interval["release_expected"] = max(1, _release_n_users(node))
+            interval["release_seen"] += 1
+            if interval["release_seen"] >= interval["release_expected"]:
+                active.pop(ds_id)["end"] = index
+
+    if active:
+        return None, "incomplete_release"
+    if not intervals:
+        return None, "no_eligible_prefetch"
+
+    packed, reason = _pack_prefetch_intervals(intervals, alignment)
+    if packed is None:
+        return None, reason
+
+    entries = []
+    for interval in packed["intervals"]:
+        for plan_id, ds_id in interval["requests"]:
+            entries.append({
+                "plan_id": plan_id,
+                "ds_id": ds_id,
+                "offset": interval["offset"],
+                "bytes": interval["bytes"],
+            })
+    entries.sort(key=lambda entry: (entry["plan_id"], entry["ds_id"]))
+    packed["entries"] = entries
+    packed["phase"] = 1 if bwd else 0
+    digest_payload = repr((packed["phase"], packed["capacity"], packed["max_live_bytes"], entries)).encode()
+    packed["digest"] = int.from_bytes(hashlib.sha256(digest_payload).digest()[:8], "big") & ((1 << 63) - 1)
+    return packed, None
+
+
+def _add_prefetch_arena_release_dependencies(graph: Graph) -> None:
+    """Keep arena-reusing prefetches after releases that make slices free.
+
+    ``prefetch_params_fused`` otherwise consumes no value produced by a
+    preceding release, so Inductor may advance it ahead of the FX order used
+    by the arena lifetime planner. The native prefetch ignores its ``params``
+    values, allowing release outputs to act as ordering-only inputs without
+    changing the collective payload.
+    """
+    arena_ds_ids = {
+        int(ds_id)
+        for node in graph.nodes if node.target == torch.ops.dc.prefetch_params_fused.default
+        for ds_id in node.meta.get("prefetch_arena_eligible_ds_ids", ())
+    }
+    pending_releases = []
+    for node in graph.nodes:
+        if node.target == torch.ops.dc.release_param.default:
+            if int(node.args[2]) in arena_ds_ids:
+                pending_releases.append(node)
+            continue
+        if node.target != torch.ops.dc.prefetch_params_fused.default or len(node.args) < 5:
+            continue
+        if int(node.args[4]) < 0 or not pending_releases:
+            continue
+
+        args = list(node.args)
+        args[1] = [*args[1], *pending_releases]
+        node.args = tuple(args)
+        node.meta["prefetch_arena_ordering_dependencies"] = tuple(release.name for release in pending_releases)
+        pending_releases.clear()
+
+
+def _configure_prefetch_arena(graph: Graph, graph_id: int, param_manager: DSGraphParamManager, bwd: bool,
+                              process_group) -> None:
+    if not _env_enabled(PREFETCH_ARENA_ENV):
+        return
+    if not dist.is_initialized():
+        print_rank_0(f"prefetch_arena graph_id={graph_id} fallback=distributed_uninitialized")
+        return
+
+    plan, reason = _build_prefetch_arena_plan(graph, param_manager, dist.get_world_size(group=process_group), bwd)
+    if plan is None:
+        print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} fallback={reason}")
+        return
+
+    entries = plan["entries"]
+    # Configure the rank-local immutable plan here, but defer cross-rank
+    # consensus until the first fused-prefetch execution.  Compilation can run
+    # concurrently and in a different order on each rank, so a blocking
+    # process-group collective in this pass can cross graph-compilation
+    # lifetimes and deadlock.  The native executor verifies the complete plan
+    # digest on its communication stream before admitting any arena slice.
+    get_deepcompile_handle().configure_z3_prefetch_arena(graph_id, plan["phase"], plan["capacity"],
+                                                         plan["max_live_bytes"], plan["digest"],
+                                                         [entry["plan_id"]
+                                                          for entry in entries], [entry["ds_id"] for entry in entries],
+                                                         [entry["offset"]
+                                                          for entry in entries], [entry["bytes"] for entry in entries])
+    ordering_dependencies = sum(
+        len(node.meta.get("prefetch_arena_ordering_dependencies", ())) for node in graph.nodes
+        if node.target == torch.ops.dc.prefetch_params_fused.default)
+    print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} capacity={plan['capacity']} "
+                 f"max_live_bytes={plan['max_live_bytes']} internal_fragmentation={plan['internal_fragmentation']} "
+                 f"entries={len(entries)} ordering_dependencies={ordering_dependencies} digest={plan['digest']}")
+
 
 def print_rank_0(message):
     if dist.get_rank() == 0:
@@ -39,7 +291,7 @@ def get_ds_id(node: Node):
 
 
 def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int, bool]], profiling_results,
-                      create_inputs_fn, mem_budget: float, param_manager: DSGraphParamManager,
+                      create_inputs_fn, mem_budget: float, param_manager: Dict[int, DSGraphParamManager],
                       bwd: bool) -> GraphModule:
 
     profile = profiling_results[graph_id]
@@ -167,6 +419,10 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
 
         assert ag_tensor_size_sum >= 0
 
+    arena_enabled = _env_enabled(PREFETCH_ARENA_ENV)
+    graph_param_manager = param_manager[graph_id] if arena_enabled else None
+    phase_plan_base = 1_000_000 if bwd else 0
+    fused_group_index = 0
     new_graph = Graph()
     env = {}
     for node in reversed(new_order_rev):
@@ -179,9 +435,32 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
             param_nodes_copy = [env[param_node.name] for param_node in param_nodes]
 
             ds_ids = [get_ds_id(ag_node) for ag_node in node]
-            new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
-                                    args=(graph_id, param_nodes_copy, ds_ids))
+            if arena_enabled:
+                plan_id = phase_plan_base + fused_group_index
+                prefetch_node = new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
+                                                        args=(graph_id, param_nodes_copy, ds_ids, None, plan_id))
+                eligible_ds_ids = []
+                arena_bytes_by_ds_id = []
+                for ag_node, param_node, ds_id in zip(node, param_nodes, ds_ids):
+                    param = graph_param_manager.params.get(param_node.name)
+                    requested_dtype = ag_node.kwargs.get("dtype")
+                    persistent = param is None or bool(getattr(param.param, "ds_persist", False))
+                    if param is not None and not persistent and (requested_dtype is None
+                                                                 or requested_dtype == param.dtype):
+                        eligible_ds_ids.append(ds_id)
+                        arena_bytes_by_ds_id.append((ds_id, int(ag_node.meta.get("allgather_allocation_bytes", 0))))
+                prefetch_node.meta["prefetch_arena_eligible_ds_ids"] = tuple(eligible_ds_ids)
+                prefetch_node.meta["prefetch_arena_bytes_by_ds_id"] = tuple(arena_bytes_by_ds_id)
+                fused_group_index += 1
+            else:
+                new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
+                                        args=(graph_id, param_nodes_copy, ds_ids))
+    if arena_enabled:
+        _add_prefetch_arena_release_dependencies(new_graph)
     new_graph.lint()
     gm.graph = new_graph
+
+    if arena_enabled:
+        _configure_prefetch_arena(new_graph, graph_id, graph_param_manager, bwd, process_group)
 
     return gm

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -84,15 +84,15 @@ def _pack_prefetch_intervals(intervals: List[Dict], alignment: int = PREFETCH_AR
         active = still_active
 
         offset = None
-        for index, (block_offset, block_size) in enumerate(free_blocks):
-            if block_size < size:
-                continue
+        fitting_blocks = [(block_size, block_offset, index)
+                          for index, (block_offset, block_size) in enumerate(free_blocks) if block_size >= size]
+        if fitting_blocks:
+            block_size, block_offset, index = min(fitting_blocks)
             offset = block_offset
             if block_size == size:
                 free_blocks.pop(index)
             else:
                 free_blocks[index] = (block_offset + size, block_size - size)
-            break
         if offset is None:
             offset = capacity
             capacity += size
@@ -246,15 +246,21 @@ def _add_prefetch_arena_release_dependencies(graph: Graph) -> None:
         pending_releases.clear()
 
 
-def _prefetch_arena_budget_admission(graph: Graph, plan: Dict, mem_dict: Dict[str, Tuple[int, int]],
-                                     reserved_mem_dict: Dict[str, int], max_mem: int):
+def _prefetch_arena_budget_admission(graph: Graph,
+                                     plan: Dict,
+                                     mem_dict: Dict[str, Tuple[int, int]],
+                                     reserved_mem_dict: Dict[str, int],
+                                     max_mem: int,
+                                     pool_reclaimable_dict: Dict[str, int] = None):
     """Check the fixed backing against the same profiled peaks as prefetch.
 
     The existing scheduler charges each gathered tensor only while it is live.
     A flat arena instead keeps its full aligned capacity from the first arena
     prefetch through graph completion.  Admission therefore replaces the live
     eligible-gather charge with the fixed capacity; it must not add capacity on
-    top of those same live bytes.
+    top of those same live bytes. Native execution also retires the old gather
+    pool and flushes allocator cache before allocating the backing, so the
+    projected allocated peak removes the pool charge measured at each node.
     """
     intervals = plan["intervals"]
     previous_peak = 0
@@ -266,13 +272,18 @@ def _prefetch_arena_budget_admission(graph: Graph, plan: Dict, mem_dict: Dict[st
     arena_modeled_peak = 0
     limiting_node = None
     limiting_metric = None
+    limiting_pool_reclaimable_bytes = 0
     previous_reserved_peak = 0
+    previous_pool_reclaimable = 0
+    pool_reclaimable_dict = pool_reclaimable_dict or {}
 
     for index, node in enumerate(graph.nodes):
         if node.name in mem_dict:
             previous_peak = int(mem_dict[node.name][1])
         if node.name in reserved_mem_dict:
             previous_reserved_peak = int(reserved_mem_dict[node.name])
+        if node.name in pool_reclaimable_dict:
+            previous_pool_reclaimable = int(pool_reclaimable_dict[node.name])
         live_gather_bytes = sum(
             int(interval["bytes"]) for interval in intervals if interval["start"] <= index <= interval["end"])
         # Keep the scheduler's existing conservative model: the profiled peak
@@ -282,22 +293,31 @@ def _prefetch_arena_budget_admission(graph: Graph, plan: Dict, mem_dict: Dict[st
         # Native backing survives executor reuse and is shared by forward and
         # backward, so after warmup it is resident for the complete graph, not
         # merely between the first and last interval in this invocation.
-        arena_at_node = previous_peak + int(plan["capacity"])
+        # The optimized graph inserts fused-prefetch nodes that do not exist in
+        # the profiling graph. Carry the most recent profiled pool charge over
+        # such nodes just as the existing memory projection carries its peak.
+        pool_reclaimable_at_node = min(previous_peak, previous_pool_reclaimable)
+        arena_at_node = previous_peak - pool_reclaimable_at_node + int(plan["capacity"])
         original_allocated_peak = max(original_allocated_peak, original_at_node)
         original_reserved_at_node = previous_reserved_peak
-        # Cached fragmentation and every unrelated reservation remain charged.
-        # Do not assume that fragmented cached blocks can satisfy the arena's
-        # single contiguous backing allocation.
+        # Keep the pre-transition reserved projection for diagnostics. Arena
+        # execution has a stronger runtime contract: it retires the old gather
+        # pool and performs one allocator-cache flush before allocating the
+        # fixed backing. Admission must therefore not add the arena to unused
+        # cache that the transition has guaranteed to release. The existing
+        # 10% max_mem margin remains available for non-releasable fragmentation
+        # and unrelated allocator growth.
         arena_reserved_at_node = previous_reserved_peak + int(plan["capacity"])
         original_reserved_peak = max(original_reserved_peak, original_reserved_at_node)
         arena_reserved_peak = max(arena_reserved_peak, arena_reserved_at_node)
         original_modeled_peak = max(original_modeled_peak, original_at_node, original_reserved_at_node)
         arena_allocated_peak = max(arena_allocated_peak, arena_at_node)
-        effective_arena_peak = max(arena_at_node, arena_reserved_at_node)
+        effective_arena_peak = arena_at_node
         if effective_arena_peak > arena_modeled_peak:
             arena_modeled_peak = effective_arena_peak
             limiting_node = node.name
-            limiting_metric = "reserved" if arena_reserved_at_node >= arena_at_node else "allocated"
+            limiting_metric = "allocated_after_pool_drain_and_empty_cache"
+            limiting_pool_reclaimable_bytes = pool_reclaimable_at_node
 
     return {
         "accepted": arena_modeled_peak <= int(max_mem),
@@ -312,15 +332,21 @@ def _prefetch_arena_budget_admission(graph: Graph, plan: Dict, mem_dict: Dict[st
         "incremental_peak": arena_modeled_peak - original_modeled_peak,
         "limiting_node": limiting_node,
         "limiting_metric": limiting_metric,
+        "limiting_pool_reclaimable_bytes": limiting_pool_reclaimable_bytes,
     }
 
 
-def _training_session_budget_admission(forward_graph: Graph, forward_plan: Dict, forward_mem_dict: Dict[str,
-                                                                                                        Tuple[int,
-                                                                                                              int]],
-                                       forward_reserved_mem_dict: Dict[str, int], backward_graph: Graph,
-                                       backward_plan: Dict, backward_mem_dict: Dict[str, Tuple[int, int]],
-                                       backward_reserved_mem_dict: Dict[str, int], max_mem: int):
+def _training_session_budget_admission(forward_graph: Graph,
+                                       forward_plan: Dict,
+                                       forward_mem_dict: Dict[str, Tuple[int, int]],
+                                       forward_reserved_mem_dict: Dict[str, int],
+                                       backward_graph: Graph,
+                                       backward_plan: Dict,
+                                       backward_mem_dict: Dict[str, Tuple[int, int]],
+                                       backward_reserved_mem_dict: Dict[str, int],
+                                       max_mem: int,
+                                       forward_pool_reclaimable_dict: Dict[str, int] = None,
+                                       backward_pool_reclaimable_dict: Dict[str, int] = None):
     """Admit the final shared backing against both actual phase plans.
 
     The forward plan is metadata-only until AOTAutograd lazily invokes the
@@ -332,9 +358,9 @@ def _training_session_budget_admission(forward_graph: Graph, forward_plan: Dict,
     bounded_forward_plan = dict(forward_plan, capacity=capacity_bound)
     bounded_backward_plan = dict(backward_plan, capacity=capacity_bound)
     forward = _prefetch_arena_budget_admission(forward_graph, bounded_forward_plan, forward_mem_dict,
-                                               forward_reserved_mem_dict, max_mem)
+                                               forward_reserved_mem_dict, max_mem, forward_pool_reclaimable_dict)
     backward = _prefetch_arena_budget_admission(backward_graph, bounded_backward_plan, backward_mem_dict,
-                                                backward_reserved_mem_dict, max_mem)
+                                                backward_reserved_mem_dict, max_mem, backward_pool_reclaimable_dict)
     return {
         "accepted": forward["accepted"] and backward["accepted"],
         "max_mem": int(max_mem),
@@ -343,6 +369,8 @@ def _training_session_budget_admission(forward_graph: Graph, forward_plan: Dict,
         "backward_arena_peak": int(backward["arena_modeled_peak"]),
         "forward_original_peak": int(forward["original_modeled_peak"]),
         "backward_original_peak": int(backward["original_modeled_peak"]),
+        "forward_pool_reclaimable_bytes": int(forward["limiting_pool_reclaimable_bytes"]),
+        "backward_pool_reclaimable_bytes": int(backward["limiting_pool_reclaimable_bytes"]),
     }
 
 
@@ -416,6 +444,10 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
     reserved_mem_dict = {
         node.name: int(node.meta["profile_reserved_peak"])
         for node in profile_graph.nodes if "profile_reserved_peak" in node.meta
+    }
+    pool_reclaimable_dict = {
+        node.name: int(node.meta.get("profile_gather_pool_charged", 0))
+        for node in profile_graph.nodes
     }
     time_dict = {name: (device_time, wall_time) for name, device_time, wall_time in op_time}
     tensor_size_dict = {name: size for name, size in tensor_sizes}
@@ -573,7 +605,7 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                 arena_reason = "incomplete_reserved_profile"
             else:
                 admission = _prefetch_arena_budget_admission(new_graph, arena_plan, mem_dict, reserved_mem_dict,
-                                                             max_mem)
+                                                             max_mem, pool_reclaimable_dict)
         if arena_plan is not None:
             print_rank_0(f"prefetch_arena_admission graph_id={graph_id} "
                          f"phase={'bwd' if bwd else 'fwd'} accepted={int(admission['accepted'])} "
@@ -586,7 +618,8 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                          f"arena_reserved_peak={admission['arena_reserved_peak']} "
                          f"incremental_peak={admission['incremental_peak']} "
                          f"limiting_node={admission['limiting_node']} "
-                         f"limiting_metric={admission['limiting_metric']}")
+                         f"limiting_metric={admission['limiting_metric']} "
+                         f"pool_reclaimable_bytes={admission['limiting_pool_reclaimable_bytes']}")
             if not admission["accepted"]:
                 if require_backward and not bwd:
                     profile.prefetch_arena_session_accepted = False
@@ -603,6 +636,7 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                 profile.prefetch_arena_forward_plan = arena_plan
                 profile.prefetch_arena_forward_mem = dict(mem_dict)
                 profile.prefetch_arena_forward_reserved_mem = dict(reserved_mem_dict)
+                profile.prefetch_arena_forward_pool_reclaimable = dict(pool_reclaimable_dict)
                 profile.prefetch_arena_session_accepted = None
                 profile.prefetch_arena_session_capacity_bound = 0
                 profile.prefetch_arena_session_reason = None
@@ -612,17 +646,16 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                 arena_plan = None
                 arena_reason = profile.prefetch_arena_session_reason or "session_not_admitted"
             elif (profile.prefetch_arena_forward_graph is None or profile.prefetch_arena_forward_plan is None
-                  or profile.prefetch_arena_forward_mem is None
-                  or profile.prefetch_arena_forward_reserved_mem is None):
+                  or profile.prefetch_arena_forward_mem is None or profile.prefetch_arena_forward_reserved_mem is None
+                  or profile.prefetch_arena_forward_pool_reclaimable is None):
                 arena_plan = None
                 arena_reason = "incomplete_forward_arena_profile"
             else:
-                session_admission = _training_session_budget_admission(profile.prefetch_arena_forward_graph,
-                                                                       profile.prefetch_arena_forward_plan,
-                                                                       profile.prefetch_arena_forward_mem,
-                                                                       profile.prefetch_arena_forward_reserved_mem,
-                                                                       new_graph, arena_plan, mem_dict,
-                                                                       reserved_mem_dict, max_mem)
+                session_admission = _training_session_budget_admission(
+                    profile.prefetch_arena_forward_graph, profile.prefetch_arena_forward_plan,
+                    profile.prefetch_arena_forward_mem, profile.prefetch_arena_forward_reserved_mem, new_graph,
+                    arena_plan, mem_dict, reserved_mem_dict, max_mem, profile.prefetch_arena_forward_pool_reclaimable,
+                    pool_reclaimable_dict)
                 profile.prefetch_arena_session_accepted = bool(session_admission["accepted"])
                 profile.prefetch_arena_session_capacity_bound = int(session_admission["capacity_bound"])
                 profile.prefetch_arena_session_reason = (None if session_admission["accepted"] else "shared_budget")
@@ -633,7 +666,11 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
                              f"forward_original_peak={session_admission['forward_original_peak']} "
                              f"forward_arena_peak={session_admission['forward_arena_peak']} "
                              f"backward_original_peak={session_admission['backward_original_peak']} "
-                             f"backward_arena_peak={session_admission['backward_arena_peak']}")
+                             f"backward_arena_peak={session_admission['backward_arena_peak']} "
+                             f"forward_pool_reclaimable_bytes="
+                             f"{session_admission['forward_pool_reclaimable_bytes']} "
+                             f"backward_pool_reclaimable_bytes="
+                             f"{session_admission['backward_pool_reclaimable_bytes']}")
                 if not session_admission["accepted"]:
                     arena_plan = None
                     arena_reason = "shared_budget"

--- a/deepspeed/compile/passes/prefetch.py
+++ b/deepspeed/compile/passes/prefetch.py
@@ -5,7 +5,6 @@
 
 import hashlib
 import math
-import os
 from typing import Dict, List, Tuple
 
 import torch
@@ -31,13 +30,7 @@ MAX_BUFFERED_SIZE = 4e9
 
 run_prefetch_pass = False
 
-PREFETCH_ARENA_ENV = "DEEPSPEED_COMPILE_PREFETCH_ARENA"
 PREFETCH_ARENA_ALIGNMENT = 256
-
-
-def _env_enabled(name: str) -> bool:
-    value = os.environ.get(name, "").strip().lower()
-    return value not in ("", "0", "false", "no")
 
 
 def _align_up(value: int, alignment: int) -> int:
@@ -556,8 +549,7 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
 
         assert ag_tensor_size_sum >= 0
 
-    arena_enabled = _env_enabled(PREFETCH_ARENA_ENV)
-    graph_param_manager = param_manager[graph_id] if arena_enabled else None
+    graph_param_manager = param_manager[graph_id]
     phase_plan_base = 1_000_000 if bwd else 0
     fused_group_index = 0
     new_graph = Graph()
@@ -572,120 +564,112 @@ def schedule_prefetch(gm: GraphModule, graph_id: int, graph_order: List[Tuple[in
             param_nodes_copy = [env[param_node.name] for param_node in param_nodes]
 
             ds_ids = [get_ds_id(ag_node) for ag_node in node]
-            if arena_enabled:
-                plan_id = phase_plan_base + fused_group_index
-                prefetch_node = new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
-                                                        args=(graph_id, param_nodes_copy, ds_ids, None, plan_id))
-                eligible_ds_ids = []
-                arena_bytes_by_ds_id = []
-                for ag_node, param_node, ds_id in zip(node, param_nodes, ds_ids):
-                    param = graph_param_manager.params.get(param_node.name)
-                    requested_dtype = ag_node.kwargs.get("dtype")
-                    persistent = param is None or bool(getattr(param.param, "ds_persist", False))
-                    if param is not None and not persistent and (requested_dtype is None
-                                                                 or requested_dtype == param.dtype):
-                        eligible_ds_ids.append(ds_id)
-                        arena_bytes_by_ds_id.append((ds_id, int(ag_node.meta.get("allgather_allocation_bytes", 0))))
-                prefetch_node.meta["prefetch_arena_eligible_ds_ids"] = tuple(eligible_ds_ids)
-                prefetch_node.meta["prefetch_arena_bytes_by_ds_id"] = tuple(arena_bytes_by_ds_id)
-                fused_group_index += 1
-            else:
-                new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
-                                        args=(graph_id, param_nodes_copy, ds_ids))
+            plan_id = phase_plan_base + fused_group_index
+            prefetch_node = new_graph.call_function(torch.ops.dc.prefetch_params_fused.default,
+                                                    args=(graph_id, param_nodes_copy, ds_ids, None, plan_id))
+            eligible_ds_ids = []
+            arena_bytes_by_ds_id = []
+            for ag_node, param_node, ds_id in zip(node, param_nodes, ds_ids):
+                param = graph_param_manager.params.get(param_node.name)
+                requested_dtype = ag_node.kwargs.get("dtype")
+                persistent = param is None or bool(getattr(param.param, "ds_persist", False))
+                if param is not None and not persistent and (requested_dtype is None
+                                                             or requested_dtype == param.dtype):
+                    eligible_ds_ids.append(ds_id)
+                    arena_bytes_by_ds_id.append((ds_id, int(ag_node.meta.get("allgather_allocation_bytes", 0))))
+            prefetch_node.meta["prefetch_arena_eligible_ds_ids"] = tuple(eligible_ds_ids)
+            prefetch_node.meta["prefetch_arena_bytes_by_ds_id"] = tuple(arena_bytes_by_ds_id)
+            fused_group_index += 1
     arena_plan = None
-    if arena_enabled:
-        if not dist.is_initialized():
-            arena_reason = "distributed_uninitialized"
+    if not dist.is_initialized():
+        arena_reason = "distributed_uninitialized"
+    else:
+        arena_plan, arena_reason = _build_prefetch_arena_plan(new_graph, graph_param_manager,
+                                                              dist.get_world_size(group=process_group), bwd)
+    if arena_plan is not None:
+        if len(reserved_mem_dict) != len(list(profile_graph.nodes)):
+            arena_plan = None
+            arena_reason = "incomplete_reserved_profile"
         else:
-            arena_plan, arena_reason = _build_prefetch_arena_plan(new_graph, graph_param_manager,
-                                                                  dist.get_world_size(group=process_group), bwd)
-        if arena_plan is not None:
-            if len(reserved_mem_dict) != len(list(profile_graph.nodes)):
-                arena_plan = None
-                arena_reason = "incomplete_reserved_profile"
-            else:
-                admission = _prefetch_arena_budget_admission(new_graph, arena_plan, mem_dict, reserved_mem_dict,
-                                                             max_mem, pool_reclaimable_dict)
-        if arena_plan is not None:
-            print_rank_0(f"prefetch_arena_admission graph_id={graph_id} "
-                         f"phase={'bwd' if bwd else 'fwd'} accepted={int(admission['accepted'])} "
-                         f"max_mem={admission['max_mem']} capacity={admission['capacity']} "
-                         f"original_allocated_peak={admission['original_allocated_peak']} "
-                         f"arena_allocated_peak={admission['arena_allocated_peak']} "
-                         f"original_modeled_peak={admission['original_modeled_peak']} "
-                         f"arena_modeled_peak={admission['arena_modeled_peak']} "
-                         f"original_reserved_peak={admission['original_reserved_peak']} "
-                         f"arena_reserved_peak={admission['arena_reserved_peak']} "
-                         f"incremental_peak={admission['incremental_peak']} "
-                         f"limiting_node={admission['limiting_node']} "
-                         f"limiting_metric={admission['limiting_metric']} "
-                         f"pool_reclaimable_bytes={admission['limiting_pool_reclaimable_bytes']}")
-            if not admission["accepted"]:
-                if require_backward and not bwd:
-                    profile.prefetch_arena_session_accepted = False
-                    profile.prefetch_arena_session_reason = "shared_budget"
+            admission = _prefetch_arena_budget_admission(new_graph, arena_plan, mem_dict, reserved_mem_dict, max_mem,
+                                                         pool_reclaimable_dict)
+    if arena_plan is not None:
+        print_rank_0(f"prefetch_arena_admission graph_id={graph_id} "
+                     f"phase={'bwd' if bwd else 'fwd'} accepted={int(admission['accepted'])} "
+                     f"max_mem={admission['max_mem']} capacity={admission['capacity']} "
+                     f"original_allocated_peak={admission['original_allocated_peak']} "
+                     f"arena_allocated_peak={admission['arena_allocated_peak']} "
+                     f"original_modeled_peak={admission['original_modeled_peak']} "
+                     f"arena_modeled_peak={admission['arena_modeled_peak']} "
+                     f"original_reserved_peak={admission['original_reserved_peak']} "
+                     f"arena_reserved_peak={admission['arena_reserved_peak']} "
+                     f"incremental_peak={admission['incremental_peak']} "
+                     f"limiting_node={admission['limiting_node']} "
+                     f"limiting_metric={admission['limiting_metric']} "
+                     f"pool_reclaimable_bytes={admission['limiting_pool_reclaimable_bytes']}")
+        if not admission["accepted"]:
+            if require_backward and not bwd:
+                profile.prefetch_arena_session_accepted = False
+                profile.prefetch_arena_session_reason = "shared_budget"
+            arena_plan = None
+            arena_reason = "shared_budget"
+    if arena_plan is not None and require_backward:
+        if not bwd:
+            # The optimized backward does not exist yet.  Keep the final
+            # forward plan as native metadata, but native execution will
+            # deliberately use the normal gather pool until the backward
+            # compiler registers its plan and decides the shared budget.
+            profile.prefetch_arena_forward_graph = new_graph
+            profile.prefetch_arena_forward_plan = arena_plan
+            profile.prefetch_arena_forward_mem = dict(mem_dict)
+            profile.prefetch_arena_forward_reserved_mem = dict(reserved_mem_dict)
+            profile.prefetch_arena_forward_pool_reclaimable = dict(pool_reclaimable_dict)
+            profile.prefetch_arena_session_accepted = None
+            profile.prefetch_arena_session_capacity_bound = 0
+            profile.prefetch_arena_session_reason = None
+            print_rank_0(f"prefetch_arena_session_pending graph_id={graph_id} "
+                         f"forward_capacity={arena_plan['capacity']}")
+        elif profile.prefetch_arena_session_accepted is False:
+            arena_plan = None
+            arena_reason = profile.prefetch_arena_session_reason or "session_not_admitted"
+        elif (profile.prefetch_arena_forward_graph is None or profile.prefetch_arena_forward_plan is None
+              or profile.prefetch_arena_forward_mem is None or profile.prefetch_arena_forward_reserved_mem is None
+              or profile.prefetch_arena_forward_pool_reclaimable is None):
+            arena_plan = None
+            arena_reason = "incomplete_forward_arena_profile"
+        else:
+            session_admission = _training_session_budget_admission(
+                profile.prefetch_arena_forward_graph, profile.prefetch_arena_forward_plan,
+                profile.prefetch_arena_forward_mem, profile.prefetch_arena_forward_reserved_mem, new_graph, arena_plan,
+                mem_dict, reserved_mem_dict, max_mem, profile.prefetch_arena_forward_pool_reclaimable,
+                pool_reclaimable_dict)
+            profile.prefetch_arena_session_accepted = bool(session_admission["accepted"])
+            profile.prefetch_arena_session_capacity_bound = int(session_admission["capacity_bound"])
+            profile.prefetch_arena_session_reason = (None if session_admission["accepted"] else "shared_budget")
+            print_rank_0(f"prefetch_arena_session_admission graph_id={graph_id} "
+                         f"accepted={int(session_admission['accepted'])} "
+                         f"max_mem={session_admission['max_mem']} "
+                         f"capacity_bound={session_admission['capacity_bound']} "
+                         f"forward_original_peak={session_admission['forward_original_peak']} "
+                         f"forward_arena_peak={session_admission['forward_arena_peak']} "
+                         f"backward_original_peak={session_admission['backward_original_peak']} "
+                         f"backward_arena_peak={session_admission['backward_arena_peak']} "
+                         f"forward_pool_reclaimable_bytes={session_admission['forward_pool_reclaimable_bytes']} "
+                         f"backward_pool_reclaimable_bytes={session_admission['backward_pool_reclaimable_bytes']}")
+            if not session_admission["accepted"]:
                 arena_plan = None
                 arena_reason = "shared_budget"
-        if arena_plan is not None and require_backward:
-            if not bwd:
-                # The optimized backward does not exist yet.  Keep the final
-                # forward plan as native metadata, but native execution will
-                # deliberately use the normal gather pool until the backward
-                # compiler registers its plan and decides the shared budget.
-                profile.prefetch_arena_forward_graph = new_graph
-                profile.prefetch_arena_forward_plan = arena_plan
-                profile.prefetch_arena_forward_mem = dict(mem_dict)
-                profile.prefetch_arena_forward_reserved_mem = dict(reserved_mem_dict)
-                profile.prefetch_arena_forward_pool_reclaimable = dict(pool_reclaimable_dict)
-                profile.prefetch_arena_session_accepted = None
-                profile.prefetch_arena_session_capacity_bound = 0
-                profile.prefetch_arena_session_reason = None
-                print_rank_0(f"prefetch_arena_session_pending graph_id={graph_id} "
-                             f"forward_capacity={arena_plan['capacity']}")
-            elif profile.prefetch_arena_session_accepted is False:
-                arena_plan = None
-                arena_reason = profile.prefetch_arena_session_reason or "session_not_admitted"
-            elif (profile.prefetch_arena_forward_graph is None or profile.prefetch_arena_forward_plan is None
-                  or profile.prefetch_arena_forward_mem is None or profile.prefetch_arena_forward_reserved_mem is None
-                  or profile.prefetch_arena_forward_pool_reclaimable is None):
-                arena_plan = None
-                arena_reason = "incomplete_forward_arena_profile"
-            else:
-                session_admission = _training_session_budget_admission(
-                    profile.prefetch_arena_forward_graph, profile.prefetch_arena_forward_plan,
-                    profile.prefetch_arena_forward_mem, profile.prefetch_arena_forward_reserved_mem, new_graph,
-                    arena_plan, mem_dict, reserved_mem_dict, max_mem, profile.prefetch_arena_forward_pool_reclaimable,
-                    pool_reclaimable_dict)
-                profile.prefetch_arena_session_accepted = bool(session_admission["accepted"])
-                profile.prefetch_arena_session_capacity_bound = int(session_admission["capacity_bound"])
-                profile.prefetch_arena_session_reason = (None if session_admission["accepted"] else "shared_budget")
-                print_rank_0(f"prefetch_arena_session_admission graph_id={graph_id} "
-                             f"accepted={int(session_admission['accepted'])} "
-                             f"max_mem={session_admission['max_mem']} "
-                             f"capacity_bound={session_admission['capacity_bound']} "
-                             f"forward_original_peak={session_admission['forward_original_peak']} "
-                             f"forward_arena_peak={session_admission['forward_arena_peak']} "
-                             f"backward_original_peak={session_admission['backward_original_peak']} "
-                             f"backward_arena_peak={session_admission['backward_arena_peak']} "
-                             f"forward_pool_reclaimable_bytes="
-                             f"{session_admission['forward_pool_reclaimable_bytes']} "
-                             f"backward_pool_reclaimable_bytes="
-                             f"{session_admission['backward_pool_reclaimable_bytes']}")
-                if not session_admission["accepted"]:
-                    arena_plan = None
-                    arena_reason = "shared_budget"
-        if arena_plan is None:
-            print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} "
-                         f"fallback={arena_reason}")
-            _disable_prefetch_arena(new_graph)
-            # Forward may already have registered a pending training-session
-            # plan.  A later backward rejection must invalidate that native
-            # metadata as one session decision, not leave a forward-only arena
-            # available on a subsequent compile/execution.
-            if bwd and require_backward:
-                get_deepcompile_handle().disable_z3_prefetch_arena(graph_id, arena_reason)
-        else:
-            _add_prefetch_arena_release_dependencies(new_graph)
+    if arena_plan is None:
+        print_rank_0(f"prefetch_arena graph_id={graph_id} phase={'bwd' if bwd else 'fwd'} fallback={arena_reason}")
+        _disable_prefetch_arena(new_graph)
+        # Forward may already have registered a pending training-session plan. A
+        # later backward rejection must invalidate that native metadata as one
+        # session decision, not leave a forward-only arena available on a
+        # subsequent compile/execution.
+        if bwd and require_backward:
+            get_deepcompile_handle().disable_z3_prefetch_arena(graph_id, arena_reason)
+    else:
+        _add_prefetch_arena_release_dependencies(new_graph)
     new_graph.lint()
     gm.graph = new_graph
 

--- a/deepspeed/compile/passes/selective_gather.py
+++ b/deepspeed/compile/passes/selective_gather.py
@@ -78,6 +78,7 @@ def _profile_result_incomplete(prof) -> bool:
 def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int, bool]], profiling_results,
                      create_inputs_fn, mem_budget: float, param_manager: DSGraphParamManager,
                      bwd: bool) -> GraphModule:
+    """Persist high-value parameters only on the final backward graph and within measured headroom."""
     target_graph_id = graph_id
 
     if not bwd:
@@ -93,6 +94,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
     if last_backward_graph_id is None or graph_id != last_backward_graph_id:
         return gm
 
+    process_group = getattr(profiling_results[graph_id], "process_group", None)
     incomplete_profile_ids = [
         profile_graph_id for profile_graph_id, prof in profiling_results.items() if _profile_result_incomplete(prof)
     ]
@@ -170,13 +172,16 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
     current_available_mem = accelerator.available_memory()
     vals_to_bcast = torch.tensor([total_mem, current_available_mem],
                                  device=torch.device(get_accelerator().current_device()))
-    dist.all_reduce(vals_to_bcast, dist.ReduceOp.MIN)
+    dist.all_reduce(vals_to_bcast, dist.ReduceOp.MIN, group=process_group)
     total_mem = vals_to_bcast[0].item()
     current_available_mem = vals_to_bcast[1].item()
 
     budget = _compute_persistence_budget(all_graph_mem_records, total_mem, MEM_MARGIN)
     profiled_available_mem = budget["available_mem"]
-    available_mem = profiled_available_mem
+    current_available_headroom = max(0, int(current_available_mem) - int(total_mem * MEM_MARGIN))
+    # The profile models transient peaks, while current allocator state captures
+    # memory retained since profiling.  Persistence must satisfy both views.
+    available_mem = min(profiled_available_mem, current_available_headroom)
 
     ds_id_to_param = {}
     for g_id, g_pm in param_manager.items():
@@ -190,7 +195,8 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
         f"selective_gather target_graph_id={target_graph_id} profiled_mem_lists={budget['profiled_list_count']} "
         f"total_mem={total_mem} usable_mem={budget['usable_mem']} peak_resident_alloc={budget['peak_resident_alloc']} "
         f"transient_peak={budget['transient_peak']} current_available_mem={current_available_mem} "
-        f"profiled_transient_available_mem={profiled_available_mem} "
+        f"current_available_headroom={current_available_headroom} "
+        f"profiled_transient_available_mem={profiled_available_mem} effective_available_mem={available_mem} "
         f"persistent_count={len(persistent_ds_ids)} persistent_bytes={persistent_bytes} "
         f"candidate_count={len(ds_ids)} candidate_bytes={candidate_bytes}")
 
@@ -203,7 +209,7 @@ def selective_gather(gm: GraphModule, graph_id: int, graph_order: List[Tuple[int
         return gm
 
     if available_mem == 0:
-        print_rank_0("selective_gather no profiled headroom for new persistent params")
+        print_rank_0("selective_gather no effective headroom for new persistent params")
         return gm
 
     persistent_mem = 0

--- a/deepspeed/compile/passes/zero3_compile.py
+++ b/deepspeed/compile/passes/zero3_compile.py
@@ -4,6 +4,9 @@
 # DeepSpeed Team
 
 import gc
+import hashlib
+import json
+import os
 from typing import List, Dict, Tuple
 import _operator
 
@@ -13,8 +16,9 @@ from torch.fx import Graph, Node, GraphModule
 from ..util import get_input_nodes, get_param_nodes, get_index_by_graph_id, get_deepcompile_handle, get_real_uses, is_cast_op
 from ..fx import (add_postprocess, _make_node_meta, get_output_node, move_primals_to_head, add_end_backward,
                   replace_reduce_outputs_with_none, should_release_reduce_buckets)
-from ..profilers.graph_profile import ProfilingInterpreter
-from ..list_schedule import fast_free_schedule
+from ..profilers.graph_profile import ProfilingInterpreter, is_profile_incomplete
+from ..list_schedule import (DS_SCHEDULER_BUDGET_DIAGNOSTICS_ATTR, SchedulerMemoryBudget, allgather_allocation_bytes,
+                             fast_free_schedule, max_possible_gathered_bytes, profiled_non_gathered_peak)
 from .contract import PassContract, CAP_Z3_GATHER_RELEASE
 
 import deepspeed.comm as dist
@@ -23,9 +27,263 @@ from deepspeed.accelerator import get_accelerator
 NAME = "zero3_compile"
 # Inserts the ZeRO-3 all-gather/release ops that prefetch and selective-gather later build on.
 CONTRACT = PassContract(provides=frozenset({CAP_Z3_GATHER_RELEASE}))
+SCHEDULER_DEBUG_ENV = "DEEPSPEED_COMPILE_SCHEDULER_BUDGET_DEBUG"
 
 
-def add_allgather(graph_id: int, graph: Graph, node: Node, ds_id: int, dtype: torch.dtype):
+def _reduce_int(value: int, op, process_group=None):
+    """Reduce an integer scheduling input, or preserve it outside distributed mode."""
+    if not dist.is_initialized():
+        return int(value)
+
+    value_tensor = torch.tensor([int(value)],
+                                device=torch.device(get_accelerator().current_device()),
+                                dtype=torch.int64)
+    dist.all_reduce(value_tensor, op, group=process_group)
+    return int(value_tensor.item())
+
+
+def _rank_min_total_memory(process_group=None):
+    return _reduce_int(get_accelerator().total_memory(), dist.ReduceOp.MIN, process_group)
+
+
+def _world_size(process_group=None):
+    if dist.is_initialized():
+        if process_group is None:
+            return dist.get_world_size()
+        return dist.get_world_size(group=process_group)
+    return 1
+
+
+def _sync_profile_complete(profile_complete: bool, process_group=None):
+    """Require every rank to have a complete profile before using it for scheduling."""
+    if not dist.is_initialized():
+        return profile_complete
+
+    complete = torch.tensor([1 if profile_complete else 0],
+                            device=torch.device(get_accelerator().current_device()),
+                            dtype=torch.int)
+    dist.all_reduce(complete, dist.ReduceOp.MIN, group=process_group)
+    return bool(complete.item())
+
+
+def _operator_profile_complete(graph: Graph):
+    """Require the graph marker plus per-node absolute start and peak memory."""
+    return not is_profile_incomplete(graph) and all(
+        "profile_mem_start" in node.meta and "profile_mem_peak" in node.meta for node in graph.nodes)
+
+
+def _rank_max_operator_profiled_non_gathered_peak(graph: Graph, process_group=None):
+    """Return the worst absolute peak after removing profiled gather residency."""
+    records = [(node.name, int(node.meta.get("profile_mem_start", 0)
+                               or 0), 0, int(node.meta.get("profile_mem_peak", 0) or 0)) for node in graph.nodes]
+    return _reduce_int(profiled_non_gathered_peak(graph, records), dist.ReduceOp.MAX, process_group)
+
+
+def _build_scheduler_budget_from_operator_profile(graph: Graph, output_size: int = 0, process_group=None):
+    """Build a budget only when every node has trustworthy operator profile data."""
+    if not _operator_profile_complete(graph):
+        return None
+
+    scheduler_budget = SchedulerMemoryBudget.from_profiled_non_gathered_peak(
+        _rank_min_total_memory(process_group), _rank_max_operator_profiled_non_gathered_peak(graph, process_group),
+        output_size)
+    minimum_budget = _minimum_gather_residency_budget(graph, process_group)
+    if scheduler_budget is not None and minimum_budget is not None:
+        scheduler_budget = scheduler_budget.clamped_to_minimum_gather_residency(minimum_budget.max_gathered_bytes)
+    return scheduler_budget
+
+
+def _minimum_gather_residency_budget(graph: Graph, process_group=None):
+    """Build a rank-consistent gather-only cap without inferring memory headroom."""
+    local_max_single_gather = max((int(node.meta.get("allgather_allocation_bytes", 0) or 0)
+                                   for node in graph.nodes if node.target == torch.ops.dc.allgather_param.default),
+                                  default=0)
+    max_single_gather = _reduce_int(local_max_single_gather, dist.ReduceOp.MAX, process_group)
+    return SchedulerMemoryBudget.minimum_gather_residency(max_single_gather)
+
+
+def _scheduler_debug_enabled():
+    return os.environ.get(SCHEDULER_DEBUG_ENV, "").lower() not in ("", "0", "false", "no")
+
+
+def _print_scheduler_debug(message: str, process_group=None):
+    if not _scheduler_debug_enabled():
+        return
+    if not dist.is_initialized() or dist.get_rank(group=process_group) == 0:
+        print(message, flush=True)
+
+
+def _stable_schedule_target(target):
+    if isinstance(target, str):
+        return target
+    module = getattr(target, "__module__", None)
+    qualname = getattr(target, "__qualname__", None) or getattr(target, "__name__", None)
+    if module and qualname:
+        return f"{module}.{qualname}"
+    return f"{type(target).__module__}.{type(target).__qualname__}"
+
+
+def _final_schedule_fingerprint(graph: Graph):
+    """Hash stable node order and dependencies without process-local graph identifiers."""
+    entries = []
+    for node in graph.nodes:
+        inputs = ",".join(input_node.name for input_node in node.all_input_nodes)
+        entries.append(f"{node.op}|{node.name}|{_stable_schedule_target(node.target)}|{inputs}")
+    digest = hashlib.sha256("\n".join(entries).encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big") & ((1 << 63) - 1)
+
+
+def _collective_schedule_projection(graph: Graph):
+    """Return the ordered gather/release identities, excluding graph-local names and IDs."""
+    entries = []
+    for node in graph.nodes:
+        if node.target == torch.ops.dc.allgather_param.default:
+            kind = "gather"
+        elif node.target == torch.ops.dc.release_param.default:
+            kind = "release"
+        else:
+            continue
+        if len(node.args) < 3 or not isinstance(node.args[2], int):
+            raise RuntimeError(f"DeepCompile ZeRO-3 {kind} node has no stable integer ds_id: {node.format_node()}")
+        entries.append((kind, node.args[2]))
+    return entries
+
+
+def _collective_schedule_fingerprint(projection):
+    payload = json.dumps(projection, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _validate_final_schedule_fingerprint(graph: Graph, graph_id: int, bwd: bool, process_group=None):
+    """In scheduler debug mode, fail every rank when final graph order diverges."""
+    if not _scheduler_debug_enabled():
+        return None
+
+    fingerprint = _final_schedule_fingerprint(graph)
+    collective_projection = _collective_schedule_projection(graph)
+    collective_fingerprint = _collective_schedule_fingerprint(collective_projection)
+    collective_message = ("DeepCompile ZeRO-3 collective_schedule_projection "
+                          f"graph_id={graph_id} bwd={bwd} value={collective_fingerprint} "
+                          f"entries={len(collective_projection)} sequence="
+                          f"{json.dumps(collective_projection, separators=(',', ':'))}")
+    if not dist.is_initialized():
+        _print_scheduler_debug(collective_message, process_group)
+        _print_scheduler_debug(
+            f"DeepCompile ZeRO-3 final_schedule_fingerprint graph_id={graph_id} bwd={bwd} value={fingerprint}",
+            process_group)
+        return fingerprint
+
+    _print_scheduler_debug(collective_message, process_group)
+    device = torch.device(get_accelerator().current_device())
+    min_fingerprint = torch.tensor([fingerprint], device=device, dtype=torch.int64)
+    max_fingerprint = min_fingerprint.clone()
+    dist.all_reduce(min_fingerprint, dist.ReduceOp.MIN, group=process_group)
+    dist.all_reduce(max_fingerprint, dist.ReduceOp.MAX, group=process_group)
+    if min_fingerprint.item() != max_fingerprint.item():
+        raise RuntimeError(
+            f"DeepCompile ZeRO-3 final schedule fingerprint mismatch for graph_id={graph_id} bwd={bwd}: "
+            f"min={min_fingerprint.item()} max={max_fingerprint.item()}")
+    _print_scheduler_debug(
+        f"DeepCompile ZeRO-3 final_schedule_fingerprint graph_id={graph_id} bwd={bwd} value={fingerprint}",
+        process_group)
+    return fingerprint
+
+
+def _set_allgather_allocation_metadata(graph: Graph, process_group=None):
+    """Stamp padded gather allocation bytes without discarding a more precise estimate."""
+    world_size = None
+    for node in graph.nodes:
+        if node.target == torch.ops.dc.allgather_param.default:
+            if world_size is None:
+                world_size = _world_size(process_group)
+            dtype = node.kwargs.get("dtype") if isinstance(node.kwargs, dict) else None
+            profiled_bytes = allgather_allocation_bytes(node.meta.get("tensor_size", 0), dtype, world_size)
+            node.meta["allgather_allocation_bytes"] = max(int(node.meta.get("allgather_allocation_bytes", 0) or 0),
+                                                          profiled_bytes)
+
+
+def _scheduler_budget_disabled_reason(graph: Graph, scheduler_budget):
+    if scheduler_budget is not None:
+        return None
+    if not _operator_profile_complete(graph):
+        return "incomplete_operator_profile"
+    return "invalid_profiled_non_gathered_peak"
+
+
+def _scheduler_budget_from_operator_profile(gm: GraphModule, process_group=None):
+    """Derive a rank-consistent budget and explain why a non-constraining gate is disabled."""
+    if not dist.is_initialized():
+        return None, "non_distributed"
+
+    _set_allgather_allocation_metadata(gm.graph, process_group)
+    operator_profile_complete = _sync_profile_complete(_operator_profile_complete(gm.graph), process_group)
+    if not operator_profile_complete:
+        # An unvisited suffix can exceed every observed partial peak, so do
+        # not infer whole-graph headroom from partial data or allocator state.
+        # Still constrain scheduler-controlled gathered-parameter residency to
+        # one largest-gather-sized cap so incomplete profiling cannot silently
+        # restore unconstrained gather overlap.
+        scheduler_budget = _minimum_gather_residency_budget(gm.graph, process_group)
+        if scheduler_budget is None:
+            return None, "incomplete_operator_profile_without_gather"
+        return scheduler_budget, None
+
+    scheduler_budget = _build_scheduler_budget_from_operator_profile(gm.graph, process_group=process_group)
+    # A gate larger than every gather combined cannot affect ordering, so keep
+    # legacy behavior and make the disabled state explicit in diagnostics.
+    if scheduler_budget is not None and scheduler_budget.max_gathered_bytes >= max_possible_gathered_bytes(gm.graph):
+        return None, "budget_not_constraining"
+    return scheduler_budget, _scheduler_budget_disabled_reason(gm.graph, scheduler_budget)
+
+
+def _log_scheduler_result(graph_id: int,
+                          bwd: bool,
+                          scheduler_budget,
+                          disabled_reason,
+                          graph: Graph,
+                          process_group=None):
+    diagnostics = getattr(graph, DS_SCHEDULER_BUDGET_DIAGNOSTICS_ATTR, {})
+    selected = diagnostics.get("selected", [])
+    max_live_gathered_bytes = max((entry.get("peak_gathered_bytes", 0) for entry in selected), default=0)
+    rejected_candidates = diagnostics.get("budget_rejected_candidates", [])
+    minimum_rejected_candidate_peak_bytes = None
+    if scheduler_budget is not None and rejected_candidates and _scheduler_debug_enabled():
+        minimum_rejected_candidate_peak_bytes = min(
+            scheduler_budget.max_gathered_bytes + entry.get("over_budget_bytes", 0) for entry in rejected_candidates)
+    if scheduler_budget is None:
+        _print_scheduler_debug(
+            f"DeepCompile ZeRO-3 scheduler graph_id={graph_id} bwd={bwd} budget_enabled=False "
+            f"disabled_reason={disabled_reason} selected_count={len(selected)} "
+            f"max_live_gathered_bytes={max_live_gathered_bytes}", process_group)
+        return
+
+    _print_scheduler_debug(
+        f"DeepCompile ZeRO-3 scheduler graph_id={graph_id} bwd={bwd} budget_enabled=True "
+        f"budget_source={scheduler_budget.source} max_gathered_bytes={scheduler_budget.max_gathered_bytes} "
+        f"safety_margin={scheduler_budget.safety_margin} "
+        f"profiled_non_gathered_peak_mem={scheduler_budget.profiled_non_gathered_peak_mem} "
+        f"budget_rejections={diagnostics.get('budget_rejections', 0)} "
+        f"minimum_rejected_candidate_peak_bytes={minimum_rejected_candidate_peak_bytes} "
+        f"over_budget_fallbacks={len(diagnostics.get('budget_overflows', []))} "
+        f"max_live_gathered_bytes={max_live_gathered_bytes}", process_group)
+
+
+def _dtype_element_size(dtype: torch.dtype):
+    return torch.empty((), dtype=dtype).element_size()
+
+
+def _param_allgather_allocation_bytes(param, dtype: torch.dtype):
+    """Return the registered parameter size in its target gather dtype."""
+    return int(param.numel) * _dtype_element_size(dtype)
+
+
+def add_allgather(graph_id: int,
+                  graph: Graph,
+                  node: Node,
+                  ds_id: int,
+                  dtype: torch.dtype,
+                  allgather_allocation_bytes: int = None):
+    """Insert gather and wait nodes while preserving the original graph output edge."""
     new_ag_node = add_postprocess(graph,
                                   node,
                                   torch.ops.dc.allgather_param.default,
@@ -33,6 +291,8 @@ def add_allgather(graph_id: int, graph: Graph, node: Node, ds_id: int, dtype: to
                                   extra_kwargs={"dtype": dtype},
                                   name=f"allgather_ds_param_{node.target}_{ds_id}",
                                   meta=_make_node_meta(node, ds_id, True))
+    if allgather_allocation_bytes is not None:
+        new_ag_node.meta["allgather_allocation_bytes"] = int(allgather_allocation_bytes)
     new_ag_node.meta["val"] = node.meta["val"].to(dtype)
 
     # Set the previous node back to output
@@ -73,6 +333,7 @@ def add_reduce(graph_id: int, graph: Graph, grad_node: Node, param_name: str, ds
 
 
 def add_gather_and_release(graph_id: int, graph: Graph, param_manager, param_nodes: List[Node]) -> Graph:
+    """Insert gather/wait lifetimes and attach releases to ordinary parameter consumers."""
 
     node_to_uses = get_real_uses(graph)
     for pn in param_nodes:
@@ -90,7 +351,14 @@ def add_gather_and_release(graph_id: int, graph: Graph, param_manager, param_nod
                 fuse_typecast = True
                 target_dtype = casted_dtype
 
-        add_allgather(graph_id, graph, pn, param_manager.ds_ids[pn.name], target_dtype)
+        param = param_manager.params[pn.name]
+        allgather_node = add_allgather(graph_id,
+                                       graph,
+                                       pn,
+                                       param_manager.ds_ids[pn.name],
+                                       target_dtype,
+                                       allgather_allocation_bytes=_param_allgather_allocation_bytes(
+                                           param, target_dtype))
         if fuse_typecast:
             users = node_to_uses[typecast_node]
             wait_node = typecast_node.args[0]
@@ -101,6 +369,15 @@ def add_gather_and_release(graph_id: int, graph: Graph, param_manager, param_nod
             graph.erase_node(typecast_node)
         else:
             users = node_to_uses[pn]
+            if len(users) == 0:
+                # Parameters returned directly by the graph have no ordinary
+                # consumer to trigger gathering, so make the waited gather the
+                # output while retaining its original output name.
+                output_node = get_output_node(graph)
+                wait_node = next(user for user in allgather_node.users
+                                 if user.target == torch.ops.dc.wait_allgather.default)
+                wait_node.meta["original_output_name"] = pn.name
+                output_node.replace_input_with(pn, wait_node)
 
         ds_id = param_manager.ds_ids[pn.name]
         for user in users:
@@ -123,6 +400,7 @@ def add_gather_and_release(graph_id: int, graph: Graph, param_manager, param_nod
 
 def add_gather_and_reduce(graph_id: int, graph: Graph, param_manager, param_nodes_bw: List[Node],
                           param_name_to_grad: Dict[str, Node]) -> Graph:
+    """Add parameter lifetimes and gradient reductions to a backward graph."""
 
     add_gather_and_release(graph_id, graph, param_manager, param_nodes_bw)
 
@@ -141,24 +419,29 @@ def add_z3_gather_release_fw(gm: GraphModule,
                              create_inputs_fn,
                              param_manager,
                              debug_log=False) -> GraphModule:
+    """Profile, budget, and schedule ZeRO-3 parameter lifetimes for a forward graph."""
 
     nz3 = get_deepcompile_handle()
 
     real_inputs = create_inputs_fn()
     param_indices = profiling_results[graph_id].param_indices
+    process_group = getattr(profiling_results[graph_id], "process_group", None)
 
     gm.graph = add_gather_and_release(graph_id, gm.graph, param_manager[graph_id],
                                       get_param_nodes(gm.graph, param_indices))
 
     nz3.register_graph_z3(graph_id, [v[1] for v in param_indices])  # Need this before profiling
 
-    profiler = ProfilingInterpreter(gm, debug_log=debug_log)
+    profiler = ProfilingInterpreter(gm, debug_log=debug_log, process_group=process_group)
     profiler.run(*real_inputs)
     del profiler
     gc.collect()
     get_accelerator().empty_cache()
+    # Build the shared scheduling budget after the operator profile is complete
+    # but before the scheduler rewrites graph order and Inductor metadata.
+    scheduler_budget, disabled_reason = _scheduler_budget_from_operator_profile(gm, process_group)
 
-    rank = dist.get_rank()
+    rank = dist.get_rank(group=process_group)
     graph_index = get_index_by_graph_id(graph_order, graph_id)
     if rank == 0 and debug_log:
         print(f"Fwd before scheduling graph {graph_index} graph_id={graph_id} {gm.graph}")
@@ -173,7 +456,15 @@ def add_z3_gather_release_fw(gm: GraphModule,
         gm.graph,
         get_accelerator().available_memory(),
         0,  # unused
-        debug_log=debug_log)
+        debug_log=debug_log,
+        scheduler_budget=scheduler_budget)
+    _log_scheduler_result(graph_id,
+                          bwd=False,
+                          scheduler_budget=scheduler_budget,
+                          disabled_reason=disabled_reason,
+                          graph=gm.graph,
+                          process_group=process_group)
+    _validate_final_schedule_fingerprint(gm.graph, graph_id, bwd=False, process_group=process_group)
 
     if rank == 0 and debug_log:
         print(f"Fwd after scheduling graph {graph_index} graph_id={graph_id} {gm.graph}")
@@ -188,21 +479,26 @@ def add_z3_gather_release_bw(gm: GraphModule,
                              create_inputs_fn,
                              param_manager,
                              debug_log=False) -> GraphModule:
+    """Profile, budget, and schedule gathers, releases, and reductions for backward."""
 
     param_nodes_bw, param_name_to_grad = param_manager[graph_id].get_bwd_mapping(gm.graph)
     gm.graph = add_gather_and_reduce(graph_id, gm.graph, param_manager[graph_id], param_nodes_bw, param_name_to_grad)
 
     input_nodes = get_input_nodes(gm.graph)
     real_inputs = create_inputs_fn()
+    process_group = getattr(profiling_results[graph_id], "process_group", None)
     assert len(input_nodes) == len(real_inputs), f"Expected {len(real_inputs)} inputs, got {len(input_nodes)}"
 
-    real_outputs = ProfilingInterpreter(gm, debug_log=debug_log).run(*real_inputs)
+    real_outputs = ProfilingInterpreter(gm, debug_log=debug_log, process_group=process_group).run(*real_inputs)
 
     del real_outputs
     gc.collect()
     get_accelerator().empty_cache()
+    # The scheduler consumes only DP-group-reduced inputs, ensuring every group
+    # rank emits collectives in the same order even when allocator state differs.
+    scheduler_budget, disabled_reason = _scheduler_budget_from_operator_profile(gm, process_group)
 
-    rank = dist.get_rank()
+    rank = dist.get_rank(group=process_group)
     graph_index = get_index_by_graph_id(graph_order, graph_id)
     if rank == 0 and debug_log:
         print(f"Bwd before scheduling graph {graph_index} graph_id={graph_id} {gm.graph}")
@@ -211,10 +507,18 @@ def add_z3_gather_release_bw(gm: GraphModule,
         gm.graph,
         get_accelerator().available_memory(),
         0,  # unused
-        debug_log=debug_log)
+        debug_log=debug_log,
+        scheduler_budget=scheduler_budget)
+    _log_scheduler_result(graph_id,
+                          bwd=True,
+                          scheduler_budget=scheduler_budget,
+                          disabled_reason=disabled_reason,
+                          graph=gm.graph,
+                          process_group=process_group)
 
     add_end_backward(gm.graph, graph_id, should_release_reduce_buckets(graph_order, graph_id))
     replace_reduce_outputs_with_none(gm.graph)
+    _validate_final_schedule_fingerprint(gm.graph, graph_id, bwd=True, process_group=process_group)
 
     return gm
 

--- a/deepspeed/compile/profilers/__init__.py
+++ b/deepspeed/compile/profilers/__init__.py
@@ -3,7 +3,7 @@
 
 # DeepSpeed Team
 
-from typing import List, Tuple
+from typing import Any, List, Tuple
 from dataclasses import dataclass, field
 
 from torch.fx import Graph
@@ -23,3 +23,6 @@ class ProfilingResult:
     fwd_tensor_sizes: List[Tuple[str, int]] = field(default_factory=list)  # name, size
     bwd_tensor_sizes: List[Tuple[str, int]] = field(default_factory=list)
     param_indices: List[Tuple[int, int, Tuple[int, ...]]] = field(default_factory=list)  # index, ds_id, ds_shape
+    # Keep newly added fields at the end so positional construction of the
+    # long-standing profiling fields remains backward compatible.
+    process_group: Any = None

--- a/deepspeed/compile/profilers/__init__.py
+++ b/deepspeed/compile/profilers/__init__.py
@@ -34,6 +34,7 @@ class ProfilingResult:
     prefetch_arena_forward_plan: Any = None
     prefetch_arena_forward_mem: Any = None
     prefetch_arena_forward_reserved_mem: Any = None
+    prefetch_arena_forward_pool_reclaimable: Any = None
     prefetch_arena_session_accepted: Any = None
     prefetch_arena_session_capacity_bound: int = 0
     prefetch_arena_session_reason: Any = None

--- a/deepspeed/compile/profilers/__init__.py
+++ b/deepspeed/compile/profilers/__init__.py
@@ -26,3 +26,14 @@ class ProfilingResult:
     # Keep newly added fields at the end so positional construction of the
     # long-standing profiling fields remains backward compatible.
     process_group: Any = None
+    # AOTAutograd invokes the optimized forward before it has compiled the
+    # optimized backward.  Retain the accepted forward plan and its original
+    # memory profile so the backward compiler can make one session-wide
+    # admission decision before the native shared backing is allocated.
+    prefetch_arena_forward_graph: Any = None
+    prefetch_arena_forward_plan: Any = None
+    prefetch_arena_forward_mem: Any = None
+    prefetch_arena_forward_reserved_mem: Any = None
+    prefetch_arena_session_accepted: Any = None
+    prefetch_arena_session_capacity_bound: int = 0
+    prefetch_arena_session_reason: Any = None

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -60,6 +60,8 @@ _PROFILE_META_DEFAULTS = {
     "tensor_size": 0,
     "alloc_mem": 0,
     "max_mem": 0,
+    "profile_mem_start": 0,
+    "profile_mem_peak": 0,
 }
 _PROFILE_INCOMPLETE_ATTR = "_deepcompile_profile_incomplete"
 _PROFILE_INCOMPLETE_META_KEY = "deepcompile_profile_incomplete"
@@ -91,6 +93,14 @@ def _backfill_missing_profile_metadata(graph: Graph, profile_complete: bool = Tr
             node.meta.setdefault(key, default)
 
 
+def _clear_interpreter_env(interpreter: Interpreter):
+    """Release FX interpreter references so profiling outputs do not remain live."""
+    try:
+        interpreter.env.clear()
+    except Exception:
+        pass
+
+
 def _run_warmup_for_profile(call_fn, warmup):
     for _ in range(warmup):
         warmup_out = call_fn()
@@ -117,12 +127,17 @@ def _get_mem_usage_out_of_torch():
         import pynvml
         pynvml.nvmlInit()
 
-        current_dev_id = get_accelerator().current_device()
-        handle = pynvml.nvmlDeviceGetHandleByIndex(current_dev_id)
+        accelerator = get_accelerator()
+        current_dev_id = accelerator.current_device()
+        map_nvml_device = getattr(accelerator, "_get_nvml_gpu_id", None)
+        nvml_dev_id = map_nvml_device(current_dev_id) if callable(map_nvml_device) else current_dev_id
+        handle = pynvml.nvmlDeviceGetHandleByIndex(nvml_dev_id)
         info = pynvml.nvmlDeviceGetMemoryInfo(handle)
 
-        torch_alloc = get_accelerator().memory_allocated()
-        adjust = info.used - torch_alloc
+        # NVML includes PyTorch's cached allocator reservation.  Subtract the
+        # whole reservation so later reuse is counted only as live allocation.
+        torch_reserved = accelerator.memory_reserved()
+        adjust = max(0, int(info.used) - int(torch_reserved or 0))
     except Exception:
         # pynvml not available
         pass
@@ -130,10 +145,24 @@ def _get_mem_usage_out_of_torch():
     return adjust
 
 
+def _absolute_profile_memory(mem_usage_out_of_torch):
+    """Read absolute allocator residency and peak with external memory included once."""
+    return (int(get_accelerator().memory_allocated()) + int(mem_usage_out_of_torch),
+            int(get_accelerator().max_memory_allocated()) + int(mem_usage_out_of_torch))
+
+
+def _rank_max_profile_memory(start_mem, peak_mem, device, distributed, process_group=None):
+    """Return per-field worst-rank absolute memory without averaging rank asymmetry."""
+    values = torch.tensor([int(start_mem), int(peak_mem)], device=device, dtype=torch.int64)
+    if distributed:
+        dist.all_reduce(values, dist.ReduceOp.MAX, group=process_group)
+    return int(values[0].item()), int(values[1].item())
+
+
 # https://pytorch.org/tutorials/intermediate/fx_profiling_tutorial.html
 class ProfilingInterpreter(Interpreter):
 
-    def __init__(self, gm: GraphModule, iteration: int = 10, warmup: int = 5, debug_log=False):
+    def __init__(self, gm: GraphModule, iteration: int = 10, warmup: int = 5, debug_log=False, process_group=None):
         super().__init__(gm)
 
         self.nz3 = get_deepcompile_handle()
@@ -145,6 +174,7 @@ class ProfilingInterpreter(Interpreter):
         self.device = torch.device(get_accelerator().current_device())
         self.cache: Dict[Tuple, Any] = {}
         self.distributed = dist.is_initialized()
+        self.process_group = process_group
         self.allgather_mem: Dict[int, int] = {}
         self.debug_log = debug_log
         self.mem_usage_out_of_torch = 0
@@ -168,27 +198,36 @@ class ProfilingInterpreter(Interpreter):
         except Exception as e:
             profile_complete = False
             msg = e.msg if "msg" in dir(e) else str(e)
-            if not self.distributed or dist.get_rank() == 0:
+            if not self.distributed or dist.get_rank(group=self.process_group) == 0:
                 print(f"DeepCompile profiling failed; using default profile metadata for incomplete nodes: {msg}")
         finally:
+            # Keep this try/finally so profiling state is restored if gathered-param cleanup fails.
             try:
                 self.nz3.clear_all_gathered_params()
             finally:
-                try:
-                    self.nz3.enable_profiling(False)
-                finally:
-                    _backfill_missing_profile_metadata(self.graph, profile_complete=profile_complete)
+                self.nz3.enable_profiling(False)
+                _clear_interpreter_env(self)
+                _backfill_missing_profile_metadata(self.graph, profile_complete=profile_complete)
         return return_val
 
     def run_node(self, n: torch.fx.Node) -> Any:
 
         if n.op in {"placeholder", "output"}:
+            get_accelerator().reset_peak_memory_stats()
+            profile_mem_start, _ = _absolute_profile_memory(self.mem_usage_out_of_torch)
+            ret = super().run_node(n)
+            _, profile_mem_peak = _absolute_profile_memory(self.mem_usage_out_of_torch)
+            profile_mem_start, profile_mem_peak = _rank_max_profile_memory(profile_mem_start, profile_mem_peak,
+                                                                           self.device, self.distributed,
+                                                                           self.process_group)
             n.meta["device_time"] = 0.0
             n.meta["wall_time"] = 0.0
             n.meta["alloc_mem"] = 0
             n.meta["max_mem"] = 0
             n.meta["tensor_size"] = _node_size(n)
-            return super().run_node(n)
+            n.meta["profile_mem_start"] = profile_mem_start
+            n.meta["profile_mem_peak"] = profile_mem_peak
+            return ret
 
         args, kwargs = self.fetch_args_kwargs_from_env(n)
         assert isinstance(args, tuple)
@@ -215,7 +254,7 @@ class ProfilingInterpreter(Interpreter):
 
         cache_hit_flag = torch.tensor([0 if cache_hit else 1], device=self.device, dtype=torch.int)
         if self.distributed:
-            dist.all_reduce(cache_hit_flag, dist.ReduceOp.SUM)
+            dist.all_reduce(cache_hit_flag, dist.ReduceOp.SUM, group=self.process_group)
         cache_hit = cache_hit_flag.item() == 0
 
         if cache_hit:
@@ -236,6 +275,7 @@ class ProfilingInterpreter(Interpreter):
         get_accelerator().reset_peak_memory_stats()
         alloc_mem_start = get_accelerator().memory_allocated()
         max_mem_start = get_accelerator().max_memory_allocated()
+        profile_mem_start, _ = _absolute_profile_memory(self.mem_usage_out_of_torch)
 
         def run_target():
             return getattr(self, n.op)(n.target, args, kwargs)
@@ -245,7 +285,7 @@ class ProfilingInterpreter(Interpreter):
 
         if is_comm_op(n):
             assert self.distributed, f"Distributed environment is not initialized but comm operator {n.name} {n.target} is used."
-            dist.barrier()
+            dist.barrier(group=self.process_group)
 
         start = time.time()
         out = _run_repeatedly_for_profile(run_target, iteration, start_events, end_events)
@@ -253,10 +293,16 @@ class ProfilingInterpreter(Interpreter):
         walltime_sum = time.time() - start
 
         if is_comm_op(n):
-            dist.barrier()
+            dist.barrier(group=self.process_group)
 
         alloc_mem = get_accelerator().memory_allocated() - alloc_mem_start + self.mem_usage_out_of_torch
         max_memory = get_accelerator().max_memory_allocated() - max_mem_start + self.mem_usage_out_of_torch
+        _, profile_mem_peak = _absolute_profile_memory(self.mem_usage_out_of_torch)
+        profile_mem_start, profile_mem_peak = _rank_max_profile_memory(profile_mem_start, profile_mem_peak,
+                                                                       self.device, self.distributed,
+                                                                       self.process_group)
+        n.meta["profile_mem_start"] = profile_mem_start
+        n.meta["profile_mem_peak"] = profile_mem_peak
         tensor_size = _node_size(out)
 
         def partition_param_if_necessary(v):
@@ -276,7 +322,7 @@ class ProfilingInterpreter(Interpreter):
                 vals_to_bcast = torch.tensor([device_time, wall_time, alloc_mem, max_memory, tensor_size],
                                              device=self.device)
                 if self.distributed:
-                    dist.all_reduce(vals_to_bcast, dist.ReduceOp.AVG)
+                    dist.all_reduce(vals_to_bcast, dist.ReduceOp.AVG, group=self.process_group)
                 n.meta["device_time"] = vals_to_bcast[0].item()
                 n.meta["wall_time"] = vals_to_bcast[1].item()
                 n.meta["alloc_mem"] = int(vals_to_bcast[2].item())
@@ -288,7 +334,7 @@ class ProfilingInterpreter(Interpreter):
             if is_release_op:
                 n.meta["alloc_mem"] = -self.allgather_mem.get(args[2], 0)
 
-            if dist.get_rank() == 0 and self.debug_log:
+            if dist.get_rank(group=self.process_group) == 0 and self.debug_log:
                 print(
                     f"{n.target} {n.meta['device_time']:.2f}ms {n.meta['wall_time']:.2f}ms alloc_mem={n.meta['alloc_mem'] / 1024 / 1024:.2f}MB max_mem={n.meta['max_mem'] / 1024 / 1024:.2f}MB tensor_size={n.meta['tensor_size']}"
                 )
@@ -307,25 +353,28 @@ class ProfilingInterpreter(Interpreter):
 
 class MemoryProfilingInterpreter(Interpreter):
 
-    def __init__(self, gm: GraphModule, debug_log=False):
+    def __init__(self, gm: GraphModule, debug_log=False, process_group=None):
         super().__init__(gm)
         self.nz3 = get_deepcompile_handle()
         self.device = torch.device(get_accelerator().current_device())
         self.mem_record = []
         self.last_alloc = get_accelerator().memory_allocated()
         self.profile_complete = True
+        self.process_group = process_group
 
         self.node_counter = 0
         self.node_num = len(gm.graph.nodes)
         self.debug_log = debug_log
 
     def run(self, *args) -> Any:
+        """Profile absolute memory and release gathered/interpreter state on every exit."""
         return_val = None
         self.profile_complete = True
         try:
             assert _all_real_if_tensor(args), "Inputs must be real tensors"
             self.nz3.enable_profiling(True)
             self.mem_usage_out_of_torch = _get_mem_usage_out_of_torch()
+            self.last_alloc = int(get_accelerator().memory_allocated()) + int(self.mem_usage_out_of_torch)
 
             with unset_fake_temporarily():
                 with get_accelerator().random().fork_rng(devices=[self.device]):
@@ -333,17 +382,21 @@ class MemoryProfilingInterpreter(Interpreter):
         except Exception as e:
             self.profile_complete = False
             self.mem_record.clear()
+            _backfill_missing_profile_metadata(self.graph, profile_complete=False)
             print(f"MemoryProfiling error {e}")
         finally:
+            # Keep this try/finally so profiling state is restored if gathered-param cleanup fails.
             try:
                 self.nz3.clear_all_gathered_params()
             finally:
                 self.nz3.enable_profiling(False)
+                _clear_interpreter_env(self)
 
         return return_val
 
     def run_node(self, n: torch.fx.Node) -> Any:
         get_accelerator().reset_peak_memory_stats()
+        profile_mem_start, _ = _absolute_profile_memory(self.mem_usage_out_of_torch)
 
         if n.op in {"placeholder", "output"}:
             ret = super().run_node(n)
@@ -355,17 +408,20 @@ class MemoryProfilingInterpreter(Interpreter):
 
             del args, kwargs
 
-        current_alloc = get_accelerator().memory_allocated() + self.mem_usage_out_of_torch
-        max_alloc = get_accelerator().max_memory_allocated() + self.mem_usage_out_of_torch
-        vals_to_bcast = torch.tensor([current_alloc, max_alloc], device=self.device, dtype=torch.int64)
-        dist.all_reduce(vals_to_bcast, dist.ReduceOp.MAX)
-        current_alloc = vals_to_bcast[0].item()
-        max_alloc = vals_to_bcast[1].item()
+        current_alloc, max_alloc = _absolute_profile_memory(self.mem_usage_out_of_torch)
+        absolute_record = torch.tensor([profile_mem_start, current_alloc, max_alloc],
+                                       device=self.device,
+                                       dtype=torch.int64)
+        if dist.is_initialized():
+            dist.all_reduce(absolute_record, dist.ReduceOp.MAX, group=self.process_group)
+        profile_mem_start, current_alloc, max_alloc = (int(value.item()) for value in absolute_record)
+        n.meta["profile_mem_start"] = profile_mem_start
+        n.meta["profile_mem_peak"] = max_alloc
 
         self.mem_record.append((n.name, current_alloc, current_alloc - self.last_alloc, max_alloc))
 
         self.node_counter += 1
-        if self.debug_log and dist.get_rank() == 0:
+        if self.debug_log and dist.get_rank(group=self.process_group) == 0:
             print(
                 f"Mem prof Node {self.node_counter}/{self.node_num} {n.name} memory {current_alloc / 1024 / 1024:.2f}MB delta {(current_alloc - self.last_alloc) / 1024 / 1024:.2f}MB"
             )

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -418,19 +418,30 @@ class MemoryProfilingInterpreter(Interpreter):
 
         current_alloc, max_alloc = _absolute_profile_memory(self.mem_usage_out_of_torch)
         current_reserved, max_reserved = _absolute_profile_reserved_memory(self.mem_usage_out_of_torch)
-        absolute_record = torch.tensor([profile_mem_start, current_alloc, max_alloc, profile_reserved_start,
-                                        current_reserved, max_reserved],
+        # Arena transition disables the gather pool, drains its idle entries,
+        # and waits for checked-out entries to retire before allocating the
+        # backing. Record that transition-specific charge rather than the
+        # pool's narrower immediately-idle reuse credit.
+        gather_pool_charged = int(self.nz3.get_z3_gather_buffer_pool_transition_reclaimable_bytes())
+        absolute_record = torch.tensor([
+            profile_mem_start, current_alloc, max_alloc, profile_reserved_start, current_reserved, max_reserved,
+            -gather_pool_charged
+        ],
                                        device=self.device,
                                        dtype=torch.int64)
         if dist.is_initialized():
             dist.all_reduce(absolute_record, dist.ReduceOp.MAX, group=self.process_group)
-        (profile_mem_start, current_alloc, max_alloc, profile_reserved_start, current_reserved,
-         max_reserved) = (int(value.item()) for value in absolute_record)
+        (profile_mem_start, current_alloc, max_alloc, profile_reserved_start, current_reserved, max_reserved,
+         negative_gather_pool_charged) = (int(value.item()) for value in absolute_record)
         n.meta["profile_mem_start"] = profile_mem_start
         n.meta["profile_mem_peak"] = max_alloc
         n.meta["profile_reserved_start"] = profile_reserved_start
         n.meta["profile_reserved_current"] = current_reserved
         n.meta["profile_reserved_peak"] = max_reserved
+        # The record is MAX-reduced for existing memory fields. Negating this
+        # one field gives the cross-rank minimum reclaimable charge without a
+        # second collective, keeping the post-transition projection safe.
+        n.meta["profile_gather_pool_charged"] = -negative_gather_pool_charged
 
         self.mem_record.append((n.name, current_alloc, current_alloc - self.last_alloc, max_alloc))
 

--- a/deepspeed/compile/profilers/graph_profile.py
+++ b/deepspeed/compile/profilers/graph_profile.py
@@ -151,6 +151,13 @@ def _absolute_profile_memory(mem_usage_out_of_torch):
             int(get_accelerator().max_memory_allocated()) + int(mem_usage_out_of_torch))
 
 
+def _absolute_profile_reserved_memory(mem_usage_out_of_torch):
+    """Read allocator-reserved residency with external memory included once."""
+    accelerator = get_accelerator()
+    return (int(accelerator.memory_reserved() or 0) + int(mem_usage_out_of_torch),
+            int(accelerator.max_memory_reserved() or 0) + int(mem_usage_out_of_torch))
+
+
 def _rank_max_profile_memory(start_mem, peak_mem, device, distributed, process_group=None):
     """Return per-field worst-rank absolute memory without averaging rank asymmetry."""
     values = torch.tensor([int(start_mem), int(peak_mem)], device=device, dtype=torch.int64)
@@ -397,6 +404,7 @@ class MemoryProfilingInterpreter(Interpreter):
     def run_node(self, n: torch.fx.Node) -> Any:
         get_accelerator().reset_peak_memory_stats()
         profile_mem_start, _ = _absolute_profile_memory(self.mem_usage_out_of_torch)
+        profile_reserved_start, _ = _absolute_profile_reserved_memory(self.mem_usage_out_of_torch)
 
         if n.op in {"placeholder", "output"}:
             ret = super().run_node(n)
@@ -409,14 +417,20 @@ class MemoryProfilingInterpreter(Interpreter):
             del args, kwargs
 
         current_alloc, max_alloc = _absolute_profile_memory(self.mem_usage_out_of_torch)
-        absolute_record = torch.tensor([profile_mem_start, current_alloc, max_alloc],
+        current_reserved, max_reserved = _absolute_profile_reserved_memory(self.mem_usage_out_of_torch)
+        absolute_record = torch.tensor([profile_mem_start, current_alloc, max_alloc, profile_reserved_start,
+                                        current_reserved, max_reserved],
                                        device=self.device,
                                        dtype=torch.int64)
         if dist.is_initialized():
             dist.all_reduce(absolute_record, dist.ReduceOp.MAX, group=self.process_group)
-        profile_mem_start, current_alloc, max_alloc = (int(value.item()) for value in absolute_record)
+        (profile_mem_start, current_alloc, max_alloc, profile_reserved_start, current_reserved,
+         max_reserved) = (int(value.item()) for value in absolute_record)
         n.meta["profile_mem_start"] = profile_mem_start
         n.meta["profile_mem_peak"] = max_alloc
+        n.meta["profile_reserved_start"] = profile_reserved_start
+        n.meta["profile_reserved_current"] = current_reserved
+        n.meta["profile_reserved_peak"] = max_reserved
 
         self.mem_record.append((n.name, current_alloc, current_alloc - self.last_alloc, max_alloc))
 

--- a/deepspeed/compile/util.py
+++ b/deepspeed/compile/util.py
@@ -251,6 +251,7 @@ def materialize_fake(v, device=None):
 
 
 def get_last_uses(graph: Graph):
+    """Map values to last consumers while propagating lifetimes through no-copy ops."""
     position = {node: i for i, node in enumerate(graph.nodes)}
 
     node_to_last_use: Dict[Node, Node] = {}
@@ -262,7 +263,9 @@ def get_last_uses(graph: Graph):
         known_last_use = None
 
         if user.target in no_copy_ops and n in node_to_last_use:
-            last_user = node_to_last_use[user]
+            # A no-copy node can itself be user-less (for example, a graph
+            # output alias).  In that case its own position is the lifetime end.
+            last_user = node_to_last_use.get(user, user)
             last_use_position = position[last_user]
 
             known_last_use = node_to_last_use[n]
@@ -271,7 +274,7 @@ def get_last_uses(graph: Graph):
 
         if n not in node_to_last_use or update:
             if user.target in no_copy_ops:
-                user = node_to_last_use[user]
+                user = node_to_last_use.get(user, user)
 
             node_to_last_use[n] = user
             user_to_last_uses.setdefault(user, []).append(n)

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -333,6 +333,7 @@ class DeepSpeedEngine(Module):
         )
 
         self._deepcompile_active = False
+        self._deepcompile_native_initialized = False
 
         # Configure distributed model
         self._configure_distributed_model(model)
@@ -829,8 +830,8 @@ class DeepSpeedEngine(Module):
         optimizer = getattr(self, "optimizer", None)
         if optimizer is not None and hasattr(optimizer, 'destroy'):
             optimizer.destroy()
-        if self.is_deepcompile_active():
-            get_deepcompile_handle().cleanup()
+        if self.is_deepcompile_active() or getattr(self, "_deepcompile_native_initialized", False):
+            self._deactivate_deepcompile()
         debug_clear_module_and_param_names()
 
         checkpoint_engine = getattr(self, "checkpoint_engine", None)
@@ -5596,7 +5597,11 @@ class DeepSpeedEngine(Module):
         if self.compile_autosp():
             resolved_backend = self.get_autosp_backend(compile_kwargs)
         else:
-            resolved_backend = self.get_deepcompile_backend(backend, compile_kwargs, schedule)
+            try:
+                resolved_backend = self.get_deepcompile_backend(backend, compile_kwargs, schedule)
+            except BaseException:
+                self._deactivate_deepcompile()
+                raise
 
         return resolved_backend, schedule
 
@@ -5638,9 +5643,9 @@ class DeepSpeedEngine(Module):
         try:
             self.module.compile(**{**compile_kwargs, 'backend': backend})
         except BaseException:
-            if is_deepspeed_compile_backend:
+            if is_deepspeed_compile_backend or getattr(self, "_deepcompile_native_initialized", False):
                 # Restore default hooks if compilation fails before completing.
-                self._set_deepcompile_active(False)
+                self._deactivate_deepcompile()
             raise
 
         self._is_compiled = True
@@ -5651,6 +5656,24 @@ class DeepSpeedEngine(Module):
             else:
                 logger.warning("Compiled autograd is not compatible with DeepCompile, disabling compiled autograd.")
                 self._is_compiled_autograd_enabled = False
+
+    def _initialize_deepcompile_native(self, compile_config):
+        dc = get_deepcompile_handle()
+        dc.init(self.data_parallel_group, compile_config, self.zero_reduce_bucket_size())
+        self._deepcompile_native_initialized = True
+        return dc
+
+    def _cleanup_deepcompile_native(self) -> None:
+        if not getattr(self, "_deepcompile_native_initialized", False):
+            return
+        self._deepcompile_native_initialized = False
+        get_deepcompile_handle().cleanup()
+
+    def _deactivate_deepcompile(self) -> None:
+        try:
+            self._cleanup_deepcompile_native()
+        finally:
+            self._set_deepcompile_active(False)
 
     def _set_deepcompile_active(self, active: bool) -> None:
         """Toggle DeepCompile runtime state and manage forward hooks accordingly."""

--- a/tests/torch_compile/test_deepcompile_z3_release.py
+++ b/tests/torch_compile/test_deepcompile_z3_release.py
@@ -25,12 +25,14 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
     def _device(self):
         return torch.device(get_accelerator().current_device_name())
 
-    def _init_dc(self):
+    def _init_dc(self, fixed_pool_budget=1 << 20):
         dc = get_deepcompile_handle()
         dc.init(dist.get_world_group(), CompileConfig(deepcompile=True), 1024)
+        if fixed_pool_budget is not None:
+            dc.set_z3_gather_buffer_pool_fixed_budget_for_test(fixed_pool_budget)
         return dc
 
-    def _register_param(self, dc, graph_id, ds_id, shape, persistent=False):
+    def _register_param(self, dc, graph_id, ds_id, shape, persistent=False, register_graph=True):
         device = self._device()
         world_size = dist.get_world_size()
         true_numel = math.prod(shape)
@@ -39,7 +41,8 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
         values = torch.arange(rank * shard_numel, (rank + 1) * shard_numel, device=device, dtype=torch.float32)
         grad_buffer = torch.zeros_like(values)
         dc.register_z3_param(ds_id, list(shape), values, grad_buffer, persistent, values.dtype)
-        dc.register_graph_z3(graph_id, [ds_id])
+        if register_graph:
+            dc.register_graph_z3(graph_id, [ds_id])
         return values
 
     def _gather_view_and_storage(self, shard, graph_id, ds_id):
@@ -63,14 +66,28 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
         values = values[:math.prod(shape)].reshape(-1)
         return values.narrow(0, 0, values.numel() - 1).sum()
 
-    def test_storage_resized_to_zero_after_release_single_use(self):
-        graph_id, ds_id = 9010, 9011
+    def _pool_state(self, dc):
+        keys = ("budget", "charged", "high_water", "entries", "checked_out", "retries", "enabled", "initialized",
+                "idle_pressure_score", "pressure_recovery_complete", "pressure_recovery_budget",
+                "pressure_recovery_pending_entries", "pressure_recovery_in_progress")
+        return dict(zip(keys, dc.get_z3_gather_buffer_pool_state_for_test()))
+
+    def test_storage_reused_after_release_single_use(self):
+        graph_id, ds_id, next_ds_id = 9010, 9011, 9012
         dc = self._init_dc()
         try:
-            shard = self._register_param(dc, graph_id, ds_id, [4097])
+            shard = self._register_param(dc, graph_id, ds_id, [4097], register_graph=False)
+            next_shard = self._register_param(dc, graph_id, next_ds_id, [2049], register_graph=False)
+            dc.register_graph_z3(graph_id, [ds_id, next_ds_id])
             view, storage = self._gather_view_and_storage(shard, graph_id, ds_id)
+            before_ptr = storage.data_ptr()
             self._release(view, graph_id, ds_id, 1)
-            assert storage.nbytes() == 0
+            assert storage.nbytes() > 0
+
+            next_view, next_storage = self._gather_view_and_storage(next_shard, graph_id, next_ds_id)
+            assert next_storage.data_ptr() == before_ptr
+            assert torch.allclose(next_view.sum(), self._expected_view_sum([2049]))
+            self._release(next_view, graph_id, next_ds_id, 1)
         finally:
             dc.cleanup()
 
@@ -84,7 +101,7 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
             self._release(view, graph_id, ds_id, 2)
             assert storage.nbytes() == before_release_nbytes
             self._release(view, graph_id, ds_id, 2)
-            assert storage.nbytes() == 0
+            assert storage.nbytes() == before_release_nbytes
         finally:
             dc.cleanup()
 
@@ -103,14 +120,16 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
             dc.cleanup()
 
     def test_consumer_stream_can_finish_before_storage_reuse(self):
-        graph_id, ds_id = 9040, 9041
+        graph_id, ds_id, next_ds_id = 9040, 9041, 9042
         if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
             pytest.skip("CUDA sleep helper is unavailable")
         dc = self._init_dc()
         try:
-            shard = self._register_param(dc, graph_id, ds_id, [4097])
+            shard = self._register_param(dc, graph_id, ds_id, [4097], register_graph=False)
+            next_shard = self._register_param(dc, graph_id, next_ds_id, [2049], register_graph=False)
+            dc.register_graph_z3(graph_id, [ds_id, next_ds_id])
             view, storage = self._gather_view_and_storage(shard, graph_id, ds_id)
-            padded_bytes = storage.nbytes()
+            before_ptr = storage.data_ptr()
             result = torch.empty((), device=self._device(), dtype=view.dtype)
             consumer_stream = get_accelerator().Stream()
             with get_accelerator().stream(consumer_stream):
@@ -118,13 +137,94 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
                 result.copy_(view.sum())
                 self._release(view, graph_id, ds_id, 1, synchronize=False)
 
-            scratch = torch.empty((padded_bytes // view.element_size()) + 1024,
-                                  device=self._device(),
-                                  dtype=view.dtype)
-            scratch.fill_(17)
+            next_view, next_storage = self._gather_view_and_storage(next_shard, graph_id, next_ds_id)
             get_accelerator().synchronize()
             assert torch.allclose(result, self._expected_view_sum([4097]))
+            assert next_storage.data_ptr() == before_ptr
+            assert torch.allclose(next_view.sum(), self._expected_view_sum([2049]))
+            assert storage.nbytes() > 0
+            self._release(next_view, graph_id, next_ds_id, 1)
+        finally:
+            dc.cleanup()
+
+    def test_repeated_allocator_pressure_recovers_once_and_readmits_non_aligned_working_set(self):
+        graph_id, ds_id = 9103, 9104
+        dc = self._init_dc(fixed_pool_budget=None)
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [1_048_577])
+            gib = 1 << 30
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(0, gib, 8 * gib)
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(1, gib, 8 * gib)
+
+            view, storage = self._gather_view_and_storage(shard, graph_id, ds_id)
+            self._release(view, graph_id, ds_id, 1)
+            assert storage.nbytes() > 2 << 20
+
+            before_pressure = self._pool_state(dc)
+            assert before_pressure["charged"] % (2 << 20) != 0
+
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(2, 8 << 20, 8 * gib)
+            after_pressure = self._pool_state(dc)
+            assert after_pressure["budget"] == before_pressure["charged"]
+            assert after_pressure["charged"] == before_pressure["charged"]
+            assert after_pressure["idle_pressure_score"] == 2
+            assert storage.nbytes() == before_pressure["charged"]
+
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(3, 8 << 20, 8 * gib)
+            after_threshold = self._pool_state(dc)
+            assert after_threshold["budget"] == before_pressure["charged"]
+            assert after_threshold["charged"] == 0
+            assert after_threshold["entries"] == 0
+            assert after_threshold["enabled"] == 1
+            assert after_threshold["idle_pressure_score"] == 0
+            assert after_threshold["pressure_recovery_complete"] == 1
             assert storage.nbytes() == 0
-            del scratch
+
+            recovered_view, recovered_storage = self._gather_view_and_storage(shard, graph_id, ds_id)
+            self._release(recovered_view, graph_id, ds_id, 1)
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(100, 8 << 20, 8 * gib)
+            after_repeat = self._pool_state(dc)
+            assert after_repeat["entries"] == 1
+            assert after_repeat["charged"] == before_pressure["charged"]
+            assert after_repeat["budget"] == before_pressure["charged"]
+            assert after_repeat["pressure_recovery_complete"] == 1
+            assert recovered_storage.nbytes() == before_pressure["charged"]
+        finally:
+            dc.cleanup()
+
+    def test_hard_cap_reclaim_preempts_recovery_below_hot_buffer_size(self):
+        graph_id, ds_id = 9135, 9136
+        dc = self._init_dc(fixed_pool_budget=None)
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [1_048_577])
+            gib = 1 << 30
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(0, gib, 8 * gib)
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(1, gib, 8 * gib)
+
+            view, storage = self._gather_view_and_storage(shard, graph_id, ds_id)
+            self._release(view, graph_id, ds_id, 1)
+            hot_capacity = storage.nbytes()
+            assert hot_capacity > 2 << 20
+
+            # The 2 MiB hard cap cannot hold this target. Recovery must drain
+            # the entry and close its one-shot lifecycle with no target.
+            dc.update_z3_gather_buffer_pool_allocator_pressure_for_test(5, 8 << 20, 64 << 20)
+            capped = self._pool_state(dc)
+            assert capped["budget"] == 0
+            assert capped["charged"] == 0
+            assert capped["entries"] == 0
+            assert capped["idle_pressure_score"] == 0
+            assert capped["pressure_recovery_complete"] == 1
+            assert capped["pressure_recovery_budget"] == 0
+            assert capped["pressure_recovery_pending_entries"] == 0
+            assert storage.nbytes() == 0
+
+            hot_view, hot_storage = self._gather_view_and_storage(shard, graph_id, ds_id)
+            self._release(hot_view, graph_id, ds_id, 1)
+            after_release = self._pool_state(dc)
+            assert after_release["entries"] == 0
+            assert after_release["charged"] == 0
+            assert after_release["pressure_recovery_complete"] == 1
+            assert hot_storage.nbytes() == 0
         finally:
             dc.cleanup()

--- a/tests/torch_compile/test_deepcompile_z3_release.py
+++ b/tests/torch_compile/test_deepcompile_z3_release.py
@@ -80,9 +80,18 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
                 "rank_plan_mismatches", "relocations", "stale_registry_releases")
         return dict(zip(keys, dc.get_z3_prefetch_arena_state_for_test(graph_id)))
 
-    def _configure_arena(self, dc, graph_id, plan_ids, ds_ids, offsets, request_bytes, capacity=512, phase=0):
-        dc.configure_z3_prefetch_arena(graph_id, phase, capacity, capacity, 12345 + phase, plan_ids, ds_ids, offsets,
-                                       request_bytes)
+    def _configure_arena(self,
+                         dc,
+                         graph_id,
+                         plan_ids,
+                         ds_ids,
+                         offsets,
+                         request_bytes,
+                         capacity=512,
+                         phase=0,
+                         require_backward=False):
+        dc.configure_z3_prefetch_arena(graph_id, phase, require_backward, capacity, capacity, 12345 + phase, plan_ids,
+                                       ds_ids, offsets, request_bytes)
 
     def _prefetch(self, shards, graph_id, ds_ids, plan_id, dtypes=None):
         torch.ops.dc.prefetch_params_fused.default(graph_id, shards, ds_ids, dtypes, plan_id)
@@ -193,6 +202,97 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
             assert state["pointer_stable"] == 1
             assert forward_storage.data_ptr() == backward_storage.data_ptr()
             assert forward_storage.nbytes() == backward_storage.nbytes() == 512
+        finally:
+            dc.cleanup()
+
+    def test_training_prefetch_arena_waits_for_backward_phase_before_allocating(self):
+        graph_id, forward_id, backward_id = 9233, 9234, 9235
+        dc = self._init_dc()
+        try:
+            forward = self._register_param(dc, graph_id, forward_id, [3], register_graph=False)
+            backward = self._register_param(dc, graph_id, backward_id, [5], register_graph=False)
+            dc.register_graph_z3(graph_id, [forward_id, backward_id])
+            self._configure_arena(dc,
+                                  graph_id, [10], [forward_id], [0], [16],
+                                  capacity=512,
+                                  phase=0,
+                                  require_backward=True)
+
+            self._prefetch([forward], graph_id, [forward_id], 10)
+            forward_view, forward_storage = self._gather_view_and_storage(forward, graph_id, forward_id)
+            pending = self._arena_state(dc, graph_id)
+            assert pending["enabled"] == 0
+            assert pending["phases"] == 1
+            assert pending["backing_allocations"] == 0
+            assert pending["fallback_bytes"] == 0
+            self._release(forward_view, graph_id, forward_id, 1)
+
+            self._configure_arena(dc,
+                                  graph_id, [1_000_010], [backward_id], [0], [32],
+                                  capacity=256,
+                                  phase=1,
+                                  require_backward=True)
+            self._prefetch([backward], graph_id, [backward_id], 1_000_010)
+            backward_view, backward_storage = self._gather_view_and_storage(backward, graph_id, backward_id)
+            active = self._arena_state(dc, graph_id)
+            assert active["enabled"] == 1
+            assert active["phases"] == 2
+            assert active["backing_allocations"] == 1
+            assert forward_storage.data_ptr() != backward_storage.data_ptr()
+            self._release(backward_view, graph_id, backward_id, 1)
+        finally:
+            dc.cleanup()
+
+    def test_training_prefetch_arena_session_disable_prevents_forward_only_backing(self):
+        graph_id, ds_id = 9236, 9237
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [5])
+            self._configure_arena(dc, graph_id, [10], [ds_id], [0], [32], capacity=512, phase=0, require_backward=True)
+            dc.disable_z3_prefetch_arena(graph_id, "shared_budget")
+            self._prefetch([shard], graph_id, [ds_id], 10)
+            gathered, _ = self._gather_view_and_storage(shard, graph_id, ds_id)
+            state = self._arena_state(dc, graph_id)
+            assert state["enabled"] == 0
+            assert state["backing_allocations"] == 0
+            assert state["fallback_bytes"] > 0
+            self._release(gathered, graph_id, ds_id, 1)
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_asymmetric_session_disable_reaches_terminal_consensus(self):
+        graph_id, first_id, second_id = 9238, 9239, 9240
+        dc = self._init_dc()
+        try:
+            first = self._register_param(dc, graph_id, first_id, [3], register_graph=False)
+            second = self._register_param(dc, graph_id, second_id, [5], register_graph=False)
+            dc.register_graph_z3(graph_id, [first_id, second_id])
+            self._configure_arena(dc, graph_id, [10, 11], [first_id, second_id], [0, 256], [16, 32])
+            rank = dist.get_rank()
+            if rank == 0:
+                dc.disable_z3_prefetch_arena(graph_id, "rank_local_budget")
+
+            self._prefetch([first], graph_id, [first_id], -1 if rank == 0 else 10)
+            first_view, first_storage = self._gather_view_and_storage(first, graph_id, first_id)
+            first_state = self._arena_state(dc, graph_id)
+            assert first_state["enabled"] == 0
+            assert first_state["backing_allocations"] == 0
+            assert first_state["rank_consistency_checks"] == 1
+            assert first_state["active_leases"] == 0
+            self._release(first_view, graph_id, first_id, 1)
+            assert first_storage.nbytes() == 0
+
+            # The globally disabled decision is terminal, so a later fused
+            # prefetch falls back without entering another session collective.
+            self._prefetch([second], graph_id, [second_id], -1 if rank == 0 else 11)
+            second_view, second_storage = self._gather_view_and_storage(second, graph_id, second_id)
+            self._release(second_view, graph_id, second_id, 1)
+            final_state = self._arena_state(dc, graph_id)
+            assert final_state["enabled"] == 0
+            assert final_state["backing_allocations"] == 0
+            assert final_state["rank_consistency_checks"] == 1
+            assert final_state["active_leases"] == 0
+            assert second_storage.nbytes() == 0
         finally:
             dc.cleanup()
 
@@ -332,7 +432,8 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
         dc = self._init_dc()
         try:
             shard = self._register_param(dc, graph_id, ds_id, [5])
-            dc.configure_z3_prefetch_arena(graph_id, 0, 512, 512, 12345 + dist.get_rank(), [10], [ds_id], [0], [32])
+            dc.configure_z3_prefetch_arena(graph_id, 0, False, 512, 512, 12345 + dist.get_rank(), [10], [ds_id], [0],
+                                           [32])
 
             self._prefetch([shard], graph_id, [ds_id], 10)
             gathered = torch.ops.dc.allgather_param.default(shard, graph_id, ds_id)

--- a/tests/torch_compile/test_deepcompile_z3_release.py
+++ b/tests/torch_compile/test_deepcompile_z3_release.py
@@ -70,7 +70,8 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
     def _pool_state(self, dc):
         keys = ("budget", "charged", "high_water", "entries", "checked_out", "retries", "enabled", "initialized",
                 "idle_pressure_score", "pressure_recovery_complete", "pressure_recovery_budget",
-                "pressure_recovery_pending_entries", "pressure_recovery_in_progress")
+                "pressure_recovery_pending_entries", "pressure_recovery_in_progress", "arena_transition_started",
+                "arena_transition_flush_complete")
         return dict(zip(keys, dc.get_z3_gather_buffer_pool_state_for_test()))
 
     def _arena_state(self, dc, graph_id):
@@ -206,12 +207,20 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
             dc.cleanup()
 
     def test_training_prefetch_arena_waits_for_backward_phase_before_allocating(self):
-        graph_id, forward_id, backward_id = 9233, 9234, 9235
+        graph_id, forward_id, backward_id, pooled_id = 9233, 9234, 9235, 9236
         dc = self._init_dc()
         try:
             forward = self._register_param(dc, graph_id, forward_id, [3], register_graph=False)
             backward = self._register_param(dc, graph_id, backward_id, [5], register_graph=False)
-            dc.register_graph_z3(graph_id, [forward_id, backward_id])
+            pooled = self._register_param(dc, graph_id, pooled_id, [7], register_graph=False)
+            dc.register_graph_z3(graph_id, [forward_id, backward_id, pooled_id])
+
+            pooled_view, pooled_storage = self._gather_view_and_storage(pooled, graph_id, pooled_id)
+            self._release(pooled_view, graph_id, pooled_id, 1)
+            before_transition = self._pool_state(dc)
+            assert before_transition["charged"] > 0
+            assert pooled_storage.nbytes() > 0
+
             self._configure_arena(dc,
                                   graph_id, [10], [forward_id], [0], [16],
                                   capacity=512,
@@ -239,12 +248,19 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
             assert active["phases"] == 2
             assert active["backing_allocations"] == 1
             assert forward_storage.data_ptr() != backward_storage.data_ptr()
+            after_transition = self._pool_state(dc)
+            assert after_transition["charged"] == 0
+            assert after_transition["entries"] == 0
+            assert after_transition["enabled"] == 0
+            assert after_transition["arena_transition_started"] == 1
+            assert after_transition["arena_transition_flush_complete"] == 1
+            assert pooled_storage.nbytes() == 0
             self._release(backward_view, graph_id, backward_id, 1)
         finally:
             dc.cleanup()
 
     def test_training_prefetch_arena_session_disable_prevents_forward_only_backing(self):
-        graph_id, ds_id = 9236, 9237
+        graph_id, ds_id = 9237, 9238
         dc = self._init_dc()
         try:
             shard = self._register_param(dc, graph_id, ds_id, [5])
@@ -495,6 +511,36 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
             self._release(gathered, graph_id, ds_id, 1)
             assert self._arena_state(dc, graph_id)["active_leases"] == 0
             dc.reset()
+        finally:
+            dc.cleanup()
+
+    def test_gather_pool_reclaimable_credit_counts_only_idle_storage(self):
+        graph_id, first_id, second_id = 9241, 9242, 9243
+        dc = self._init_dc()
+        try:
+            first = self._register_param(dc, graph_id, first_id, [4097], register_graph=False)
+            second = self._register_param(dc, graph_id, second_id, [2049], register_graph=False)
+            dc.register_graph_z3(graph_id, [first_id, second_id])
+
+            first_view, first_storage = self._gather_view_and_storage(first, graph_id, first_id)
+            self._release(first_view, graph_id, first_id, 1)
+            idle_credit = dc.get_z3_gather_buffer_pool_reclaimable_bytes()
+            assert idle_credit == first_storage.nbytes() > 0
+
+            second_view, second_storage = self._gather_view_and_storage(second, graph_id, second_id)
+            checked_out = self._pool_state(dc)
+            assert second_storage.data_ptr() == first_storage.data_ptr()
+            assert checked_out["charged"] == idle_credit
+            assert checked_out["checked_out"] == 1
+            assert dc.get_z3_gather_buffer_pool_reclaimable_bytes() == 0
+            assert dc.get_z3_gather_buffer_pool_transition_reclaimable_bytes() == idle_credit
+
+            self._release(second_view, graph_id, second_id, 1)
+            returned = self._pool_state(dc)
+            assert returned["charged"] == idle_credit
+            assert returned["checked_out"] == 0
+            assert dc.get_z3_gather_buffer_pool_reclaimable_bytes() == idle_credit
+            assert dc.get_z3_gather_buffer_pool_transition_reclaimable_bytes() == idle_credit
         finally:
             dc.cleanup()
 

--- a/tests/torch_compile/test_deepcompile_z3_release.py
+++ b/tests/torch_compile/test_deepcompile_z3_release.py
@@ -12,6 +12,7 @@ import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
 from deepspeed.compile.config import CompileConfig
 from deepspeed.compile.util import get_deepcompile_handle, is_deepcompile_supported
+from torch._subclasses.fake_tensor import FakeTensorMode
 from unit.common import DistributedTest
 
 pytestmark = pytest.mark.skipif(not is_deepcompile_supported(),
@@ -71,6 +72,330 @@ class TestDeepCompileZ3ReleaseStorage(DistributedTest):
                 "idle_pressure_score", "pressure_recovery_complete", "pressure_recovery_budget",
                 "pressure_recovery_pending_entries", "pressure_recovery_in_progress")
         return dict(zip(keys, dc.get_z3_gather_buffer_pool_state_for_test()))
+
+    def _arena_state(self, dc, graph_id):
+        keys = ("enabled", "phases", "capacity", "planned_max_live", "backing_allocations", "request_bytes",
+                "reuse_bytes", "fallback_bytes", "active_bytes", "high_water_bytes", "active_leases",
+                "high_water_slices", "event_waits", "overlaps", "pointer_stable", "rank_consistency_checks",
+                "rank_plan_mismatches", "relocations", "stale_registry_releases")
+        return dict(zip(keys, dc.get_z3_prefetch_arena_state_for_test(graph_id)))
+
+    def _configure_arena(self, dc, graph_id, plan_ids, ds_ids, offsets, request_bytes, capacity=512, phase=0):
+        dc.configure_z3_prefetch_arena(graph_id, phase, capacity, capacity, 12345 + phase, plan_ids, ds_ids, offsets,
+                                       request_bytes)
+
+    def _prefetch(self, shards, graph_id, ds_ids, plan_id, dtypes=None):
+        torch.ops.dc.prefetch_params_fused.default(graph_id, shards, ds_ids, dtypes, plan_id)
+
+    def test_prefetch_arena_distinct_slices_retrieval_and_stable_backing(self):
+        graph_id, first_id, second_id = 9200, 9201, 9202
+        dc = self._init_dc()
+        try:
+            first = self._register_param(dc, graph_id, first_id, [3], register_graph=False)
+            second = self._register_param(dc, graph_id, second_id, [5], register_graph=False)
+            dc.register_graph_z3(graph_id, [first_id, second_id])
+            # The optimization pass registers this metadata while Dynamo's
+            # FakeTensorMode is active.  Registration must not allocate or
+            # inspect the real CUDA backing in that context.
+            with FakeTensorMode(allow_non_fake_inputs=True):
+                self._configure_arena(dc, graph_id, [10, 10], [first_id, second_id], [0, 256], [16, 32])
+
+            before = self._arena_state(dc, graph_id)
+            self._prefetch([first, second], graph_id, [first_id, second_id], 10)
+            first_view, first_storage = self._gather_view_and_storage(first, graph_id, first_id)
+            second_view, second_storage = self._gather_view_and_storage(second, graph_id, second_id)
+
+            assert first_storage.data_ptr() + 256 == second_view.data_ptr()
+            assert first_storage.data_ptr() == second_storage.data_ptr()
+            assert torch.allclose(first_view.sum(), self._expected_view_sum([3]))
+            assert torch.allclose(second_view.sum(), self._expected_view_sum([5]))
+            self._release(first_view, graph_id, first_id, 1)
+            self._release(second_view, graph_id, second_id, 1)
+            after = self._arena_state(dc, graph_id)
+            # Python graph compilation only registers immutable plan metadata;
+            # the real CUDA backing is materialized by the first native fused
+            # prefetch after cross-rank consensus.
+            assert before["backing_allocations"] == 0
+            assert after["backing_allocations"] == 1
+            assert after["pointer_stable"] == 1
+            assert after["fallback_bytes"] == 0
+            assert after["active_leases"] == after["overlaps"] == 0
+            assert first_storage.nbytes() == second_storage.nbytes() == 512
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_final_release_reuses_slice_after_consumer_stream(self):
+        graph_id, first_id, second_id = 9210, 9211, 9212
+        if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
+            pytest.skip("CUDA sleep helper is unavailable")
+        dc = self._init_dc()
+        try:
+            first = self._register_param(dc, graph_id, first_id, [4097], register_graph=False)
+            second = self._register_param(dc, graph_id, second_id, [2049], register_graph=False)
+            dc.register_graph_z3(graph_id, [first_id, second_id])
+            first_bytes = first.numel() * dist.get_world_size() * first.element_size()
+            second_bytes = second.numel() * dist.get_world_size() * second.element_size()
+            capacity = math.ceil(max(first_bytes, second_bytes) / 256) * 256
+            self._configure_arena(dc,
+                                  graph_id, [10, 11], [first_id, second_id], [0, 0], [first_bytes, second_bytes],
+                                  capacity=capacity)
+
+            self._prefetch([first], graph_id, [first_id], 10)
+            first_view, first_storage = self._gather_view_and_storage(first, graph_id, first_id)
+            result = torch.empty((), device=self._device(), dtype=first_view.dtype)
+            consumer_stream = get_accelerator().Stream()
+            with get_accelerator().stream(consumer_stream):
+                torch.cuda._sleep(int(1e8))  #ignore-cuda
+                result.copy_(first_view.sum())
+                self._release(first_view, graph_id, first_id, 1, synchronize=False)
+
+            self._prefetch([second], graph_id, [second_id], 11)
+            second_view, second_storage = self._gather_view_and_storage(second, graph_id, second_id)
+            get_accelerator().synchronize()
+
+            assert second_storage.data_ptr() == first_storage.data_ptr()
+            assert torch.allclose(result, self._expected_view_sum([4097]))
+            assert torch.allclose(second_view.sum(), self._expected_view_sum([2049]))
+            self._release(second_view, graph_id, second_id, 1)
+            state = self._arena_state(dc, graph_id)
+            assert state["reuse_bytes"] == second_bytes
+            assert state["event_waits"] == 1
+            assert state["active_leases"] == 0
+            assert first_storage.nbytes() == capacity
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_shares_one_backing_across_forward_and_backward_phases(self):
+        graph_id, forward_id, backward_id = 9213, 9214, 9215
+        dc = self._init_dc()
+        try:
+            forward = self._register_param(dc, graph_id, forward_id, [3], register_graph=False)
+            backward = self._register_param(dc, graph_id, backward_id, [5], register_graph=False)
+            dc.register_graph_z3(graph_id, [forward_id, backward_id])
+            self._configure_arena(dc, graph_id, [10], [forward_id], [0], [16], capacity=512, phase=0)
+            self._configure_arena(dc, graph_id, [1_000_010], [backward_id], [0], [32], capacity=256, phase=1)
+
+            self._prefetch([forward], graph_id, [forward_id], 10)
+            forward_view, forward_storage = self._gather_view_and_storage(forward, graph_id, forward_id)
+            self._release(forward_view, graph_id, forward_id, 1)
+
+            self._prefetch([backward], graph_id, [backward_id], 1_000_010)
+            backward_view, backward_storage = self._gather_view_and_storage(backward, graph_id, backward_id)
+            self._release(backward_view, graph_id, backward_id, 1)
+
+            state = self._arena_state(dc, graph_id)
+            assert state["phases"] == 2
+            assert state["capacity"] == 512
+            assert state["planned_max_live"] == 512
+            assert state["backing_allocations"] == 1
+            assert state["fallback_bytes"] == 0
+            assert state["active_leases"] == state["overlaps"] == 0
+            assert state["pointer_stable"] == 1
+            assert forward_storage.data_ptr() == backward_storage.data_ptr()
+            assert forward_storage.nbytes() == backward_storage.nbytes() == 512
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_relocates_when_compiler_advances_prefetch(self):
+        graph_id, first_id, second_id = 9221, 9222, 9223
+        dc = self._init_dc()
+        try:
+            first = self._register_param(dc, graph_id, first_id, [3], register_graph=False)
+            second = self._register_param(dc, graph_id, second_id, [5], register_graph=False)
+            dc.register_graph_z3(graph_id, [first_id, second_id])
+            self._configure_arena(dc, graph_id, [10, 11], [first_id, second_id], [0, 0], [16, 32], capacity=512)
+
+            self._prefetch([first], graph_id, [first_id], 10)
+            first_view, first_storage = self._gather_view_and_storage(first, graph_id, first_id)
+            self._prefetch([second], graph_id, [second_id], 11)
+            second_view, second_storage = self._gather_view_and_storage(second, graph_id, second_id)
+
+            assert first_storage.data_ptr() + 256 == second_view.data_ptr()
+            assert first_storage.data_ptr() == second_storage.data_ptr()
+            assert torch.allclose(first_view.sum(), self._expected_view_sum([3]))
+            assert torch.allclose(second_view.sum(), self._expected_view_sum([5]))
+            self._release(first_view, graph_id, first_id, 1)
+            self._release(second_view, graph_id, second_id, 1)
+            state = self._arena_state(dc, graph_id)
+            assert state["relocations"] == 1
+            assert state["overlaps"] == 0
+            assert state["fallback_bytes"] == 0
+            assert state["active_leases"] == 0
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_stale_release_preserves_newer_registry_generation(self):
+        arena_graph_id, newer_graph_id, ds_id = 9218, 9219, 9220
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, arena_graph_id, ds_id, [5], register_graph=False)
+            dc.register_graph_z3(arena_graph_id, [ds_id])
+            dc.register_graph_z3(newer_graph_id, [ds_id])
+            self._configure_arena(dc, arena_graph_id, [10], [ds_id], [0], [32])
+
+            self._prefetch([shard], arena_graph_id, [ds_id], 10)
+            arena_view, arena_storage = self._gather_view_and_storage(shard, arena_graph_id, ds_id)
+
+            # Profiling owns this global invalidation API. A nested/newer graph
+            # can then install another gathered tensor before the arena graph's
+            # release node executes.
+            dc.invalidate_gathered_param(ds_id)
+            newer_view, newer_storage = self._gather_view_and_storage(shard, newer_graph_id, ds_id)
+            assert newer_storage.data_ptr() != arena_storage.data_ptr()
+
+            self._release(arena_view, arena_graph_id, ds_id, 1)
+            latest_view, latest_storage = self._gather_view_and_storage(shard, newer_graph_id, ds_id)
+            assert latest_storage.data_ptr() == newer_storage.data_ptr()
+            assert torch.allclose(latest_view.sum(), self._expected_view_sum([5]))
+
+            state = self._arena_state(dc, arena_graph_id)
+            assert state["active_leases"] == 0
+            assert state["stale_registry_releases"] == 1
+            assert arena_storage.nbytes() == 512
+            self._release(newer_view, newer_graph_id, ds_id, 1)
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_capacity_exhaustion_falls_back_without_leasing_overlap(self):
+        graph_id, first_id, second_id = 9218, 9219, 9220
+        dc = self._init_dc()
+        try:
+            first = self._register_param(dc, graph_id, first_id, [3], register_graph=False)
+            second = self._register_param(dc, graph_id, second_id, [5], register_graph=False)
+            dc.register_graph_z3(graph_id, [first_id, second_id])
+            self._configure_arena(dc, graph_id, [10, 11], [first_id, second_id], [0, 0], [16, 32], capacity=256)
+
+            self._prefetch([first], graph_id, [first_id], 10)
+            first_view, first_storage = self._gather_view_and_storage(first, graph_id, first_id)
+            self._prefetch([second], graph_id, [second_id], 11)
+            second_view, second_storage = self._gather_view_and_storage(second, graph_id, second_id)
+
+            assert first_storage.data_ptr() != second_storage.data_ptr()
+            assert torch.allclose(first_view.sum(), self._expected_view_sum([3]))
+            assert torch.allclose(second_view.sum(), self._expected_view_sum([5]))
+            self._release(first_view, graph_id, first_id, 1)
+            self._release(second_view, graph_id, second_id, 1)
+            state = self._arena_state(dc, graph_id)
+            assert state["relocations"] == 0
+            assert state["overlaps"] == 0
+            assert state["fallback_bytes"] == second.numel() * dist.get_world_size() * second.element_size()
+            assert state["active_leases"] == 0
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_dtype_mismatch_falls_back_without_resizing_backing(self):
+        graph_id, ds_id = 9220, 9221
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [5])
+            self._configure_arena(dc, graph_id, [10], [ds_id], [0], [32])
+
+            self._prefetch([shard], graph_id, [ds_id], 10, [torch.float16])
+            gathered = torch.ops.dc.allgather_param.default(shard, graph_id, ds_id, torch.float16)
+            gathered = torch.ops.dc.wait_allgather.default(gathered, graph_id, ds_id)
+            fallback_storage = gathered.untyped_storage()
+            self._release(gathered, graph_id, ds_id, 1)
+
+            state = self._arena_state(dc, graph_id)
+            assert state["fallback_bytes"] == shard.numel() * dist.get_world_size() * 2
+            assert state["active_leases"] == 0
+            assert state["capacity"] == 512
+            assert state["pointer_stable"] == 1
+            assert fallback_storage.nbytes() == 0
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_capacity_overflow_falls_back_without_resizing_backing(self):
+        graph_id, ds_id = 9225, 9226
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [5])
+            self._configure_arena(dc, graph_id, [10], [ds_id], [0], [16])
+
+            self._prefetch([shard], graph_id, [ds_id], 10)
+            gathered = torch.ops.dc.allgather_param.default(shard, graph_id, ds_id)
+            gathered = torch.ops.dc.wait_allgather.default(gathered, graph_id, ds_id)
+            fallback_storage = gathered.untyped_storage()
+            self._release(gathered, graph_id, ds_id, 1)
+
+            state = self._arena_state(dc, graph_id)
+            assert state["fallback_bytes"] == shard.numel() * dist.get_world_size() * shard.element_size()
+            assert state["active_leases"] == 0
+            assert state["capacity"] == 512
+            assert state["pointer_stable"] == 1
+            assert fallback_storage.nbytes() == 0
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_rank_plan_mismatch_falls_back_on_every_rank(self):
+        graph_id, ds_id = 9227, 9228
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [5])
+            dc.configure_z3_prefetch_arena(graph_id, 0, 512, 512, 12345 + dist.get_rank(), [10], [ds_id], [0], [32])
+
+            self._prefetch([shard], graph_id, [ds_id], 10)
+            gathered = torch.ops.dc.allgather_param.default(shard, graph_id, ds_id)
+            gathered = torch.ops.dc.wait_allgather.default(gathered, graph_id, ds_id)
+            fallback_storage = gathered.untyped_storage()
+            self._release(gathered, graph_id, ds_id, 1)
+
+            state = self._arena_state(dc, graph_id)
+            assert state["enabled"] == 0
+            assert state["rank_consistency_checks"] == 1
+            assert state["rank_plan_mismatches"] == 1
+            assert state["active_leases"] == 0
+            assert fallback_storage.nbytes() == 0
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_missing_plan_on_one_rank_falls_back_on_every_rank(self):
+        graph_id, ds_id = 9229, 9230
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [5])
+            rank = dist.get_rank()
+            if rank == 0:
+                self._configure_arena(dc, graph_id, [10], [ds_id], [0], [32])
+
+            # The fused graph carries the same plan ID on every rank even if
+            # rank-local metadata prevented one executor from configuring the
+            # plan. Both ranks must still enter runtime consensus and disable
+            # the arena before the gather.
+            self._prefetch([shard], graph_id, [ds_id], 10)
+            gathered = torch.ops.dc.allgather_param.default(shard, graph_id, ds_id)
+            gathered = torch.ops.dc.wait_allgather.default(gathered, graph_id, ds_id)
+            fallback_storage = gathered.untyped_storage()
+            self._release(gathered, graph_id, ds_id, 1)
+
+            state = self._arena_state(dc, graph_id)
+            assert state["enabled"] == 0
+            assert state["rank_consistency_checks"] == 1
+            assert state["rank_plan_mismatches"] == 1
+            assert state["active_leases"] == 0
+            assert fallback_storage.nbytes() == 0
+        finally:
+            dc.cleanup()
+
+    def test_prefetch_arena_reset_requires_zero_leases(self):
+        graph_id, ds_id = 9230, 9231
+        dc = self._init_dc()
+        try:
+            shard = self._register_param(dc, graph_id, ds_id, [3])
+            self._configure_arena(dc, graph_id, [10], [ds_id], [0], [16])
+            self._prefetch([shard], graph_id, [ds_id], 10)
+            gathered = torch.ops.dc.allgather_param.default(shard, graph_id, ds_id)
+            gathered = torch.ops.dc.wait_allgather.default(gathered, graph_id, ds_id)
+
+            with pytest.raises(RuntimeError, match="active leases"):
+                dc.reset()
+            assert self._arena_state(dc, graph_id)["active_leases"] == 1
+
+            self._release(gathered, graph_id, ds_id, 1)
+            assert self._arena_state(dc, graph_id)["active_leases"] == 0
+            dc.reset()
+        finally:
+            dc.cleanup()
 
     def test_storage_reused_after_release_single_use(self):
         graph_id, ds_id, next_ds_id = 9010, 9011, 9012

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -16,6 +16,7 @@ from deepspeed.compile import inductor as inductor_mod
 from deepspeed.compile import list_schedule as schedule_mod
 from deepspeed.compile.passes import prefetch as prefetch_mod
 from deepspeed.compile.passes import selective_gather as selective_gather_mod
+from deepspeed.compile.passes import zero3_compile as zero3_compile_mod
 from deepspeed.compile.profilers import ProfilingResult
 from deepspeed.compile.profilers.graph_profile import _backfill_missing_profile_metadata, is_profile_incomplete
 
@@ -58,6 +59,9 @@ def stub_deepcompile_ops(monkeypatch):
 
 def _with_meta(node, tensor_size=0, device_time=0):
     node.meta["tensor_size"] = tensor_size
+    node.meta["alloc_mem"] = 0
+    node.meta["profile_mem_start"] = 0
+    node.meta["profile_mem_peak"] = 0
     if device_time is not None:
         node.meta["device_time"] = device_time
     return node
@@ -90,6 +94,76 @@ def test_sync_memory_profile_complete_reduces_asymmetric_failure(monkeypatch):
     monkeypatch.setattr(backend_mod.dist, "all_reduce", mark_any_rank_failed)
 
     assert not backend_mod._sync_memory_profile_complete(True)
+
+
+def test_scheduler_debug_env_flag_values(monkeypatch):
+    monkeypatch.delenv(zero3_compile_mod.SCHEDULER_DEBUG_ENV, raising=False)
+    assert not zero3_compile_mod._scheduler_debug_enabled()
+
+    for value in ("", "0", "false", "FALSE", "no", "No"):
+        monkeypatch.setenv(zero3_compile_mod.SCHEDULER_DEBUG_ENV, value)
+        assert not zero3_compile_mod._scheduler_debug_enabled()
+
+    for value in ("1", "true", "TRUE", "yes", "debug"):
+        monkeypatch.setenv(zero3_compile_mod.SCHEDULER_DEBUG_ENV, value)
+        assert zero3_compile_mod._scheduler_debug_enabled()
+
+
+def test_unreleased_scheduler_debug_alias_is_not_supported(monkeypatch):
+    monkeypatch.delenv(zero3_compile_mod.SCHEDULER_DEBUG_ENV, raising=False)
+    monkeypatch.setenv("DEEPSPEED_DEEPCOMPILE_SCHEDULER_DEBUG", "1")
+
+    assert not zero3_compile_mod._scheduler_debug_enabled()
+
+
+def test_zero3_scheduler_budget_uses_rank_reduced_non_gathered_peak(monkeypatch):
+    monkeypatch.setattr(zero3_compile_mod.dist, "is_initialized", lambda: True)
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 2000
+
+    max_reductions = iter((850, 200))
+
+    def reduce_budget_inputs(tensor, op, group=None):
+        assert group is None
+        if op == zero3_compile_mod.dist.ReduceOp.MIN:
+            tensor[0] = 1000
+        elif op == zero3_compile_mod.dist.ReduceOp.MAX:
+            tensor[0] = next(max_reductions)
+        else:
+            raise AssertionError(f"unexpected reduce op {op}")
+
+    monkeypatch.setattr(zero3_compile_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(zero3_compile_mod.dist, "all_reduce", reduce_budget_inputs)
+
+    graph = Graph()
+    param = _placeholder(graph, "budget_builder_param")
+    ag = _allgather(graph, param, 1, "budget_builder", tensor_size=200)
+    wait = _wait(graph, ag, 1, "budget_builder")
+    op = _neg(graph, wait, "budget_builder_op")
+    op.meta.update(max_mem=800, profile_mem_start=250, profile_mem_peak=1050)
+    release = _release(graph, op, 1, "budget_builder")
+    graph.output((release, ))
+    graph.lint()
+    for node in graph.nodes:
+        node.meta.setdefault("alloc_mem", 0)
+        node.meta.setdefault("max_mem", 0)
+        node.meta.setdefault("profile_mem_start", 0)
+        node.meta.setdefault("profile_mem_peak", 0)
+
+    budget = zero3_compile_mod._build_scheduler_budget_from_operator_profile(graph)
+
+    assert budget.source == "profiled_non_gathered_peak_memory_clamped_to_minimum_gather_residency"
+    assert budget.total_mem == 1000
+    assert budget.profiled_non_gathered_peak_mem == 850
+    assert budget.safety_margin == 100
+    assert budget.available_mem == 50
+    assert budget.max_gathered_bytes == 200
 
 
 # The helpers below build nodes through Graph.create_node instead of Graph.call_function
@@ -129,8 +203,16 @@ def _release(graph, arg, ds_id, name):
                           name=f"release_ds_param_{name}_{ds_id}"))
 
 
-def _scheduled_names(graph):
-    return [node.name for node in schedule_mod.fast_free_schedule(graph, 0, 0, debug_log=True).nodes]
+def _scheduled_graph(graph, scheduler_budget=None):
+    return schedule_mod.fast_free_schedule(graph, 0, 0, debug_log=True, scheduler_budget=scheduler_budget)
+
+
+def _scheduled_names(graph, scheduler_budget=None):
+    return [node.name for node in _scheduled_graph(graph, scheduler_budget=scheduler_budget).nodes]
+
+
+def _scheduler_diagnostics(graph):
+    return getattr(graph, schedule_mod.DS_SCHEDULER_BUDGET_DIAGNOSTICS_ATTR)
 
 
 def test_fast_free_schedule_keeps_zero_free_acc_filter():
@@ -223,6 +305,49 @@ def test_fast_free_schedule_uses_pressure_tiebreaker_in_fallback_bucket():
     names = _scheduled_names(graph)
 
     assert names.index(low_ag.name) < names.index(high_ag.name)
+
+
+def test_fast_free_schedule_counts_live_gathered_bytes_when_filtering_candidates():
+    graph = Graph()
+
+    first_param = _placeholder(graph, "budget_first_param")
+    high_param = _placeholder(graph, "budget_high_param")
+    low_param = _placeholder(graph, "budget_low_param")
+
+    first_ag = _allgather(graph, first_param, 80, "budget_first", tensor_size=70)
+    first_wait = _wait(graph, first_ag, 80, "budget_first")
+
+    high_dep = _add(graph, high_param, first_wait, "budget_high_dep")
+    high_ag = _allgather(graph, high_dep, 81, "budget_high", tensor_size=40)
+    high_wait = _wait(graph, high_ag, 81, "budget_high")
+    high_use = _neg(graph, high_wait, "budget_high_use", device_time=1)
+    high_release = _release(graph, high_use, 81, "budget_high")
+
+    low_dep = _add(graph, low_param, first_wait, "budget_low_dep")
+    low_ag = _allgather(graph, low_dep, 82, "budget_low", tensor_size=20)
+    low_wait = _wait(graph, low_ag, 82, "budget_low")
+    low_use = _neg(graph, low_wait, "budget_low_use", device_time=100)
+    low_release = _release(graph, low_use, 82, "budget_low")
+
+    high_low_pair = _add(graph, high_wait, low_wait, "budget_high_low_pair")
+    first_use = _add(graph, first_wait, high_low_pair, "budget_first_use")
+    first_release = _release(graph, first_use, 80, "budget_first")
+
+    graph.output((first_release, high_release, low_release))
+    graph.lint()
+
+    no_budget_names = _scheduled_names(graph)
+    assert no_budget_names.index(high_ag.name) < no_budget_names.index(low_ag.name)
+
+    budget = schedule_mod.SchedulerMemoryBudget(max_gathered_bytes=100, source="test")
+    scheduled_graph = _scheduled_graph(graph, scheduler_budget=budget)
+    names = [node.name for node in scheduled_graph.nodes]
+    diagnostics = _scheduler_diagnostics(scheduled_graph)
+
+    assert names.index(first_ag.name) < names.index(low_ag.name)
+    assert names.index(low_ag.name) < names.index(high_ag.name)
+    assert diagnostics["budget_rejections"] > 0
+    assert any(record["node"] == high_ag.name for record in diagnostics["budget_rejected_candidates"])
 
 
 def test_fast_free_schedule_keeps_single_allgather_release_order():

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -26,9 +26,11 @@ _DC_LIBRARIES = []
 def _define_dc_ops():
     try:
         torch.ops.dc.allgather_param.default
+        torch.ops.dc.prefetch_params_fused.default
         torch.ops.dc.wait_allgather.default
         torch.ops.dc.release_param.default
         torch.ops.dc.reduce_grad.default
+        torch.ops.dc.reload_parameter.default
         return
     except AttributeError:
         pass
@@ -36,9 +38,11 @@ def _define_dc_ops():
     lib = torch.library.Library("dc", "DEF")
     for schema in (
             "allgather_param(Tensor a, int graph_id, int id, ScalarType? dtype = None) -> Tensor",
+            "prefetch_params_fused(int graph_id, Tensor[] params, int[] ids, ScalarType[]? dtypes = None, int arena_plan_id = -1) -> ()",
             "wait_allgather(Tensor(a) a, int graph_id, int id) -> Tensor(a)",
             "release_param(Tensor(a) a, int graph_id, int id, int n_users) -> Tensor(a)",
             "reduce_grad(Tensor a, int graph_id, int id) -> Tensor",
+            "reload_parameter(Tensor a, int graph_id, int id) -> ()",
             "free_tensors(Tensor[] tensors) -> ()",
             "end_backward(Tensor[] tensors, int graph_id, bool release_reduce_buckets = True) -> ()",
     ):
@@ -201,6 +205,272 @@ def _release(graph, arg, ds_id, name):
         graph.create_node('call_function',
                           torch.ops.dc.release_param.default, (arg, 0, ds_id, 1), {},
                           name=f"release_ds_param_{name}_{ds_id}"))
+
+
+def _arena_prefetch(graph, params, ds_ids, plan_id, sizes):
+    node = graph.create_node('call_function',
+                             torch.ops.dc.prefetch_params_fused.default, (0, params, ds_ids, None, plan_id), {},
+                             name=f"prefetch_arena_{plan_id}")
+    node.meta["prefetch_arena_eligible_ds_ids"] = tuple(dict.fromkeys(ds_ids))
+    node.meta["prefetch_arena_bytes_by_ds_id"] = tuple(zip(ds_ids, sizes))
+    return node
+
+
+def _fake_arena_param_manager(params):
+    return SimpleNamespace(
+        params={
+            name: SimpleNamespace(shape=torch.Size(shape), dtype=dtype, param=SimpleNamespace(ds_persist=False))
+            for name, _, shape, dtype in params
+        },
+        ds_ids={
+            name: ds_id
+            for name, ds_id, _, _ in params
+        },
+    )
+
+
+def test_prefetch_arena_interval_packing_alignment_and_reuse():
+    packed, reason = prefetch_mod._pack_prefetch_intervals([
+        {
+            "ds_id": 1,
+            "start": 0,
+            "end": 2,
+            "bytes": 257,
+            "requests": [(10, 1)]
+        },
+        {
+            "ds_id": 2,
+            "start": 1,
+            "end": 3,
+            "bytes": 255,
+            "requests": [(11, 2)]
+        },
+        {
+            "ds_id": 3,
+            "start": 4,
+            "end": 5,
+            "bytes": 256,
+            "requests": [(12, 3)]
+        },
+    ])
+
+    assert reason is None
+    by_ds_id = {interval["ds_id"]: interval for interval in packed["intervals"]}
+    assert by_ds_id[1]["size"] == 512
+    assert by_ds_id[2]["size"] == 256
+    assert by_ds_id[1]["offset"] != by_ds_id[2]["offset"]
+    assert by_ds_id[3]["offset"] == by_ds_id[1]["offset"]
+    assert packed["max_live_bytes"] == 768
+    assert packed["capacity"] == 768
+
+
+def test_prefetch_arena_plan_uses_final_padded_bytes_and_coalesces_repeated_ids():
+    graph = Graph()
+    first = graph.placeholder("first")
+    second = graph.placeholder("second")
+    _arena_prefetch(graph, [first, first, second], [1, 1, 2], 10, [12, 12, 16])
+    release_first = _release(graph, first, 1, "arena_first")
+    release_second = _release(graph, second, 2, "arena_second")
+    graph.output((release_first, release_second))
+    manager = _fake_arena_param_manager([
+        ("first", 1, (5, ), torch.float16),
+        ("second", 2, (8, ), torch.float16),
+    ])
+
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=False)
+
+    assert reason is None
+    assert [(entry["plan_id"], entry["ds_id"], entry["bytes"]) for entry in plan["entries"]] == [(10, 1, 12),
+                                                                                                 (10, 2, 16)]
+    assert plan["capacity"] == 512
+    assert plan["max_live_bytes"] == 512
+    assert all(entry["offset"] % prefetch_mod.PREFETCH_ARENA_ALIGNMENT == 0 for entry in plan["entries"])
+
+
+def test_prefetch_arena_reuse_adds_release_ordering_dependencies():
+    graph = Graph()
+    first = graph.placeholder("first")
+    second = graph.placeholder("second")
+    demand_only = graph.placeholder("demand_only")
+    first_prefetch = _arena_prefetch(graph, [first], [1], 10, [16])
+    first_release = _release(graph, first, 1, "arena_first")
+    _release(graph, demand_only, 3, "demand_only")
+    second_release = _release(graph, second, 2, "arena_second")
+    second_prefetch = _arena_prefetch(graph, [second], [2], 11, [16])
+    graph.output((first_prefetch, second_prefetch))
+
+    prefetch_mod._add_prefetch_arena_release_dependencies(graph)
+    graph.lint()
+
+    assert first_prefetch.args[1] == [first]
+    assert second_prefetch.args[1] == [second, first_release, second_release]
+    assert second_prefetch.args[2] == [2]
+    assert second_prefetch.meta["prefetch_arena_ordering_dependencies"] == (
+        first_release.name,
+        second_release.name,
+    )
+
+
+def test_prefetch_arena_plan_reuses_nonoverlapping_slice_but_not_overlapping_slice():
+    graph = Graph()
+    first = graph.placeholder("first")
+    second = graph.placeholder("second")
+    third = graph.placeholder("third")
+    _arena_prefetch(graph, [first], [1], 10, [256])
+    release_first = _release(graph, first, 1, "arena_first")
+    _arena_prefetch(graph, [second, third], [2, 3], 11, [256, 256])
+    release_second = _release(graph, second, 2, "arena_second")
+    release_third = _release(graph, third, 3, "arena_third")
+    graph.output((release_first, release_second, release_third))
+    manager = _fake_arena_param_manager([
+        ("first", 1, (128, ), torch.float16),
+        ("second", 2, (128, ), torch.float16),
+        ("third", 3, (128, ), torch.float16),
+    ])
+
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=True)
+
+    assert reason is None
+    offsets = {entry["ds_id"]: entry["offset"] for entry in plan["entries"]}
+    assert offsets[1] == offsets[2]
+    assert offsets[2] != offsets[3]
+    assert plan["phase"] == 1
+    assert plan["capacity"] == plan["max_live_bytes"] == 512
+
+
+def test_prefetch_arena_plan_reuses_slice_for_sequential_repeated_id():
+    graph = Graph()
+    param = graph.placeholder("param")
+    _arena_prefetch(graph, [param], [1], 10, [256])
+    first_release = _release(graph, param, 1, "arena_first")
+    _arena_prefetch(graph, [param], [1], 11, [256])
+    second_release = _release(graph, param, 1, "arena_second")
+    graph.output((first_release, second_release))
+    manager = _fake_arena_param_manager([("param", 1, (128, ), torch.float16)])
+
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=False)
+
+    assert reason is None
+    assert [(entry["plan_id"], entry["offset"]) for entry in plan["entries"]] == [(10, 0), (11, 0)]
+    assert plan["capacity"] == plan["max_live_bytes"] == 256
+
+
+@pytest.mark.parametrize("missing", ["release", "scheduled_bytes"])
+def test_prefetch_arena_plan_falls_back_on_incomplete_metadata(missing):
+    graph = Graph()
+    param = graph.placeholder("param")
+    prefetch = _arena_prefetch(graph, [param], [1], 10, [12])
+    if missing == "scheduled_bytes":
+        prefetch.meta["prefetch_arena_bytes_by_ds_id"] = ()
+    if missing != "release":
+        release = _release(graph, param, 1, "arena_param")
+        graph.output((release, ))
+    else:
+        graph.output((param, ))
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=False)
+
+    assert plan is None
+    assert reason == ("incomplete_release" if missing == "release" else "missing_scheduled_bytes")
+
+
+def test_prefetch_arena_plan_falls_back_on_dynamic_shape():
+    graph = Graph()
+    param = graph.placeholder("param")
+    _arena_prefetch(graph, [param], [1], 10, [12])
+    release = _release(graph, param, 1, "arena_param")
+    graph.output((release, ))
+    manager = SimpleNamespace(
+        params={"param": SimpleNamespace(shape=(object(), ), dtype=torch.float16)},
+        ds_ids={"param": 1},
+    )
+
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=False)
+
+    assert plan is None
+    assert reason == "dynamic_shape"
+
+
+@pytest.mark.parametrize("arena_enabled", [False, True])
+def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypatch, arena_enabled):
+    graph = Graph()
+    param = _placeholder(graph, "param")
+    ag = _allgather(graph, param, 1, "arena", tensor_size=12)
+    ag.meta["allgather_allocation_bytes"] = 12
+    wait = _wait(graph, ag, 1, "arena")
+    use = _neg(graph, wait, "arena_use")
+    release = _release(graph, use, 1, "arena")
+    graph.output((release, ))
+    graph.lint()
+
+    records = [(node.name, 0, 0, 0) for node in graph.nodes]
+    times = [(node.name, 1, 1) for node in graph.nodes]
+    sizes = [(node.name, int(node.meta.get("tensor_size", 0))) for node in graph.nodes]
+    profile = ProfilingResult(fwd_graph=graph,
+                              fwd_mem=records,
+                              fwd_time=times,
+                              fwd_tensor_sizes=sizes,
+                              process_group="test-group")
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+    configured = []
+    reductions = []
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 1 << 20
+
+        def available_memory(self):
+            return 1 << 20
+
+        def memory_allocated(self):
+            return 0
+
+        def max_memory_allocated(self):
+            return 0
+
+    if arena_enabled:
+        monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
+    else:
+        monkeypatch.delenv(prefetch_mod.PREFETCH_ARENA_ENV, raising=False)
+    monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
+    monkeypatch.setattr(prefetch_mod.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(prefetch_mod.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(prefetch_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(prefetch_mod.dist, "all_reduce", lambda *args, **kwargs: reductions.append(args))
+    monkeypatch.setattr(prefetch_mod, "get_deepcompile_handle",
+                        lambda: SimpleNamespace(configure_z3_prefetch_arena=lambda *args: configured.append(args)))
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    result = prefetch_mod.schedule_prefetch(gm,
+                                            graph_id=0,
+                                            graph_order=[(0, False)],
+                                            profiling_results={0: profile},
+                                            create_inputs_fn=lambda: (),
+                                            mem_budget=0,
+                                            param_manager={0: manager},
+                                            bwd=False)
+
+    prefetch_nodes = [node for node in result.graph.nodes if node.target == torch.ops.dc.prefetch_params_fused.default]
+    # The scheduler's existing memory-budget reduction remains, but arena-plan
+    # consensus is deferred to native execution where graph order is stable.
+    assert len(reductions) == 1
+    assert len(prefetch_nodes) == 1
+    if arena_enabled:
+        assert prefetch_nodes[0].args[4] == 0
+        assert prefetch_nodes[0].meta["prefetch_arena_eligible_ds_ids"] == (1, )
+        assert len(configured) == 1
+        assert configured[0][:4] == (0, 0, 256, 256)
+        assert configured[0][4] > 0
+        assert configured[0][5:] == ([0], [1], [0], [12])
+    else:
+        assert len(prefetch_nodes[0].args) == 3
+        assert configured == []
 
 
 def _scheduled_graph(graph, scheduler_budget=None):

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -264,6 +264,48 @@ def test_prefetch_arena_interval_packing_alignment_and_reuse():
     assert packed["capacity"] == 768
 
 
+def test_prefetch_arena_interval_packing_uses_best_fit_free_block():
+    packed, reason = prefetch_mod._pack_prefetch_intervals([
+        {
+            "ds_id": 1,
+            "start": 0,
+            "end": 1,
+            "bytes": 10
+        },
+        {
+            "ds_id": 2,
+            "start": 0,
+            "end": 10,
+            "bytes": 4
+        },
+        {
+            "ds_id": 3,
+            "start": 1,
+            "end": 2,
+            "bytes": 6
+        },
+        {
+            "ds_id": 4,
+            "start": 3,
+            "end": 4,
+            "bytes": 6
+        },
+        {
+            "ds_id": 5,
+            "start": 3,
+            "end": 4,
+            "bytes": 10
+        },
+    ],
+                                                           alignment=1)
+
+    assert reason is None
+    assert packed["capacity"] == packed["max_live_bytes"] == 20
+    offsets = {interval["ds_id"]: interval["offset"] for interval in packed["intervals"]}
+    assert offsets[4] == 14
+    assert offsets[5] == 0
+
+
 def test_prefetch_arena_plan_uses_final_padded_bytes_and_coalesces_repeated_ids():
     graph = Graph()
     first = graph.placeholder("first")
@@ -419,12 +461,35 @@ def test_prefetch_arena_budget_admission_replaces_live_gather_charge_with_fixed_
         "arena_reserved_peak": 756,
         "incremental_peak": 244,
         "limiting_node": "param",
-        "limiting_metric": "reserved",
+        "limiting_metric": "allocated_after_pool_drain_and_empty_cache",
+        "limiting_pool_reclaimable_bytes": 0,
     }
     assert accepted["accepted"] is True
     # Capacity replaces the already-counted 12 live bytes rather than being
     # added on top of them a second time.
     assert accepted["incremental_peak"] == plan["capacity"] - 12
+
+
+def test_prefetch_arena_budget_does_not_charge_cache_flushed_before_backing():
+    graph = Graph()
+    param = graph.placeholder("param")
+    _arena_prefetch(graph, [param], [1], 10, [12])
+    release = _release(graph, param, 1, "arena_param")
+    graph.output((release, ))
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=False)
+    assert reason is None
+
+    mem_dict = {node.name: (500, 500) for node in graph.nodes}
+    reserved_mem_dict = {node.name: 900 for node in graph.nodes}
+    admission = prefetch_mod._prefetch_arena_budget_admission(graph, plan, mem_dict, reserved_mem_dict, max_mem=800)
+
+    assert admission["accepted"] is True
+    assert admission["arena_allocated_peak"] == 756
+    assert admission["arena_modeled_peak"] == 756
+    assert admission["arena_reserved_peak"] == 1156
+    assert admission["limiting_metric"] == "allocated_after_pool_drain_and_empty_cache"
+    assert admission["limiting_pool_reclaimable_bytes"] == 0
 
 
 def test_training_session_budget_uses_shared_forward_backward_capacity_bound():
@@ -468,7 +533,65 @@ def test_training_session_budget_uses_shared_forward_backward_capacity_bound():
         "backward_arena_peak": 612,
         "forward_original_peak": 112,
         "backward_original_peak": 400,
+        "forward_pool_reclaimable_bytes": 0,
+        "backward_pool_reclaimable_bytes": 0,
     }
+
+
+def test_training_session_budget_subtracts_only_profiled_pool_charge():
+    fwd = Graph()
+    fwd_param = _placeholder(fwd, "fwd_param")
+    _arena_prefetch(fwd, [fwd_param], [1], 10, [12])
+    fwd.output((_release(fwd, fwd_param, 1, "fwd_param"), ))
+    fwd_plan, reason = prefetch_mod._build_prefetch_arena_plan(fwd,
+                                                               _fake_arena_param_manager([("fwd_param", 1, (5, ),
+                                                                                           torch.float16)]),
+                                                               world_size=2,
+                                                               bwd=False)
+    assert reason is None
+
+    bwd = Graph()
+    bwd_param = _placeholder(bwd, "bwd_param")
+    _arena_prefetch(bwd, [bwd_param], [1], 1_000_010, [300])
+    bwd.output((_release(bwd, bwd_param, 1, "bwd_param"), ))
+    bwd_plan, reason = prefetch_mod._build_prefetch_arena_plan(bwd,
+                                                               _fake_arena_param_manager([("bwd_param", 1, (150, ),
+                                                                                           torch.float16)]),
+                                                               world_size=2,
+                                                               bwd=True)
+    assert reason is None
+
+    fwd_mem = {node.name: (600, 600) for node in fwd.nodes}
+    bwd_mem = {node.name: (600, 600) for node in bwd.nodes}
+    reserved = {node.name: 900 for node in (*list(fwd.nodes), *list(bwd.nodes))}
+    no_credit = prefetch_mod._training_session_budget_admission(fwd,
+                                                                fwd_plan,
+                                                                fwd_mem,
+                                                                reserved,
+                                                                bwd,
+                                                                bwd_plan,
+                                                                bwd_mem,
+                                                                reserved,
+                                                                max_mem=700)
+    pool_credit = {node.name: 450 for node in (*list(fwd.nodes), *list(bwd.nodes))}
+    credited = prefetch_mod._training_session_budget_admission(fwd,
+                                                               fwd_plan,
+                                                               fwd_mem,
+                                                               reserved,
+                                                               bwd,
+                                                               bwd_plan,
+                                                               bwd_mem,
+                                                               reserved,
+                                                               max_mem=700,
+                                                               forward_pool_reclaimable_dict=pool_credit,
+                                                               backward_pool_reclaimable_dict=pool_credit)
+
+    assert no_credit["accepted"] is False
+    assert credited["accepted"] is True
+    assert credited["forward_arena_peak"] == 662
+    assert credited["backward_arena_peak"] == 662
+    assert credited["forward_pool_reclaimable_bytes"] == 450
+    assert credited["backward_pool_reclaimable_bytes"] == 450
 
 
 @pytest.mark.parametrize("arena_enabled", [False, True])
@@ -732,7 +855,9 @@ def test_schedule_prefetch_training_backward_decides_pending_session(monkeypatch
                               prefetch_arena_forward_mem={node.name: (0, 0)
                                                           for node in fwd.nodes},
                               prefetch_arena_forward_reserved_mem={node.name: 0
-                                                                   for node in fwd.nodes})
+                                                                   for node in fwd.nodes},
+                              prefetch_arena_forward_pool_reclaimable={node.name: 0
+                                                                       for node in fwd.nodes})
     for node in bwd.nodes:
         node.meta["profile_reserved_peak"] = 0
     manager = _fake_arena_param_manager([("bwd_param", 1, (5, ), torch.float16)])

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -392,6 +392,85 @@ def test_prefetch_arena_plan_falls_back_on_dynamic_shape():
     assert reason == "dynamic_shape"
 
 
+def test_prefetch_arena_budget_admission_replaces_live_gather_charge_with_fixed_capacity():
+    graph = Graph()
+    param = graph.placeholder("param")
+    _arena_prefetch(graph, [param], [1], 10, [12])
+    release = _release(graph, param, 1, "arena_param")
+    graph.output((release, ))
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+    plan, reason = prefetch_mod._build_prefetch_arena_plan(graph, manager, world_size=2, bwd=False)
+    assert reason is None
+    mem_dict = {node.name: (500, 500) for node in graph.nodes}
+
+    reserved_mem_dict = {node.name: 500 for node in graph.nodes}
+    rejected = prefetch_mod._prefetch_arena_budget_admission(graph, plan, mem_dict, reserved_mem_dict, max_mem=700)
+    accepted = prefetch_mod._prefetch_arena_budget_admission(graph, plan, mem_dict, reserved_mem_dict, max_mem=800)
+
+    assert rejected == {
+        "accepted": False,
+        "max_mem": 700,
+        "capacity": 256,
+        "original_allocated_peak": 512,
+        "arena_allocated_peak": 756,
+        "original_modeled_peak": 512,
+        "arena_modeled_peak": 756,
+        "original_reserved_peak": 500,
+        "arena_reserved_peak": 756,
+        "incremental_peak": 244,
+        "limiting_node": "param",
+        "limiting_metric": "reserved",
+    }
+    assert accepted["accepted"] is True
+    # Capacity replaces the already-counted 12 live bytes rather than being
+    # added on top of them a second time.
+    assert accepted["incremental_peak"] == plan["capacity"] - 12
+
+
+def test_training_session_budget_uses_shared_forward_backward_capacity_bound():
+    fwd = Graph()
+    fwd_param = _placeholder(fwd, "fwd_param")
+    _arena_prefetch(fwd, [fwd_param], [1], 10, [12])
+    fwd_release = _release(fwd, fwd_param, 1, "fwd_param")
+    fwd.output((fwd_release, ))
+    manager = _fake_arena_param_manager([("fwd_param", 1, (5, ), torch.float16)])
+    fwd_plan, reason = prefetch_mod._build_prefetch_arena_plan(fwd, manager, world_size=2, bwd=False)
+    assert reason is None
+
+    bwd = Graph()
+    bwd_param = _placeholder(bwd, "bwd_param")
+    _arena_prefetch(bwd, [bwd_param], [1], 1_000_010, [300])
+    bwd_release = _release(bwd, bwd_param, 1, "bwd_param")
+    bwd.output((bwd_release, ))
+    bwd_manager = _fake_arena_param_manager([("bwd_param", 1, (150, ), torch.float16)])
+    bwd_plan, reason = prefetch_mod._build_prefetch_arena_plan(bwd, bwd_manager, world_size=2, bwd=True)
+    assert reason is None
+    fwd_mem = {node.name: (100, 100) for node in fwd.nodes}
+    fwd_reserved = {node.name: 100 for node in fwd.nodes}
+    bwd_mem = {node.name: (100, 100) for node in bwd.nodes}
+    bwd_reserved = {node.name: 100 for node in bwd.nodes}
+
+    admission = prefetch_mod._training_session_budget_admission(fwd,
+                                                                fwd_plan,
+                                                                fwd_mem,
+                                                                fwd_reserved,
+                                                                bwd,
+                                                                bwd_plan,
+                                                                bwd_mem,
+                                                                bwd_reserved,
+                                                                max_mem=700)
+
+    assert admission == {
+        "accepted": True,
+        "max_mem": 700,
+        "capacity_bound": 512,
+        "forward_arena_peak": 612,
+        "backward_arena_peak": 612,
+        "forward_original_peak": 112,
+        "backward_original_peak": 400,
+    }
+
+
 @pytest.mark.parametrize("arena_enabled", [False, True])
 def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypatch, arena_enabled):
     graph = Graph()
@@ -412,6 +491,8 @@ def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypat
                               fwd_time=times,
                               fwd_tensor_sizes=sizes,
                               process_group="test-group")
+    for node in graph.nodes:
+        node.meta["profile_reserved_peak"] = 0
     manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
     configured = []
     reductions = []
@@ -465,12 +546,312 @@ def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypat
         assert prefetch_nodes[0].args[4] == 0
         assert prefetch_nodes[0].meta["prefetch_arena_eligible_ds_ids"] == (1, )
         assert len(configured) == 1
-        assert configured[0][:4] == (0, 0, 256, 256)
-        assert configured[0][4] > 0
-        assert configured[0][5:] == ([0], [1], [0], [12])
+        assert configured[0][:5] == (0, 0, False, 256, 256)
+        assert configured[0][5] > 0
+        assert configured[0][6:] == ([0], [1], [0], [12])
     else:
         assert len(prefetch_nodes[0].args) == 3
         assert configured == []
+
+
+def test_schedule_prefetch_shared_budget_rejection_restores_original_call_shape(monkeypatch):
+    graph = Graph()
+    param = _placeholder(graph, "param")
+    ag = _allgather(graph, param, 1, "arena", tensor_size=12)
+    ag.meta["allgather_allocation_bytes"] = 12
+    wait = _wait(graph, ag, 1, "arena")
+    use = _neg(graph, wait, "arena_use")
+    release = _release(graph, use, 1, "arena")
+    graph.output((release, ))
+    graph.lint()
+
+    # 90% of 1 MiB is 943,718 bytes. The fixed 256-byte backing takes the
+    # modeled peak above that common budget even though the original 12-byte
+    # live gather remains admissible.
+    records = [(node.name, 943_500, 0, 943_500) for node in graph.nodes]
+    times = [(node.name, 1, 1) for node in graph.nodes]
+    sizes = [(node.name, int(node.meta.get("tensor_size", 0))) for node in graph.nodes]
+    profile = ProfilingResult(fwd_graph=graph,
+                              fwd_mem=records,
+                              fwd_time=times,
+                              fwd_tensor_sizes=sizes,
+                              process_group="test-group")
+    for node in graph.nodes:
+        node.meta["profile_reserved_peak"] = 943_500
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+    configured = []
+    logs = []
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 1 << 20
+
+        def available_memory(self):
+            return 1 << 20
+
+        def memory_allocated(self):
+            return 0
+
+        def max_memory_allocated(self):
+            return 0
+
+    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
+    monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
+    monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
+    monkeypatch.setattr(prefetch_mod.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(prefetch_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(prefetch_mod.dist, "all_reduce", lambda *args, **kwargs: None)
+    monkeypatch.setattr(prefetch_mod, "get_deepcompile_handle",
+                        lambda: SimpleNamespace(configure_z3_prefetch_arena=lambda *args: configured.append(args)))
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    result = prefetch_mod.schedule_prefetch(gm,
+                                            graph_id=0,
+                                            graph_order=[(0, False)],
+                                            profiling_results={0: profile},
+                                            create_inputs_fn=lambda: (),
+                                            mem_budget=0,
+                                            param_manager={0: manager},
+                                            bwd=False)
+
+    prefetch_nodes = [node for node in result.graph.nodes if node.target == torch.ops.dc.prefetch_params_fused.default]
+    assert len(prefetch_nodes) == 1
+    assert len(prefetch_nodes[0].args) == 3
+    assert "prefetch_arena_eligible_ds_ids" not in prefetch_nodes[0].meta
+    assert configured == []
+    assert any("accepted=0" in message for message in logs)
+    assert any("fallback=shared_budget" in message for message in logs)
+
+
+def test_schedule_prefetch_training_forward_registers_pending_session_plan(monkeypatch):
+    graph = Graph()
+    param = _placeholder(graph, "param")
+    ag = _allgather(graph, param, 1, "arena", tensor_size=12)
+    ag.meta["allgather_allocation_bytes"] = 12
+    wait = _wait(graph, ag, 1, "arena")
+    use = _neg(graph, wait, "arena_use")
+    release = _release(graph, use, 1, "arena")
+    graph.output((release, ))
+    records = [(node.name, 0, 0, 0) for node in graph.nodes]
+    profile = ProfilingResult(fwd_graph=graph,
+                              fwd_mem=records,
+                              fwd_time=[(node.name, 1, 1) for node in graph.nodes],
+                              fwd_tensor_sizes=[(node.name, int(node.meta.get("tensor_size", 0)))
+                                                for node in graph.nodes],
+                              needs_backward=True,
+                              process_group="test-group")
+    for node in graph.nodes:
+        node.meta["profile_reserved_peak"] = 0
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+    configured = []
+    logs = []
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 1 << 20
+
+        def available_memory(self):
+            return 1 << 20
+
+        def memory_allocated(self):
+            return 0
+
+        def max_memory_allocated(self):
+            return 0
+
+    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
+    monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
+    monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
+    monkeypatch.setattr(prefetch_mod.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(prefetch_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(prefetch_mod.dist, "all_reduce", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        prefetch_mod, "get_deepcompile_handle",
+        lambda: SimpleNamespace(configure_z3_prefetch_arena=lambda *args: configured.append(args),
+                                disable_z3_prefetch_arena=lambda *args: None))
+
+    result = prefetch_mod.schedule_prefetch(GraphModule(torch.nn.Module(), graph),
+                                            graph_id=0,
+                                            graph_order=[(0, True)],
+                                            profiling_results={0: profile},
+                                            create_inputs_fn=lambda: (),
+                                            mem_budget=0,
+                                            param_manager={0: manager},
+                                            bwd=False)
+
+    prefetch_nodes = [node for node in result.graph.nodes if node.target == torch.ops.dc.prefetch_params_fused.default]
+    assert len(prefetch_nodes) == 1
+    assert prefetch_nodes[0].args[4] == 0
+    assert len(configured) == 1
+    assert configured[0][:5] == (0, 0, True, 256, 256)
+    assert profile.prefetch_arena_forward_plan is not None
+    assert profile.prefetch_arena_session_accepted is None
+    assert any("prefetch_arena_session_pending" in message for message in logs)
+
+
+def test_schedule_prefetch_training_backward_decides_pending_session(monkeypatch):
+    fwd = Graph()
+    fwd_param = _placeholder(fwd, "fwd_param")
+    _arena_prefetch(fwd, [fwd_param], [1], 0, [12])
+    fwd_release = _release(fwd, fwd_param, 1, "fwd_param")
+    fwd.output((fwd_release, ))
+    fwd_plan, reason = prefetch_mod._build_prefetch_arena_plan(fwd,
+                                                               _fake_arena_param_manager([("fwd_param", 1, (5, ),
+                                                                                           torch.float16)]),
+                                                               world_size=2,
+                                                               bwd=False)
+    assert reason is None
+
+    bwd = Graph()
+    bwd_param = _placeholder(bwd, "bwd_param")
+    bwd_ag = _allgather(bwd, bwd_param, 1, "bwd_param", tensor_size=12)
+    bwd_ag.meta["allgather_allocation_bytes"] = 12
+    bwd_wait = _wait(bwd, bwd_ag, 1, "bwd_param")
+    bwd_release = _release(bwd, bwd_wait, 1, "bwd_param")
+    bwd.output((bwd_release, ))
+    records = [(node.name, 0, 0, 0) for node in bwd.nodes]
+    profile = ProfilingResult(bwd_graph=bwd,
+                              bwd_mem=records,
+                              bwd_time=[(node.name, 1, 1) for node in bwd.nodes],
+                              bwd_tensor_sizes=[(node.name, int(node.meta.get("tensor_size", 0)))
+                                                for node in bwd.nodes],
+                              needs_backward=True,
+                              process_group="test-group",
+                              prefetch_arena_forward_graph=fwd,
+                              prefetch_arena_forward_plan=fwd_plan,
+                              prefetch_arena_forward_mem={node.name: (0, 0)
+                                                          for node in fwd.nodes},
+                              prefetch_arena_forward_reserved_mem={node.name: 0
+                                                                   for node in fwd.nodes})
+    for node in bwd.nodes:
+        node.meta["profile_reserved_peak"] = 0
+    manager = _fake_arena_param_manager([("bwd_param", 1, (5, ), torch.float16)])
+    configured = []
+    logs = []
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 1 << 20
+
+        def available_memory(self):
+            return 1 << 20
+
+        def memory_allocated(self):
+            return 0
+
+        def max_memory_allocated(self):
+            return 0
+
+    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
+    monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
+    monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
+    monkeypatch.setattr(prefetch_mod.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(prefetch_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(prefetch_mod.dist, "all_reduce", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        prefetch_mod, "get_deepcompile_handle",
+        lambda: SimpleNamespace(configure_z3_prefetch_arena=lambda *args: configured.append(args),
+                                disable_z3_prefetch_arena=lambda *args: None))
+
+    result = prefetch_mod.schedule_prefetch(GraphModule(torch.nn.Module(), bwd),
+                                            graph_id=0,
+                                            graph_order=[(0, True)],
+                                            profiling_results={0: profile},
+                                            create_inputs_fn=lambda: (),
+                                            mem_budget=0,
+                                            param_manager={0: manager},
+                                            bwd=True)
+
+    prefetch_nodes = [node for node in result.graph.nodes if node.target == torch.ops.dc.prefetch_params_fused.default]
+    assert len(prefetch_nodes) == 1
+    assert prefetch_nodes[0].args[4] == 1_000_000
+    assert len(configured) == 1
+    assert configured[0][:5] == (0, 1, True, 256, 256)
+    assert profile.prefetch_arena_session_accepted is True
+    assert profile.prefetch_arena_session_capacity_bound == 256
+    assert any("prefetch_arena_session_admission" in message and "accepted=1" in message for message in logs)
+
+
+def test_schedule_prefetch_missing_reserved_profile_restores_original_call_shape(monkeypatch):
+    graph = Graph()
+    param = _placeholder(graph, "param")
+    ag = _allgather(graph, param, 1, "arena", tensor_size=12)
+    ag.meta["allgather_allocation_bytes"] = 12
+    wait = _wait(graph, ag, 1, "arena")
+    use = _neg(graph, wait, "arena_use")
+    release = _release(graph, use, 1, "arena")
+    graph.output((release, ))
+    graph.lint()
+
+    records = [(node.name, 0, 0, 0) for node in graph.nodes]
+    times = [(node.name, 1, 1) for node in graph.nodes]
+    sizes = [(node.name, int(node.meta.get("tensor_size", 0))) for node in graph.nodes]
+    profile = ProfilingResult(fwd_graph=graph,
+                              fwd_mem=records,
+                              fwd_time=times,
+                              fwd_tensor_sizes=sizes,
+                              process_group="test-group")
+    manager = _fake_arena_param_manager([("param", 1, (5, ), torch.float16)])
+    configured = []
+    logs = []
+
+    class FakeAccelerator:
+
+        def current_device(self):
+            return "cpu"
+
+        def total_memory(self):
+            return 1 << 20
+
+        def available_memory(self):
+            return 1 << 20
+
+        def memory_allocated(self):
+            return 0
+
+        def max_memory_allocated(self):
+            return 0
+
+    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
+    monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
+    monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
+    monkeypatch.setattr(prefetch_mod.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(prefetch_mod.dist, "get_world_size", lambda group=None: 2)
+    monkeypatch.setattr(prefetch_mod.dist, "all_reduce", lambda *args, **kwargs: None)
+    monkeypatch.setattr(prefetch_mod, "get_deepcompile_handle",
+                        lambda: SimpleNamespace(configure_z3_prefetch_arena=lambda *args: configured.append(args)))
+    gm = GraphModule(torch.nn.Module(), graph)
+
+    result = prefetch_mod.schedule_prefetch(gm,
+                                            graph_id=0,
+                                            graph_order=[(0, False)],
+                                            profiling_results={0: profile},
+                                            create_inputs_fn=lambda: (),
+                                            mem_budget=0,
+                                            param_manager={0: manager},
+                                            bwd=False)
+
+    prefetch_nodes = [node for node in result.graph.nodes if node.target == torch.ops.dc.prefetch_params_fused.default]
+    assert len(prefetch_nodes) == 1
+    assert len(prefetch_nodes[0].args) == 3
+    assert configured == []
+    assert any("fallback=incomplete_reserved_profile" in message for message in logs)
 
 
 def _scheduled_graph(graph, scheduler_budget=None):

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -594,8 +594,7 @@ def test_training_session_budget_subtracts_only_profiled_pool_charge():
     assert credited["backward_pool_reclaimable_bytes"] == 450
 
 
-@pytest.mark.parametrize("arena_enabled", [False, True])
-def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypatch, arena_enabled):
+def test_schedule_prefetch_configures_arena_by_default_from_final_graph(monkeypatch):
     graph = Graph()
     param = _placeholder(graph, "param")
     ag = _allgather(graph, param, 1, "arena", tensor_size=12)
@@ -637,10 +636,7 @@ def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypat
         def max_memory_allocated(self):
             return 0
 
-    if arena_enabled:
-        monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
-    else:
-        monkeypatch.delenv(prefetch_mod.PREFETCH_ARENA_ENV, raising=False)
+    monkeypatch.delenv("DEEPSPEED_COMPILE_PREFETCH_ARENA", raising=False)
     monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
     monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
     monkeypatch.setattr(prefetch_mod.dist, "is_initialized", lambda: True)
@@ -665,16 +661,12 @@ def test_schedule_prefetch_configures_env_gated_arena_from_final_graph(monkeypat
     # consensus is deferred to native execution where graph order is stable.
     assert len(reductions) == 1
     assert len(prefetch_nodes) == 1
-    if arena_enabled:
-        assert prefetch_nodes[0].args[4] == 0
-        assert prefetch_nodes[0].meta["prefetch_arena_eligible_ds_ids"] == (1, )
-        assert len(configured) == 1
-        assert configured[0][:5] == (0, 0, False, 256, 256)
-        assert configured[0][5] > 0
-        assert configured[0][6:] == ([0], [1], [0], [12])
-    else:
-        assert len(prefetch_nodes[0].args) == 3
-        assert configured == []
+    assert prefetch_nodes[0].args[4] == 0
+    assert prefetch_nodes[0].meta["prefetch_arena_eligible_ds_ids"] == (1, )
+    assert len(configured) == 1
+    assert configured[0][:5] == (0, 0, False, 256, 256)
+    assert configured[0][5] > 0
+    assert configured[0][6:] == ([0], [1], [0], [12])
 
 
 def test_schedule_prefetch_shared_budget_rejection_restores_original_call_shape(monkeypatch):
@@ -722,7 +714,6 @@ def test_schedule_prefetch_shared_budget_rejection_restores_original_call_shape(
         def max_memory_allocated(self):
             return 0
 
-    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
     monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
     monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
     monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
@@ -791,7 +782,6 @@ def test_schedule_prefetch_training_forward_registers_pending_session_plan(monke
         def max_memory_allocated(self):
             return 0
 
-    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
     monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
     monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
     monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
@@ -881,7 +871,6 @@ def test_schedule_prefetch_training_backward_decides_pending_session(monkeypatch
         def max_memory_allocated(self):
             return 0
 
-    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
     monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
     monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
     monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)
@@ -952,7 +941,6 @@ def test_schedule_prefetch_missing_reserved_profile_restores_original_call_shape
         def max_memory_allocated(self):
             return 0
 
-    monkeypatch.setenv(prefetch_mod.PREFETCH_ARENA_ENV, "1")
     monkeypatch.setattr(prefetch_mod, "print_rank_0", logs.append)
     monkeypatch.setattr(prefetch_mod, "get_accelerator", lambda: FakeAccelerator())
     monkeypatch.setattr(prefetch_mod, "create_predictor", lambda: lambda _: 1)

--- a/tests/unit/compile/test_zero3_grad_dtype.py
+++ b/tests/unit/compile/test_zero3_grad_dtype.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -227,3 +229,106 @@ def test_deactivation_releases_only_the_engine_owned_state(monkeypatch):
     finally:
         backend_mod.frames_needing_bwd.clear()
         backend_mod.unpatch_compiled_func()
+
+
+def test_repeated_engine_destroy_cleans_native_state_once_and_deactivates(monkeypatch):
+    engine = object.__new__(DeepSpeedEngine)
+    torch.nn.Module.__init__(engine)
+    engine._deepcompile_active = True
+    engine._deepcompile_native_initialized = True
+    cleanup_calls = []
+    engine._release_deepcompile_compiled_backward_state = lambda: None
+    engine._release_deepcompile_dynamo_config = lambda: None
+    engine.is_deepcompile_active = lambda: engine._deepcompile_active
+    engine._set_deepcompile_active = lambda active: setattr(engine, "_deepcompile_active", active)
+
+    fake_handle = type("FakeDeepCompileHandle", (), {"cleanup": lambda self: cleanup_calls.append("cleanup")})()
+    monkeypatch.setattr("deepspeed.runtime.engine.get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr("deepspeed.runtime.engine.debug_clear_module_and_param_names", lambda: None)
+
+    engine.destroy()
+    engine.destroy()
+    engine.__del__()
+
+    assert cleanup_calls == ["cleanup"]
+    assert engine._deepcompile_active is False
+
+
+def test_backend_setup_failure_after_native_init_cleans_once(monkeypatch):
+    engine = object.__new__(DeepSpeedEngine)
+    torch.nn.Module.__init__(engine)
+    engine._deepcompile_active = False
+    engine._deepcompile_native_initialized = False
+    engine.data_parallel_group = object()
+    engine.zero_reduce_bucket_size = lambda: 1
+    engine._release_deepcompile_compiled_backward_state = lambda: None
+    engine._release_deepcompile_dynamo_config = lambda: None
+    engine.compile_autosp = lambda: False
+    init_calls = []
+    cleanup_calls = []
+    fake_handle = SimpleNamespace(init=lambda *_: init_calls.append("init"),
+                                  cleanup=lambda: cleanup_calls.append("cleanup"))
+
+    def fail_after_native_init(*_):
+        engine._initialize_deepcompile_native(SimpleNamespace())
+        raise RuntimeError("backend setup failed")
+
+    engine.get_deepcompile_backend = fail_after_native_init
+    monkeypatch.setattr("deepspeed.runtime.engine.get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr("deepspeed.runtime.engine.debug_clear_module_and_param_names", lambda: None)
+
+    with pytest.raises(RuntimeError, match="backend setup failed"):
+        engine.get_deepspeed_compile_backend("inductor", {}, None)
+
+    assert init_calls == ["init"]
+    assert cleanup_calls == ["cleanup"]
+    assert engine._deepcompile_native_initialized is False
+    assert engine.is_deepcompile_active() is False
+
+    engine.destroy()
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_module_compile_failure_cleans_native_state_once_before_destroy(monkeypatch):
+    engine = object.__new__(DeepSpeedEngine)
+    torch.nn.Module.__init__(engine)
+    engine._config = SimpleNamespace(compile_config=SimpleNamespace(deepcompile=True))
+    engine._is_compiled = False
+    engine._deepcompile_active = False
+    engine._deepcompile_native_initialized = False
+    engine.data_parallel_group = object()
+    engine.zero_reduce_bucket_size = lambda: 1
+    engine.module_forward_pre_hook = None
+    engine.module_forward_post_hook = None
+    engine._create_module_forward_pre_hook = lambda: None
+    engine._create_module_forward_post_hook = lambda: None
+    engine._release_deepcompile_compiled_backward_state = lambda: None
+    engine._release_deepcompile_dynamo_config = lambda: None
+    init_calls = []
+    cleanup_calls = []
+    fake_handle = SimpleNamespace(init=lambda *_: init_calls.append("init"),
+                                  cleanup=lambda: cleanup_calls.append("cleanup"))
+
+    def resolve_backend(*_):
+        engine._initialize_deepcompile_native(SimpleNamespace())
+        return object(), None
+
+    def fail_compile(**_):
+        raise RuntimeError("module compile failed")
+
+    engine.get_deepspeed_compile_backend = resolve_backend
+    engine.module = SimpleNamespace(compile=fail_compile)
+    monkeypatch.setattr("deepspeed.runtime.engine.is_compile_supported", lambda: True)
+    monkeypatch.setattr("deepspeed.runtime.engine.get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr("deepspeed.runtime.engine.debug_clear_module_and_param_names", lambda: None)
+
+    with pytest.raises(RuntimeError, match="module compile failed"):
+        engine.compile(backend="inductor")
+
+    assert init_calls == ["init"]
+    assert cleanup_calls == ["cleanup"]
+    assert engine._deepcompile_native_initialized is False
+    assert engine.is_deepcompile_active() is False
+
+    engine.destroy()
+    assert cleanup_calls == ["cleanup"]

--- a/tests/unit/v1/compile/test_graph_profile.py
+++ b/tests/unit/v1/compile/test_graph_profile.py
@@ -126,7 +126,7 @@ def test_profiling_interpreter_wall_time_excludes_warmup(monkeypatch):
     monkeypatch.setattr(graph_profile, "is_comm_op", lambda node: False)
     monkeypatch.setattr(graph_profile, "is_release_node", lambda node: False)
     monkeypatch.setattr(graph_profile.dist, "is_initialized", lambda: False)
-    monkeypatch.setattr(graph_profile.dist, "get_rank", lambda: 0)
+    monkeypatch.setattr(graph_profile.dist, "get_rank", lambda group=None: 0)
 
     timestamps = iter(range(20))
     monkeypatch.setattr(graph_profile.time, "time", lambda: next(timestamps))
@@ -191,3 +191,29 @@ def test_memory_profiling_interpreter_disables_profiling_if_cleanup_fails(monkey
         interpreter.run()
 
     assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]
+
+
+def test_profiling_interpreter_restores_state_if_gathered_param_cleanup_fails(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    def fail_clear():
+        fake_handle.events.append(("clear", None))
+        raise RuntimeError("cleanup failed")
+
+    fake_handle.clear_all_gathered_params = fail_clear
+
+    monkeypatch.setattr(graph_profile, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(graph_profile, "get_accelerator", lambda: FakeAccelerator())
+    monkeypatch.setattr(graph_profile, "_all_real_if_tensor", lambda args: True)
+    monkeypatch.setattr(graph_profile, "_get_mem_usage_out_of_torch", lambda: 0)
+    monkeypatch.setattr(graph_profile.dist, "is_initialized", lambda: False)
+    monkeypatch.setattr(graph_profile.Interpreter, "run", lambda self, *args: None)
+
+    interpreter = graph_profile.ProfilingInterpreter(_make_empty_graph_module(), iteration=1)
+    interpreter.env["retained"] = object()
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        interpreter.run()
+
+    assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]
+    assert interpreter.env == {}

--- a/tests/unit/v1/compile/test_graph_profile.py
+++ b/tests/unit/v1/compile/test_graph_profile.py
@@ -61,12 +61,19 @@ class FakeDeepCompileHandle:
 
     def __init__(self):
         self.events = []
+        self.reclaimable_bytes = 0
 
     def enable_profiling(self, enabled):
         self.events.append(("enable", enabled))
 
     def clear_all_gathered_params(self):
         self.events.append(("clear", None))
+
+    def get_z3_gather_buffer_pool_reclaimable_bytes(self):
+        return self.reclaimable_bytes
+
+    def get_z3_gather_buffer_pool_transition_reclaimable_bytes(self):
+        return self.reclaimable_bytes
 
 
 class FakeEvent:
@@ -201,6 +208,7 @@ def test_memory_profiling_interpreter_disables_profiling_if_cleanup_fails(monkey
 
 def test_memory_profiling_interpreter_records_allocator_reserved_peaks(monkeypatch):
     fake_handle = FakeDeepCompileHandle()
+    fake_handle.reclaimable_bytes = 32
 
     class ReservedAccelerator(FakeAccelerator):
 
@@ -232,6 +240,7 @@ def test_memory_profiling_interpreter_records_allocator_reserved_peaks(monkeypat
     assert output.meta["profile_reserved_start"] == 107
     assert output.meta["profile_reserved_current"] == 107
     assert output.meta["profile_reserved_peak"] == 127
+    assert output.meta["profile_gather_pool_charged"] == 32
     assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]
 
 

--- a/tests/unit/v1/compile/test_graph_profile.py
+++ b/tests/unit/v1/compile/test_graph_profile.py
@@ -36,6 +36,12 @@ class FakeAccelerator:
     def max_memory_allocated(self):
         return 0
 
+    def memory_reserved(self):
+        return 0
+
+    def max_memory_reserved(self):
+        return 0
+
     def reset_peak_memory_stats(self):
         return None
 
@@ -190,6 +196,42 @@ def test_memory_profiling_interpreter_disables_profiling_if_cleanup_fails(monkey
     with pytest.raises(RuntimeError, match="cleanup failed"):
         interpreter.run()
 
+    assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]
+
+
+def test_memory_profiling_interpreter_records_allocator_reserved_peaks(monkeypatch):
+    fake_handle = FakeDeepCompileHandle()
+
+    class ReservedAccelerator(FakeAccelerator):
+
+        def memory_allocated(self):
+            return 10
+
+        def max_memory_allocated(self):
+            return 20
+
+        def memory_reserved(self):
+            return 100
+
+        def max_memory_reserved(self):
+            return 120
+
+    monkeypatch.setattr(graph_profile, "get_deepcompile_handle", lambda: fake_handle)
+    monkeypatch.setattr(graph_profile, "get_accelerator", lambda: ReservedAccelerator())
+    monkeypatch.setattr(graph_profile, "_all_real_if_tensor", lambda args: True)
+    monkeypatch.setattr(graph_profile, "_get_mem_usage_out_of_torch", lambda: 7)
+    monkeypatch.setattr(graph_profile.dist, "is_initialized", lambda: False)
+
+    gm = _make_empty_graph_module()
+    interpreter = graph_profile.MemoryProfilingInterpreter(gm)
+
+    assert interpreter.run() is None
+    output = next(node for node in gm.graph.nodes if node.op == "output")
+    assert output.meta["profile_mem_start"] == 17
+    assert output.meta["profile_mem_peak"] == 27
+    assert output.meta["profile_reserved_start"] == 107
+    assert output.meta["profile_reserved_current"] == 107
+    assert output.meta["profile_reserved_peak"] == 127
     assert fake_handle.events == [("enable", True), ("clear", None), ("enable", False)]
 
 

--- a/tests/unit/v1/compile/test_selective_gather.py
+++ b/tests/unit/v1/compile/test_selective_gather.py
@@ -73,8 +73,8 @@ def test_selective_gather_sets_persistent_params_when_transient_headroom_exists(
 
     monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=220))
     monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
-    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
-    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op, group=None: tensor)
 
     profiling_results = {
         0:
@@ -114,8 +114,8 @@ def test_selective_gather_uses_profiled_headroom_instead_of_current_available_me
 
     monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=1000))
     monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
-    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
-    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op, group=None: tensor)
 
     profiling_results = {
         0:
@@ -152,13 +152,13 @@ def test_selective_gather_uses_profiled_headroom_instead_of_current_available_me
     assert fake_handle.persistent_ds_ids == [1, 2]
 
 
-def test_selective_gather_uses_profiled_headroom_when_current_available_memory_is_low(monkeypatch):
+def test_selective_gather_caps_profiled_headroom_by_current_available_memory(monkeypatch):
     fake_handle = FakeDeepCompileHandle()
 
     monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=100))
     monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
-    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
-    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op, group=None: tensor)
 
     profiling_results = {
         0:
@@ -192,7 +192,7 @@ def test_selective_gather_uses_profiled_headroom_when_current_available_memory_i
                                                       bwd=True)
 
     assert returned is gm
-    assert fake_handle.persistent_ds_ids == [1, 2]
+    assert fake_handle.persistent_ds_ids == []
 
 
 def test_selective_gather_skips_persistence_when_memory_profile_incomplete(monkeypatch):
@@ -200,8 +200,8 @@ def test_selective_gather_skips_persistence_when_memory_profile_incomplete(monke
 
     monkeypatch.setattr(selective_gather_pass, "get_accelerator", lambda: FakeAccelerator(available_mem=1000))
     monkeypatch.setattr(selective_gather_pass, "get_deepcompile_handle", lambda: fake_handle)
-    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda: 0)
-    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op: tensor)
+    monkeypatch.setattr(selective_gather_pass.dist, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(selective_gather_pass.dist, "all_reduce", lambda tensor, op, group=None: tensor)
 
     profiling_results = {
         0:


### PR DESCRIPTION
(#8233 needs to be merged before this PR)
Splits the native gather-buffer pool and allocator-pressure recovery changes out of #8169. This is stacked on the scheduler PR and passed 12/12 tests on a single node with 2 H100 GPUs.