### PR TITLE
Split native host pinning into standalone pin_memory op

### DIFF
--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -316,9 +316,9 @@ class CPU_Accelerator(DeepSpeedAccelerator):
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
             # if successful this also means we're doing a local install and not JIT compile path
             from op_builder import __deepspeed__  # noqa: F401 # type: ignore
-            from op_builder.cpu import AsyncIOBuilder, CCLCommBuilder, ShareMemCommBuilder, FusedAdamBuilder, CPUAdamBuilder, NotImplementedBuilder
+            from op_builder.cpu import AsyncIOBuilder, CCLCommBuilder, ShareMemCommBuilder, FusedAdamBuilder, CPUAdamBuilder, PinMemoryBuilder, NotImplementedBuilder
         except ImportError:
-            from deepspeed.ops.op_builder.cpu import AsyncIOBuilder, CCLCommBuilder, ShareMemCommBuilder, FusedAdamBuilder, CPUAdamBuilder, NotImplementedBuilder
+            from deepspeed.ops.op_builder.cpu import AsyncIOBuilder, CCLCommBuilder, ShareMemCommBuilder, FusedAdamBuilder, CPUAdamBuilder, PinMemoryBuilder, NotImplementedBuilder
 
         if class_name == "CCLCommBuilder":
             return CCLCommBuilder
@@ -330,6 +330,8 @@ class CPU_Accelerator(DeepSpeedAccelerator):
             return CPUAdamBuilder
         elif class_name == "AsyncIOBuilder":
             return AsyncIOBuilder
+        elif class_name == "PinMemoryBuilder":
+            return PinMemoryBuilder
         else:
             # return a NotImplementedBuilder to avoid get NoneType[Name] in unit tests
             return NotImplementedBuilder

--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -233,8 +233,9 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         if align_bytes == 1:
             return tensor.pin_memory(device=self.current_device_name())
         elif align_bytes == 0:
-            from deepspeed.ops.op_builder.xpu import AsyncIOBuilder
-            self.aio_handle = AsyncIOBuilder().load().aio_handle(128 * 1024, 8, False, False, False)
+            # Page-locked host buffer without starting AIO worker threads.
+            from deepspeed.ops.op_builder import PinMemoryBuilder
+            self.aio_handle = PinMemoryBuilder().load().pin_handle()
             aligned_t = self.aio_handle.new_cpu_locked_tensor(tensor.numel(), tensor)
             aligned_t = aligned_t[:tensor.numel()].copy_(tensor)
             self.aligned_tensors.append([aligned_t.data_ptr(), aligned_t[-1].data_ptr()])

--- a/csrc/aio/common/deepspeed_aio_utils.cpp
+++ b/csrc/aio/common/deepspeed_aio_utils.cpp
@@ -116,25 +116,3 @@ int64_t get_fd_file_size(const int fd, int64_t& size)
     size = st.st_size;
     return 0;
 }
-
-void* ds_page_aligned_alloc(const int64_t size, const bool lock)
-{
-    void* ptr;
-    int retval;
-
-    retval = posix_memalign(&ptr, (size_t)sysconf(_SC_PAGESIZE), size);
-    if (retval) { return nullptr; }
-
-    if (lock == false) { return ptr; }
-
-    auto mlock_ret = mlock(ptr, size);
-    if (mlock_ret != 0) {
-        auto mlock_error = errno;
-        std::cerr << "mlock failed to allocate " << size << " bytes with error no " << mlock_error
-                  << " msg " << strerror(mlock_error) << std::endl;
-        free(ptr);
-        return nullptr;
-    }
-
-    return ptr;
-}

--- a/csrc/aio/common/deepspeed_aio_utils.h
+++ b/csrc/aio/common/deepspeed_aio_utils.h
@@ -76,7 +76,5 @@ struct io_prep_generator {
     int prep_iocbs(const int n_iocbs, std::vector<struct iocb*>* iocbs);
 };
 
-void* ds_page_aligned_alloc(const int64_t size, const bool lock = false);
-
 int64_t get_file_size(const char* filename, int64_t& size);
 int64_t get_fd_file_size(const int fd, int64_t& size);

--- a/csrc/aio/py_lib/deepspeed_pin_tensor.h
+++ b/csrc/aio/py_lib/deepspeed_pin_tensor.h
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/aio/py_lib/deepspeed_pin_tensor.h
+++ b/csrc/aio/py_lib/deepspeed_pin_tensor.h
@@ -4,34 +4,9 @@
 // DeepSpeed Team
 
 /*
-Functionality for managing CPU tensors occupying page-locked memory.
-TODO: Implement a full-featured manager that
-1. Avoid page-locked memory leaks
-2. Minimize page-locked memory usage by reducing internal fragmentation
-Functionality for managing CPU tensors occupying page-locked memory.
+Compatibility include: pin-tensor manager lives under csrc/pin_memory/.
 */
 
-#include <map>
-#include <memory>
-#include <mutex>
-#include "deepspeed_py_aio.h"
+#pragma once
 
-struct deepspeed_pin_tensor_t {
-    std::map<void*, int64_t> _locked_tensors;
-    std::mutex _mutex;
-
-    deepspeed_pin_tensor_t() = default;
-
-    ~deepspeed_pin_tensor_t();
-
-    // Process-wide shared manager so that pinned-buffer recognition is consistent
-    // across every io handle (each handle references this single instance).
-    static std::shared_ptr<deepspeed_pin_tensor_t> shared();
-
-    torch::Tensor alloc(const int64_t num_elem, const at::ScalarType& elem_type);
-    torch::Tensor alloc(const int64_t num_elem, const torch::TensorOptions& options);
-
-    bool free(torch::Tensor& locked_tensor);
-
-    bool is_managed(const torch::Tensor& buffer);
-};
+#include "../../pin_memory/deepspeed_pin_tensor.h"

--- a/csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp
+++ b/csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp
+++ b/csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+/*
+Resolve the process-wide pin-tensor manager exported by the pin_memory op.
+The manager is compiled only into pin_memory; async_io/gds must load that op
+first (see AsyncIOBuilder.load) so this symbol is visible via RTLD_GLOBAL.
+*/
+
+#include "deepspeed_pin_tensor.h"
+
+#include <dlfcn.h>
+#include <stdexcept>
+
+std::shared_ptr<deepspeed_pin_tensor_t> deepspeed_pin_tensor_t::shared()
+{
+    using holder_fn_t = void* (*)();
+    auto* fn =
+        reinterpret_cast<holder_fn_t>(dlsym(RTLD_DEFAULT, "deepspeed_pin_tensor_mgr_holder"));
+    if (fn == nullptr) {
+        throw std::runtime_error(
+            "DeepSpeed pin_memory op must be loaded before async_io/gds (missing "
+            "deepspeed_pin_tensor_mgr_holder). Load PinMemoryBuilder first.");
+    }
+    auto* holder = static_cast<std::shared_ptr<deepspeed_pin_tensor_t>*>(fn());
+    return *holder;
+}

--- a/csrc/pin_memory/deepspeed_pin_tensor.cpp
+++ b/csrc/pin_memory/deepspeed_pin_tensor.cpp
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/pin_memory/deepspeed_pin_tensor.cpp
+++ b/csrc/pin_memory/deepspeed_pin_tensor.cpp
@@ -8,6 +8,11 @@ Functionality for managing CPU tensors occupying page-locked memory.
 */
 
 #include "deepspeed_pin_tensor.h"
+#include "page_alloc.h"
+
+#include <cassert>
+
+#include <sys/mman.h>
 
 using namespace std;
 
@@ -24,6 +29,15 @@ std::shared_ptr<deepspeed_pin_tensor_t> deepspeed_pin_tensor_t::shared()
 {
     static auto mgr = std::make_shared<deepspeed_pin_tensor_t>();
     return mgr;
+}
+
+extern "C" void* deepspeed_pin_tensor_mgr_holder()
+{
+    // Heap-allocate the shared_ptr so its control block outlives any transient
+    // copies made by other extensions that resolve this symbol via dlsym.
+    static auto* holder =
+        new std::shared_ptr<deepspeed_pin_tensor_t>(deepspeed_pin_tensor_t::shared());
+    return static_cast<void*>(holder);
 }
 
 torch::Tensor deepspeed_pin_tensor_t::alloc(const int64_t num_elem,

--- a/csrc/pin_memory/deepspeed_pin_tensor.h
+++ b/csrc/pin_memory/deepspeed_pin_tensor.h
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/pin_memory/deepspeed_pin_tensor.h
+++ b/csrc/pin_memory/deepspeed_pin_tensor.h
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+/*
+Functionality for managing CPU tensors occupying page-locked memory.
+TODO: Implement a full-featured manager that
+1. Avoid page-locked memory leaks
+2. Minimize page-locked memory usage by reducing internal fragmentation
+*/
+
+#pragma once
+
+#include <torch/extension.h>
+#include <map>
+#include <memory>
+#include <mutex>
+
+struct deepspeed_pin_tensor_t {
+    std::map<void*, int64_t> _locked_tensors;
+    std::mutex _mutex;
+
+    deepspeed_pin_tensor_t() = default;
+
+    ~deepspeed_pin_tensor_t();
+
+    // Process-wide shared manager so that pinned-buffer recognition is consistent
+    // across every io handle (each handle references this single instance).
+    // Canonical instance lives in the pin_memory extension; other ops resolve it
+    // via deepspeed_pin_tensor_mgr_holder() after that extension is loaded.
+    static std::shared_ptr<deepspeed_pin_tensor_t> shared();
+
+    torch::Tensor alloc(const int64_t num_elem, const at::ScalarType& elem_type);
+    torch::Tensor alloc(const int64_t num_elem, const torch::TensorOptions& options);
+
+    bool free(torch::Tensor& locked_tensor);
+
+    bool is_managed(const torch::Tensor& buffer);
+};
+
+// Exported so async_io/gds can resolve the same manager across .so boundaries.
+extern "C" void* deepspeed_pin_tensor_mgr_holder();

--- a/csrc/pin_memory/page_alloc.cpp
+++ b/csrc/pin_memory/page_alloc.cpp
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/pin_memory/page_alloc.cpp
+++ b/csrc/pin_memory/page_alloc.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+#include "page_alloc.h"
+
+#include <sys/mman.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+void* ds_page_aligned_alloc(const int64_t size, const bool lock)
+{
+    void* ptr;
+    int retval;
+
+    retval = posix_memalign(&ptr, (size_t)sysconf(_SC_PAGESIZE), size);
+    if (retval) { return nullptr; }
+
+    if (lock == false) { return ptr; }
+
+    auto mlock_ret = mlock(ptr, size);
+    if (mlock_ret != 0) {
+        auto mlock_error = errno;
+        std::cerr << "mlock failed to allocate " << size << " bytes with error no " << mlock_error
+                  << " msg " << strerror(mlock_error) << std::endl;
+        free(ptr);
+        return nullptr;
+    }
+
+    return ptr;
+}

--- a/csrc/pin_memory/page_alloc.h
+++ b/csrc/pin_memory/page_alloc.h
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/pin_memory/page_alloc.h
+++ b/csrc/pin_memory/page_alloc.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+/*
+Page-aligned host allocation with optional mlock, independent of libaio.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+void* ds_page_aligned_alloc(const int64_t size, const bool lock = false);

--- a/csrc/pin_memory/py_ds_pin_memory.cpp
+++ b/csrc/pin_memory/py_ds_pin_memory.cpp
@@ -1,4 +1,3 @@
-// Copyright (c) Microsoft Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 // DeepSpeed Team

--- a/csrc/pin_memory/py_ds_pin_memory.cpp
+++ b/csrc/pin_memory/py_ds_pin_memory.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+// DeepSpeed Team
+
+#include <torch/extension.h>
+#include "deepspeed_pin_tensor.h"
+
+using namespace pybind11::literals;
+
+struct deepspeed_pin_handle_t {
+    std::shared_ptr<deepspeed_pin_tensor_t> _pinned_tensor_mgr;
+
+    deepspeed_pin_handle_t() : _pinned_tensor_mgr(deepspeed_pin_tensor_t::shared()) {}
+
+    torch::Tensor new_cpu_locked_tensor(const int64_t num_elem, const torch::Tensor& example_tensor)
+    {
+        return _pinned_tensor_mgr->alloc(num_elem, example_tensor.options());
+    }
+
+    bool free_cpu_locked_tensor(torch::Tensor& locked_tensor)
+    {
+        return _pinned_tensor_mgr->free(locked_tensor);
+    }
+
+    bool is_pinned(const torch::Tensor& buffer)
+    {
+        return buffer.is_pinned() || _pinned_tensor_mgr->is_managed(buffer);
+    }
+};
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    py::class_<deepspeed_pin_handle_t>(m, "pin_handle")
+        .def(py::init<>(), "Pin-memory handle constructor")
+        .def("new_cpu_locked_tensor",
+             &deepspeed_pin_handle_t::new_cpu_locked_tensor,
+             "Allocate a page-locked CPU tensor",
+             "num_elem"_a,
+             "example_tensor"_a)
+        .def("free_cpu_locked_tensor",
+             &deepspeed_pin_handle_t::free_cpu_locked_tensor,
+             "Free a page-locked CPU tensor",
+             "locked_tensor"_a)
+        .def("is_pinned",
+             &deepspeed_pin_handle_t::is_pinned,
+             "Return whether buffer is torch-pinned or managed by DeepSpeed pin_memory",
+             "buffer"_a);
+}

--- a/deepspeed/ops/pin_memory/__init__.py
+++ b/deepspeed/ops/pin_memory/__init__.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/deepspeed/ops/pin_memory/__init__.py
+++ b/deepspeed/ops/pin_memory/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from ..op_builder.pin_memory import PinMemoryBuilder

--- a/docs/_tutorials/deepnvme.md
+++ b/docs/_tutorials/deepnvme.md
@@ -146,7 +146,7 @@ True
 1073741824
 ```
 
-You can also allocate page-locked host tensors directly through the standalone `pin_memory` operator, which pins CPU memory (`posix_memalign` + `mlock`) without requiring `libaio` or the `async_io` worker threads. This is useful on CPU-only hosts or when you want a pinned buffer without an `aio_handle`. Buffers allocated this way are recognized by `aio_handle`/`gds_handle` (they share one process-wide pin manager), so DeepNVMe can still skip bounce buffers for them.
+You can also allocate page-locked host tensors directly through the standalone `pin_memory` operator, which pins CPU memory (`posix_memalign` + `mlock`). This is useful on CPU-only hosts or when you want a pinned buffer without starting an I/O handle. Buffers allocated this way are recognized by DeepNVMe I/O handles (they share one process-wide pin manager), so DeepNVMe can still skip bounce buffers for them.
 
 ```bash
 >>> import torch
@@ -159,7 +159,7 @@ True
 True
 ```
 
-The `pin_handle` exposes `new_cpu_locked_tensor(num_elem, example_tensor)`, `free_cpu_locked_tensor(tensor)`, and `is_pinned(tensor)`. The same methods remain available on `aio_handle` and `gds_handle` as thin wrappers, so existing code continues to work unchanged.
+The `pin_handle` exposes `new_cpu_locked_tensor(num_elem, example_tensor)`, `free_cpu_locked_tensor(tensor)`, and `is_pinned(tensor)`. The same methods remain available on DeepNVMe I/O handles as thin wrappers, so existing code continues to work unchanged.
 
 On the other hand,`gds_handle` provides `new_pinned_device_tensor()` and `pin_device_tensor()` functions for pinning CUDA tensors. The following example illustrates writing a pinned CUDA tensor to a local NVMe file.
 

--- a/docs/_tutorials/deepnvme.md
+++ b/docs/_tutorials/deepnvme.md
@@ -146,6 +146,21 @@ True
 1073741824
 ```
 
+You can also allocate page-locked host tensors directly through the standalone `pin_memory` operator, which pins CPU memory (`posix_memalign` + `mlock`) without requiring `libaio` or the `async_io` worker threads. This is useful on CPU-only hosts or when you want a pinned buffer without an `aio_handle`. Buffers allocated this way are recognized by `aio_handle`/`gds_handle` (they share one process-wide pin manager), so DeepNVMe can still skip bounce buffers for them.
+
+```bash
+>>> import torch
+>>> from deepspeed.ops.op_builder import PinMemoryBuilder
+>>> pin = PinMemoryBuilder().load().pin_handle()
+>>> t = pin.new_cpu_locked_tensor(1024**3, torch.empty(0, dtype=torch.uint8))
+>>> pin.is_pinned(t)
+True
+>>> pin.free_cpu_locked_tensor(t)
+True
+```
+
+The `pin_handle` exposes `new_cpu_locked_tensor(num_elem, example_tensor)`, `free_cpu_locked_tensor(tensor)`, and `is_pinned(tensor)`. The same methods remain available on `aio_handle` and `gds_handle` as thin wrappers, so existing code continues to work unchanged.
+
 On the other hand,`gds_handle` provides `new_pinned_device_tensor()` and `pin_device_tensor()` functions for pinning CUDA tensors. The following example illustrates writing a pinned CUDA tensor to a local NVMe file.
 
 ```bash

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -265,7 +265,7 @@ Note about gradients: While gradients are stored in fp16 (2 bytes), during the w
 
 **Pinned Memory**
 
-Pinned general RAM is included in normal general RAM allocations (i.e. this is not extra memory allocations but simply shows how much of the general RAM is pinned). Pinning is controlled by the ``pin_memory`` field of ``offload_optimizer`` / ``offload_param`` (both default to ``true``); set to ``false`` on hosts with tight memlock limits (``ulimit -l``).
+Pinned general RAM is included in normal general RAM allocations (i.e. this is not extra memory allocations but simply shows how much of the general RAM is pinned). Pinning is controlled by the ``pin_memory`` field of ``offload_optimizer`` / ``offload_param`` (both default to ``true``); set to ``false`` on hosts with tight memlock limits (``ulimit -l``). See :ref:`host-memory-pinning` for how host memory is page-locked (``torch`` vs the DeepSpeed ``pin_memory`` op).
 
 * ZeRO-1/2: controlled by ``offload_optimizer.pin_memory``
 
@@ -288,3 +288,99 @@ With pinning enabled there are 2 sub-cases:
 XXX: For Transformers is probably around (2* seq * attn_heads + 16 * hidden_size) * sequence * batch/gpu
 
 This needs to be completed.
+
+
+.. _host-memory-pinning:
+
+Host Memory Pinning
+-----------------------
+
+DeepSpeed page-locks (pins) host memory so DMA engines can move data efficiently
+between CPU RAM and accelerators or NVMe. Host tensors can be pinned either with
+PyTorch / the accelerator hook, or with the standalone DeepSpeed ``pin_memory``
+operator (``posix_memalign`` + ``mlock``), which does not require ``libaio`` or
+``async_io`` worker threads.
+
+Accelerator API (torch path)
+============================
+
+.. code-block:: python
+
+    from deepspeed.accelerator import get_accelerator
+
+    pinned = get_accelerator().pin_memory(tensor)
+    assert get_accelerator().is_pinned(pinned)
+
+On most accelerators this routes to ``tensor.pin_memory()``. The CPU accelerator
+historically treats this as a no-op (torch cannot pin a CPU tensor to a device).
+
+DeepSpeed ``pin_memory`` op
+==========================
+
+Allocate and free page-locked host tensors through ``PinMemoryBuilder`` /
+``pin_handle``:
+
+.. code-block:: python
+
+    import torch
+    from deepspeed.ops.op_builder import PinMemoryBuilder
+
+    pin = PinMemoryBuilder().load().pin_handle()
+    t = pin.new_cpu_locked_tensor(1024**3, torch.empty(0, dtype=torch.uint8))
+    assert pin.is_pinned(t)
+    pin.free_cpu_locked_tensor(t)
+
+``pin_handle`` exposes:
+
+* ``new_cpu_locked_tensor(num_elem, example_tensor)`` — allocate a page-locked CPU tensor
+* ``free_cpu_locked_tensor(tensor)`` — unlock and free the allocation
+* ``is_pinned(tensor)`` — ``True`` for torch-pinned buffers and for tensors whose
+  storage falls inside a DeepSpeed-managed locked range (slices/views included)
+
+The same three methods remain available on ``aio_handle`` / ``gds_handle`` as thin
+wrappers. Buffers allocated via ``pin_handle`` and via an I/O handle share one
+process-wide pin manager, so DeepNVMe bounce-buffer skipping stays consistent
+across both paths.
+
+.. list-table:: Differences between torch pinning and the DeepSpeed ``pin_memory`` op
+   :header-rows: 1
+   :widths: 22 39 39
+
+   * - Aspect
+     - Torch / accelerator ``pin_memory``
+     - DeepSpeed ``pin_memory`` op
+   * - Allocator
+     - ``torch.Tensor.pin_memory()`` (device-specific accelerator hook)
+     - ``posix_memalign`` + ``mlock`` via ``PinMemoryBuilder`` / ``pin_handle``
+   * - Build dependency
+     - None beyond the active accelerator / PyTorch
+     - DeepSpeed **pin_memory** op must build and load (no ``libaio`` required)
+   * - AIO / GDS worker threads
+     - Not involved
+     - Not required (unlike allocating through ``aio_handle`` alone)
+   * - Visible to DeepNVMe
+     - Yes (``aio_handle.is_pinned`` / bounce-buffer skip)
+     - Yes (same process-wide manager as ``async_io`` / ``gds``)
+   * - ``is_pinned``
+     - Torch pinned status (``tensor.is_pinned()``)
+     - Torch-pinned **or** DeepSpeed-managed locked range (slices/views included)
+   * - Explicit free
+     - Freed when the tensor is garbage-collected (PyTorch)
+     - ``free_cpu_locked_tensor`` releases the mlocked pages immediately
+   * - CPU accelerator
+     - Historical no-op (torch cannot pin CPU tensors)
+     - Real ``mlock`` pins on CPU-only hosts
+
+Requirements
+============
+
+* The DeepSpeed **pin_memory** op must build and load successfully. When
+  ``async_io`` / ``gds`` are precompiled, ``setup.py`` also precompiles
+  ``pin_memory`` so deployments without a runtime compiler still get the shared
+  manager.
+* The process must be allowed to lock the requested host memory (see
+  ``ulimit -l`` / ``memlock`` limits). Large ZeRO CPU-offload or DeepNVMe
+  footprints can otherwise hit the memlock ceiling.
+
+See also the DeepNVMe tutorial for end-to-end examples of pinning host and device
+tensors for NVMe I/O.

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -298,8 +298,7 @@ Host Memory Pinning
 DeepSpeed page-locks (pins) host memory so DMA engines can move data efficiently
 between CPU RAM and accelerators or NVMe. Host tensors can be pinned either with
 PyTorch / the accelerator hook, or with the standalone DeepSpeed ``pin_memory``
-operator (``posix_memalign`` + ``mlock``), which does not require ``libaio`` or
-``async_io`` worker threads.
+operator (``posix_memalign`` + ``mlock``).
 
 Accelerator API (torch path)
 ============================
@@ -337,10 +336,9 @@ Allocate and free page-locked host tensors through ``PinMemoryBuilder`` /
 * ``is_pinned(tensor)`` — ``True`` for torch-pinned buffers and for tensors whose
   storage falls inside a DeepSpeed-managed locked range (slices/views included)
 
-The same three methods remain available on ``aio_handle`` / ``gds_handle`` as thin
-wrappers. Buffers allocated via ``pin_handle`` and via an I/O handle share one
-process-wide pin manager, so DeepNVMe bounce-buffer skipping stays consistent
-across both paths.
+The same three methods remain available on DeepNVMe I/O handles as thin wrappers.
+Buffers allocated via ``pin_handle`` and via an I/O handle share one process-wide
+pin manager, so DeepNVMe bounce-buffer skipping stays consistent across both paths.
 
 .. list-table:: Differences between torch pinning and the DeepSpeed ``pin_memory`` op
    :header-rows: 1
@@ -354,13 +352,10 @@ across both paths.
      - ``posix_memalign`` + ``mlock`` via ``PinMemoryBuilder`` / ``pin_handle``
    * - Build dependency
      - None beyond the active accelerator / PyTorch
-     - DeepSpeed **pin_memory** op must build and load (no ``libaio`` required)
-   * - AIO / GDS worker threads
-     - Not involved
-     - Not required (unlike allocating through ``aio_handle`` alone)
+     - DeepSpeed **pin_memory** op must build and load
    * - Visible to DeepNVMe
-     - Yes (``aio_handle.is_pinned`` / bounce-buffer skip)
-     - Yes (same process-wide manager as ``async_io`` / ``gds``)
+     - Yes (``is_pinned`` / bounce-buffer skip on I/O handles)
+     - Yes (same process-wide pin manager)
    * - ``is_pinned``
      - Torch pinned status (``tensor.is_pinned()``)
      - Torch-pinned **or** DeepSpeed-managed locked range (slices/views included)
@@ -374,10 +369,7 @@ across both paths.
 Requirements
 ============
 
-* The DeepSpeed **pin_memory** op must build and load successfully. When
-  ``async_io`` / ``gds`` are precompiled, ``setup.py`` also precompiles
-  ``pin_memory`` so deployments without a runtime compiler still get the shared
-  manager.
+* The DeepSpeed **pin_memory** op must build and load successfully.
 * The process must be allowed to lock the requested host memory (see
   ``ulimit -l`` / ``memlock`` limits). Large ZeRO CPU-offload or DeepNVMe
   footprints can otherwise hit the memlock ceiling.

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -265,7 +265,7 @@ Note about gradients: While gradients are stored in fp16 (2 bytes), during the w
 
 **Pinned Memory**
 
-Pinned general RAM is included in normal general RAM allocations (i.e. this is not extra memory allocations but simply shows how much of the general RAM is pinned). Pinning is controlled by the ``pin_memory`` field of ``offload_optimizer`` / ``offload_param`` (both default to ``true``); set to ``false`` on hosts with tight memlock limits (``ulimit -l``). See :ref:`host-memory-pinning` for how host memory is page-locked (``torch`` vs the DeepSpeed ``pin_memory`` op).
+Pinned general RAM is included in normal general RAM allocations (i.e. this is not extra memory allocations but simply shows how much of the general RAM is pinned). Pinning is controlled by the ``pin_memory`` field of ``offload_optimizer`` / ``offload_param`` (both default to ``true``); set to ``false`` on hosts with tight memlock limits (``ulimit -l``). See :ref:`host-memory-pinning` for how host memory is page-locked (accelerator / torch pinning and the DeepSpeed ``pin_memory`` op).
 
 * ZeRO-1/2: controlled by ``offload_optimizer.pin_memory``
 

--- a/op_builder/async_io.py
+++ b/op_builder/async_io.py
@@ -27,7 +27,7 @@ class AsyncIOBuilder(TorchCPUOpBuilder):
             'csrc/aio/common/deepspeed_aio_utils.cpp', 'csrc/aio/common/deepspeed_aio_common.cpp',
             'csrc/aio/common/deepspeed_aio_types.cpp', 'csrc/aio/py_lib/deepspeed_cpu_op.cpp',
             'csrc/aio/py_lib/deepspeed_aio_op_desc.cpp', 'csrc/aio/py_lib/deepspeed_py_copy.cpp',
-            'csrc/aio/py_lib/deepspeed_pin_tensor.cpp'
+            'csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp'
         ]
         return src_list
 
@@ -46,7 +46,7 @@ class AsyncIOBuilder(TorchCPUOpBuilder):
                 os.path.join(torch.utils.cpp_extension.ROCM_HOME, "include", "rocrand"),
                 os.path.join(torch.utils.cpp_extension.ROCM_HOME, "include", "hiprand"),
             ]
-        return ['csrc/aio/py_lib', 'csrc/aio/common'] + CUDA_INCLUDE
+        return ['csrc/aio/py_lib', 'csrc/aio/common', 'csrc/pin_memory'] + CUDA_INCLUDE
 
     def cxx_args(self):
         # -O0 for improved debugging, since performance is bound by I/O
@@ -92,6 +92,13 @@ class AsyncIOBuilder(TorchCPUOpBuilder):
                     self.warning(f"{self.NAME}: please install the {lib} package with {tool}")
                 break
         return found
+
+    def load(self, verbose=False):
+        # Pin manager is compiled only into pin_memory; load it first so aio can
+        # resolve the shared manager (and related symbols) across .so boundaries.
+        from .pin_memory import PinMemoryBuilder
+        PinMemoryBuilder().load(verbose=verbose)
+        return super().load(verbose=verbose)
 
     def is_compatible(self, verbose=False):
         # Check for the existence of libaio by using distutils

--- a/op_builder/cpu/__init__.py
+++ b/op_builder/cpu/__init__.py
@@ -9,3 +9,4 @@ from .fused_adam import FusedAdamBuilder
 from .cpu_adam import CPUAdamBuilder
 from .no_impl import NotImplementedBuilder
 from .async_io import AsyncIOBuilder
+from .pin_memory import PinMemoryBuilder

--- a/op_builder/cpu/async_io.py
+++ b/op_builder/cpu/async_io.py
@@ -26,7 +26,7 @@ class AsyncIOBuilder(CPUOpBuilder):
             'csrc/aio/common/deepspeed_aio_utils.cpp', 'csrc/aio/common/deepspeed_aio_common.cpp',
             'csrc/aio/common/deepspeed_aio_types.cpp', 'csrc/aio/py_lib/deepspeed_cpu_op.cpp',
             'csrc/aio/py_lib/deepspeed_aio_op_desc.cpp', 'csrc/aio/py_lib/deepspeed_py_copy.cpp',
-            'csrc/aio/py_lib/deepspeed_pin_tensor.cpp'
+            'csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp'
         ]
         return src_list
 
@@ -34,7 +34,7 @@ class AsyncIOBuilder(CPUOpBuilder):
         return self.lib_sources() + ['csrc/aio/py_lib/py_ds_aio.cpp']
 
     def include_paths(self):
-        return ['csrc/aio/py_lib', 'csrc/aio/common']
+        return ['csrc/aio/py_lib', 'csrc/aio/common', 'csrc/pin_memory']
 
     def cxx_args(self):
         # -O0 for improved debugging, since performance is bound by I/O
@@ -70,6 +70,13 @@ class AsyncIOBuilder(CPUOpBuilder):
                     self.warning(f"{self.NAME}: please install the {lib} package with {tool}")
                 break
         return found
+
+    def load(self, verbose=False):
+        # Pin manager is compiled only into pin_memory; load it first so aio can
+        # resolve the shared manager (and related symbols) across .so boundaries.
+        from .pin_memory import PinMemoryBuilder
+        PinMemoryBuilder().load(verbose=verbose)
+        return super().load(verbose=verbose)
 
     def is_compatible(self, verbose=False):
         # Check for the existence of libaio by using distutils

--- a/op_builder/cpu/pin_memory.py
+++ b/op_builder/cpu/pin_memory.py
@@ -1,44 +1,11 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team
 
-import sys
-
-from .builder import CPUOpBuilder
+# Host pin_memory is accelerator-agnostic; reuse the top-level builder.
 try:
-    from op_builder.pin_memory_load import load_pin_memory_module
+    from op_builder.pin_memory import PinMemoryBuilder
 except ImportError:
-    from deepspeed.ops.op_builder.pin_memory_load import load_pin_memory_module
+    from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
 
-
-class PinMemoryBuilder(CPUOpBuilder):
-    BUILD_VAR = "DS_BUILD_PIN_MEMORY"
-    NAME = "pin_memory"
-
-    def __init__(self):
-        super().__init__(name=self.NAME)
-
-    def absolute_name(self):
-        return f'deepspeed.ops.pin_memory.{self.NAME}_op'
-
-    def is_compatible(self, verbose=False):
-        # The allocator relies on POSIX mlock/posix_memalign, which are unavailable on Windows.
-        if sys.platform == "win32":
-            if verbose:
-                self.warning(f"{self.NAME} is only supported on POSIX platforms, not Windows.")
-            return False
-        return super().is_compatible(verbose)
-
-    def sources(self):
-        return [
-            'csrc/pin_memory/page_alloc.cpp',
-            'csrc/pin_memory/deepspeed_pin_tensor.cpp',
-            'csrc/pin_memory/py_ds_pin_memory.cpp',
-        ]
-
-    def include_paths(self):
-        return ['csrc/pin_memory']
-
-    def load(self, verbose=False):
-        return load_pin_memory_module(self, verbose=verbose)
+__all__ = ["PinMemoryBuilder"]

--- a/op_builder/cpu/pin_memory.py
+++ b/op_builder/cpu/pin_memory.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .builder import CPUOpBuilder
+try:
+    from op_builder.pin_memory_load import load_pin_memory_module
+except ImportError:
+    from deepspeed.ops.op_builder.pin_memory_load import load_pin_memory_module
+
+
+class PinMemoryBuilder(CPUOpBuilder):
+    BUILD_VAR = "DS_BUILD_PIN_MEMORY"
+    NAME = "pin_memory"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.pin_memory.{self.NAME}_op'
+
+    def sources(self):
+        return [
+            'csrc/pin_memory/page_alloc.cpp',
+            'csrc/pin_memory/deepspeed_pin_tensor.cpp',
+            'csrc/pin_memory/py_ds_pin_memory.cpp',
+        ]
+
+    def include_paths(self):
+        return ['csrc/pin_memory']
+
+    def load(self, verbose=False):
+        return load_pin_memory_module(self, verbose=verbose)

--- a/op_builder/cpu/pin_memory.py
+++ b/op_builder/cpu/pin_memory.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+import sys
+
 from .builder import CPUOpBuilder
 try:
     from op_builder.pin_memory_load import load_pin_memory_module
@@ -19,6 +21,14 @@ class PinMemoryBuilder(CPUOpBuilder):
 
     def absolute_name(self):
         return f'deepspeed.ops.pin_memory.{self.NAME}_op'
+
+    def is_compatible(self, verbose=False):
+        # The allocator relies on POSIX mlock/posix_memalign, which are unavailable on Windows.
+        if sys.platform == "win32":
+            if verbose:
+                self.warning(f"{self.NAME} is only supported on POSIX platforms, not Windows.")
+            return False
+        return super().is_compatible(verbose)
 
     def sources(self):
         return [

--- a/op_builder/gds.py
+++ b/op_builder/gds.py
@@ -30,7 +30,7 @@ class GDSBuilder(AsyncIOBuilder):
     def include_paths(self):
         import torch
         CUDA_INCLUDE = [os.path.join(torch.utils.cpp_extension.CUDA_HOME, "include")]
-        return ['csrc/aio/py_lib', 'csrc/aio/common'] + CUDA_INCLUDE
+        return ['csrc/aio/py_lib', 'csrc/aio/common', 'csrc/pin_memory'] + CUDA_INCLUDE
 
     def extra_ldflags(self):
         return super().extra_ldflags() + ['-lcufile']

--- a/op_builder/npu/__init__.py
+++ b/op_builder/npu/__init__.py
@@ -6,6 +6,7 @@
 
 from .fused_adam import FusedAdamBuilder
 from .async_io import AsyncIOBuilder
+from .pin_memory import PinMemoryBuilder
 from .no_impl import NotImplementedBuilder
 from .cpu_adam import CPUAdamBuilder
 from .cpu_adagrad import CPUAdagradBuilder

--- a/op_builder/npu/async_io.py
+++ b/op_builder/npu/async_io.py
@@ -25,13 +25,13 @@ class AsyncIOBuilder(NPUOpBuilder):
             'csrc/aio/py_lib/deepspeed_py_aio.cpp', 'csrc/aio/py_lib/deepspeed_py_aio_handle.cpp',
             'csrc/aio/py_lib/deepspeed_aio_thread.cpp', 'csrc/aio/common/deepspeed_aio_utils.cpp',
             'csrc/aio/common/deepspeed_aio_common.cpp', 'csrc/aio/common/deepspeed_aio_types.cpp',
-            'csrc/aio/py_lib/deepspeed_pin_tensor.cpp', 'csrc/aio/py_lib/deepspeed_py_io_handle.cpp',
+            'csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp', 'csrc/aio/py_lib/deepspeed_py_io_handle.cpp',
             'csrc/aio/py_lib/deepspeed_aio_op_desc.cpp', 'csrc/aio/py_lib/deepspeed_cpu_op.cpp'
         ]
 
     def include_paths(self):
         args = super().include_paths()
-        args += ['csrc/aio/py_lib', 'csrc/aio/common']
+        args += ['csrc/aio/py_lib', 'csrc/aio/common', 'csrc/pin_memory']
         return args
 
     def cxx_args(self):
@@ -83,6 +83,16 @@ class AsyncIOBuilder(NPUOpBuilder):
                     self.warning(f"{self.NAME}: please install the {lib} package with {tool}")
                 break
         return found
+
+    def load(self, verbose=False):
+        # Pin manager is compiled only into pin_memory; load it first so aio can
+        # resolve the shared manager (and related symbols) across .so boundaries.
+        try:
+            from op_builder.pin_memory import PinMemoryBuilder
+        except ImportError:
+            from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
+        PinMemoryBuilder().load(verbose=verbose)
+        return super().load(verbose=verbose)
 
     def is_compatible(self, verbose=False):
         # Check for the existence of libaio by using distutils

--- a/op_builder/npu/pin_memory.py
+++ b/op_builder/npu/pin_memory.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/npu/pin_memory.py
+++ b/op_builder/npu/pin_memory.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+# Host pin_memory is accelerator-agnostic; reuse the top-level builder.
+try:
+    from op_builder.pin_memory import PinMemoryBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
+
+__all__ = ["PinMemoryBuilder"]

--- a/op_builder/pin_memory.py
+++ b/op_builder/pin_memory.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/pin_memory.py
+++ b/op_builder/pin_memory.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .builder import OpBuilder
+from .pin_memory_load import load_pin_memory_module
+
+
+class PinMemoryBuilder(OpBuilder):
+    BUILD_VAR = "DS_BUILD_PIN_MEMORY"
+    NAME = "pin_memory"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.pin_memory.{self.NAME}_op'
+
+    def sources(self):
+        return [
+            'csrc/pin_memory/page_alloc.cpp',
+            'csrc/pin_memory/deepspeed_pin_tensor.cpp',
+            'csrc/pin_memory/py_ds_pin_memory.cpp',
+        ]
+
+    def include_paths(self):
+        return ['csrc/pin_memory']
+
+    def load(self, verbose=False):
+        return load_pin_memory_module(self, verbose=verbose)

--- a/op_builder/pin_memory.py
+++ b/op_builder/pin_memory.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+import sys
+
 from .builder import OpBuilder
 from .pin_memory_load import load_pin_memory_module
 
@@ -16,6 +18,14 @@ class PinMemoryBuilder(OpBuilder):
 
     def absolute_name(self):
         return f'deepspeed.ops.pin_memory.{self.NAME}_op'
+
+    def is_compatible(self, verbose=False):
+        # The allocator relies on POSIX mlock/posix_memalign, which are unavailable on Windows.
+        if sys.platform == "win32":
+            if verbose:
+                self.warning(f"{self.NAME} is only supported on POSIX platforms, not Windows.")
+            return False
+        return super().is_compatible(verbose)
 
     def sources(self):
         return [

--- a/op_builder/pin_memory_load.py
+++ b/op_builder/pin_memory_load.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/pin_memory_load.py
+++ b/op_builder/pin_memory_load.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import ctypes
+import sys
+
+# Process-wide cache so pin_memory is loaded once even if OpBuilder is imported
+# under both ``op_builder`` and ``deepspeed.ops.op_builder`` (separate _loaded_ops).
+_SYS_CACHE_ATTR = "_deepspeed_pin_memory_op_module"
+
+
+def load_pin_memory_module(builder, verbose=False):
+    module = getattr(sys, _SYS_CACHE_ATTR, None)
+    if module is None:
+        # Call OpBuilder.load without going through subclass load() recursion.
+        module = super(type(builder), builder).load(verbose=verbose)
+        setattr(sys, _SYS_CACHE_ATTR, module)
+    so_path = getattr(module, "__file__", None)
+    if so_path:
+        ctypes.CDLL(so_path, mode=ctypes.RTLD_GLOBAL)
+    return module

--- a/op_builder/supa/__init__.py
+++ b/op_builder/supa/__init__.py
@@ -8,6 +8,7 @@ from .fused_lion import FusedLionBuilder
 from .inference import InferenceBuilder
 from .quantizer import QuantizerBuilder
 from .async_io import AsyncIOBuilder
+from .pin_memory import PinMemoryBuilder
 from .no_impl import NotImplementedBuilder
 from .cpu_adam import CPUAdamBuilder
 from .cpu_lion import CPULionBuilder

--- a/op_builder/supa/async_io.py
+++ b/op_builder/supa/async_io.py
@@ -27,7 +27,7 @@ class AsyncIOBuilder(SUPAOpBuilder):
             'csrc/aio/common/deepspeed_aio_utils.cpp',
             'csrc/aio/common/deepspeed_aio_common.cpp',
             'csrc/aio/common/deepspeed_aio_types.cpp',
-            'csrc/aio/py_lib/deepspeed_pin_tensor.cpp',
+            'csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp',
             'csrc/aio/py_lib/deepspeed_py_io_handle.cpp',
             'csrc/aio/py_lib/deepspeed_cpu_op.cpp',
             'csrc/aio/py_lib/deepspeed_aio_op_desc.cpp',
@@ -35,7 +35,7 @@ class AsyncIOBuilder(SUPAOpBuilder):
 
     def include_paths(self):
         args = super().include_paths()
-        args += ['csrc/aio/py_lib', 'csrc/aio/common']
+        args += ['csrc/aio/py_lib', 'csrc/aio/common', 'csrc/pin_memory']
         return args
 
     def cxx_args(self):
@@ -66,6 +66,16 @@ class AsyncIOBuilder(SUPAOpBuilder):
                     self.warning(f"{self.NAME}: please install the {lib} package with {tool}")
                 break
         return found
+
+    def load(self, verbose=False):
+        # Pin manager is compiled only into pin_memory; load it first so aio can
+        # resolve the shared manager (and related symbols) across .so boundaries.
+        try:
+            from op_builder.pin_memory import PinMemoryBuilder
+        except ImportError:
+            from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
+        PinMemoryBuilder().load(verbose=verbose)
+        return super().load(verbose=verbose)
 
     def is_compatible(self, verbose=False):
         # Check for the existence of libaio by using distutils

--- a/op_builder/supa/pin_memory.py
+++ b/op_builder/supa/pin_memory.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/supa/pin_memory.py
+++ b/op_builder/supa/pin_memory.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+# Host pin_memory is accelerator-agnostic; reuse the top-level builder.
+try:
+    from op_builder.pin_memory import PinMemoryBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
+
+__all__ = ["PinMemoryBuilder"]

--- a/op_builder/xpu/__init__.py
+++ b/op_builder/xpu/__init__.py
@@ -7,6 +7,7 @@ from .cpu_adam import CPUAdamBuilder
 from .cpu_adagrad import CPUAdagradBuilder
 from .fused_adam import FusedAdamBuilder
 from .async_io import AsyncIOBuilder
+from .pin_memory import PinMemoryBuilder
 from .flash_attn import FlashAttentionBuilder
 from .no_impl import NotImplementedBuilder
 from .packbits import PackbitsBuilder

--- a/op_builder/xpu/async_io.py
+++ b/op_builder/xpu/async_io.py
@@ -29,14 +29,14 @@ class AsyncIOBuilder(OpBuilder):
             'csrc/aio/common/deepspeed_aio_utils.cpp',
             'csrc/aio/common/deepspeed_aio_common.cpp',
             'csrc/aio/common/deepspeed_aio_types.cpp',
-            'csrc/aio/py_lib/deepspeed_pin_tensor.cpp',
+            'csrc/aio/py_lib/deepspeed_pin_tensor_client.cpp',
             'csrc/aio/py_lib/deepspeed_py_io_handle.cpp',
             'csrc/aio/py_lib/deepspeed_cpu_op.cpp',
             'csrc/aio/py_lib/deepspeed_aio_op_desc.cpp',
         ]
 
     def include_paths(self):
-        return ['csrc/aio/py_lib', 'csrc/aio/common']
+        return ['csrc/aio/py_lib', 'csrc/aio/common', 'csrc/pin_memory']
 
     def cxx_args(self):
         import torch
@@ -85,6 +85,16 @@ class AsyncIOBuilder(OpBuilder):
                     self.warning(f"{self.NAME}: please install the {lib} package with {tool}")
                 break
         return found
+
+    def load(self, verbose=False):
+        # Pin manager is compiled only into pin_memory; load it first so aio can
+        # resolve the shared manager (and related symbols) across .so boundaries.
+        try:
+            from op_builder.pin_memory import PinMemoryBuilder
+        except ImportError:
+            from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
+        PinMemoryBuilder().load(verbose=verbose)
+        return super().load(verbose=verbose)
 
     def is_compatible(self, verbose=False):
         # Check for the existence of libaio by using distutils

--- a/op_builder/xpu/pin_memory.py
+++ b/op_builder/xpu/pin_memory.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/xpu/pin_memory.py
+++ b/op_builder/xpu/pin_memory.py
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+# Host pin_memory is accelerator-agnostic; reuse the top-level builder.
+try:
+    from op_builder.pin_memory import PinMemoryBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.pin_memory import PinMemoryBuilder
+
+__all__ = ["PinMemoryBuilder"]

--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,21 @@ for op_name, builder in ALL_OPS.items():
         install_ops[op_name] = op_enabled(op_name)
         ext_modules.append(builder.builder())
 
+# async_io/gds load the pin_memory op's shared manager at runtime. If they are
+# precompiled but pin_memory is not, deployments without a compiler would hit a
+# runtime JIT build, so precompile pin_memory alongside them.
+pin_memory_dependents = [name for name in ("async_io", "gds") if install_ops.get(name)]
+if pin_memory_dependents and not install_ops.get("pin_memory"):
+    pin_memory_builder = ALL_OPS.get("pin_memory")
+    if pin_memory_builder is not None and pin_memory_builder.is_compatible():
+        assert torch_available, "Unable to pre-compile pin_memory, please first install torch"
+        install_ops["pin_memory"] = 1
+        ext_modules.append(pin_memory_builder.builder())
+    else:
+        raise RuntimeError(
+            f"Cannot pre-compile {', '.join(pin_memory_dependents)} without pin_memory, which is required at "
+            "runtime but is not compatible on this platform.")
+
 print(f'Install Ops={install_ops}')
 
 # Write out version/git info.

--- a/tests/unit/v1/nvme/test_pinned_manager.py
+++ b/tests/unit/v1/nvme/test_pinned_manager.py
@@ -48,3 +48,36 @@ def test_buffer_is_shared_across_handles():
 def test_unmanaged_buffer_is_not_pinned():
     handle = _new_handle()
     assert not handle.is_pinned(torch.empty(NUM_ELEMS, dtype=torch.float))
+
+
+def test_pin_handle_buffer_recognized_by_aio_handle():
+    # Buffers allocated via the standalone pin_memory op must share the same
+    # process-wide manager as async_io, so aio_handle.is_pinned sees them.
+    from deepspeed.ops.op_builder import PinMemoryBuilder
+    if not deepspeed.ops.__compatible_ops__.get(PinMemoryBuilder.NAME, True):
+        pytest.skip('Skip tests since pin_memory is not compatible')
+
+    pin_handle = PinMemoryBuilder().load().pin_handle()
+    aio_handle = _new_handle()
+    buffer = pin_handle.new_cpu_locked_tensor(NUM_ELEMS, torch.empty(0, dtype=torch.float))
+    try:
+        assert pin_handle.is_pinned(buffer)
+        assert aio_handle.is_pinned(buffer)
+        assert aio_handle.is_pinned(buffer.narrow(0, BLOCK_SIZE, BLOCK_SIZE))
+    finally:
+        pin_handle.free_cpu_locked_tensor(buffer)
+
+
+def test_aio_handle_buffer_recognized_by_pin_handle():
+    from deepspeed.ops.op_builder import PinMemoryBuilder
+    if not deepspeed.ops.__compatible_ops__.get(PinMemoryBuilder.NAME, True):
+        pytest.skip('Skip tests since pin_memory is not compatible')
+
+    pin_handle = PinMemoryBuilder().load().pin_handle()
+    aio_handle = _new_handle()
+    buffer = aio_handle.new_cpu_locked_tensor(NUM_ELEMS, torch.empty(0, dtype=torch.float))
+    try:
+        assert aio_handle.is_pinned(buffer)
+        assert pin_handle.is_pinned(buffer)
+    finally:
+        aio_handle.free_cpu_locked_tensor(buffer)

--- a/tests/unit/v1/pin_memory/test_pin_memory_op.py
+++ b/tests/unit/v1/pin_memory/test_pin_memory_op.py
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+import torch
+import deepspeed
+from deepspeed.ops.op_builder import PinMemoryBuilder
+
+if not deepspeed.ops.__compatible_ops__.get(PinMemoryBuilder.NAME, True):
+    pytest.skip('Skip tests since pin_memory is not compatible', allow_module_level=True)
+
+NUM_ELEMS = 4096
+
+
+def test_pin_handle_alloc_free_and_is_pinned():
+    # pin_memory must work without libaio / async_io.
+    handle = PinMemoryBuilder().load().pin_handle()
+    buffer = handle.new_cpu_locked_tensor(NUM_ELEMS, torch.empty(0, dtype=torch.float))
+    try:
+        assert handle.is_pinned(buffer)
+        assert handle.is_pinned(buffer.narrow(0, 16, 16))
+        assert not handle.is_pinned(torch.empty(NUM_ELEMS, dtype=torch.float))
+    finally:
+        assert handle.free_cpu_locked_tensor(buffer) is True


### PR DESCRIPTION
## Summary
- Extract host page-locking (`posix_memalign`/`mlock`) into a standalone `deepspeed.ops.pin_memory` / `PinMemoryBuilder` that does not require libaio or AIO worker threads.
- Compile the pin manager only in the `pin_memory` op and share one process-wide manager with `async_io`/`gds` (via exported symbol + `RTLD_GLOBAL`) so DeepNVMe bounce-buffer skipping and `is_pinned` stay consistent.
- Keep `new_cpu_locked_tensor` / `free_cpu_locked_tensor` / `is_pinned` on `aio_handle`/`gds_handle` as thin wrappers; point XPU `align_bytes=0` at `pin_handle`.

## Test plan
- [x] `tests/unit/v1/pin_memory/test_pin_memory_op.py` (pin without async_io)
- [x] `tests/unit/v1/nvme/test_pinned_manager.py` cross-op recognition (`pin_handle` ↔ `aio_handle`)
- [x] Confirm AIO I/O tests still pass with shared manager (`tests/unit/v1/nvme/` including `test_aio.py` / `test_gds.py` — 131 passed on `tunji-h200-n1g2-ds2-0`, job `20260809T123310Z`, HEAD `a6f6ab6e`)
- [x] `ds_report` shows `pin_memory` as compatible without libaio-dev (`pin_memory ... [OKAY]`; with `io_submit`/libaio mocked missing, `pin_memory` stays compatible while `async_io` does not — job `20260809T124859Z`)

## Follow-up
Native backend (`DS_PIN_MEMORY_BACKEND=native`, #8211) will be stacked on this PR once it lands.


Made with [Cursor](https://cursor.com)
