### PR TITLE
[DeepCompile] Fix staticmethod handling on Python 3.9

### DIFF
--- a/deepspeed/compile/patch_compiled_func.py
+++ b/deepspeed/compile/patch_compiled_func.py
@@ -15,13 +15,20 @@ enabled_patched_func = False
 original_grad_fn = None
 base_meta = type(torch.autograd.Function)
 
+
+def _unwrap_staticmethod(method):
+    if isinstance(method, staticmethod):
+        return method.__func__
+    return method
+
+
 if required_torch_version(min_version=2.7):
 
     class FunctionMeta(base_meta):
 
         def __new__(cls, name, bases, dct):
             if name == "CompiledFunction":
-                original_backward_impl = dct.get("_backward_impl")
+                original_backward_impl = _unwrap_staticmethod(dct.get("_backward_impl"))
                 frame_key = backward_frame_keys.popleft() if backward_frame_keys else None
 
                 def wrapped_backward_impl(ctx, all_args):
@@ -48,7 +55,7 @@ elif required_torch_version(min_version=2.6):
 
         def __new__(cls, name, bases, dct):
             if name == "CompiledFunction":
-                original_backward_prologue = dct.get("_backward_prologue")
+                original_backward_prologue = _unwrap_staticmethod(dct.get("_backward_prologue"))
                 frame_key = backward_frame_keys.popleft() if backward_frame_keys else None
 
                 def wrapped_backward_prologue(ctx, *grad_outputs):

--- a/tests/unit/compile/test_backend.py
+++ b/tests/unit/compile/test_backend.py
@@ -13,6 +13,7 @@ from deepspeed.compile.inductor import patch_create_aot_dispatcher_function
 from deepspeed.compile.input_storage import InputStorage
 from deepspeed.compile.patch_compiled_func import (clear_backward_inputs, get_backward_inputs, patch_compiled_func,
                                                    unpatch_compiled_func)
+from deepspeed.utils.torch import required_torch_version
 
 
 def test_forward_real_inputs_are_graph_local():
@@ -75,6 +76,39 @@ def test_unpatch_compiled_func_clears_backward_inputs():
         get_backward_inputs()[(object(), 17)] = [(torch.ones(1), )]
         unpatch_compiled_func()
         assert get_backward_inputs() == {}
+    finally:
+        unpatch_compiled_func()
+
+
+def test_patch_compiled_func_unwraps_staticmethod_descriptor():
+
+    class NonCallableStaticMethod(staticmethod):
+        # Staticmethod descriptors became callable in Python 3.10, so emulate Python 3.9 on newer interpreters.
+        def __call__(self, *args, **kwargs):
+            raise TypeError("staticmethod object is not callable")
+
+    clear_backward_inputs()
+    patch_compiled_func()
+    try:
+
+        class CompiledFunction(torch.autograd.Function):
+
+            @NonCallableStaticMethod
+            def _backward_impl(ctx, all_args):
+                return all_args
+
+            @NonCallableStaticMethod
+            def _backward_prologue(ctx, *grad_outputs):
+                return grad_outputs
+
+        inputs = (torch.ones(1), )
+        if required_torch_version(min_version=2.7):
+            result = CompiledFunction._backward_impl(None, inputs)
+        else:
+            result = CompiledFunction._backward_prologue(None, *inputs)
+
+        assert len(result) == 1
+        assert result[0] is inputs[0]
     finally:
         unpatch_compiled_func()
 


### PR DESCRIPTION
  ## Description

  DeepCompile retrieves PyTorch's compiled backward hooks directly from the class namespace. On Python 3.9, this returns a `staticmethod` descriptor that cannot be
  called directly, resulting in:

  ```text
  TypeError: 'staticmethod' object is not callable
  ```

  This change unwraps the underlying function before DeepSpeed invokes it.

  The fix covers both supported implementations:

  - PyTorch 2.6: `_backward_prologue`
  - PyTorch 2.7+: `_backward_impl`

  A regression test emulates Python 3.9's non-callable `staticmethod` behavior so the failure remains covered when CI runs on newer Python versions.

  ## Testing

  - `pytest -q tests/unit/compile/test_backend.py tests/unit/compile/test_zero3_grad_dtype.py`
  - `pre-commit run --files deepspeed/compile/patch_compiled_func.py tests/unit/compile/test_backend.py`

  Fixes #7433

