### PR TITLE
Fix shared loss gradient accumulation

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -19,6 +19,9 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 from contextlib import contextmanager
+from contextvars import ContextVar
+from threading import Lock
+from weakref import ref
 
 from typing import Callable, Dict, Union, Iterable, Container, List
 
@@ -247,6 +250,85 @@ def _checkpoint_parallel_metadata(mpu):
             CHECKPOINT_TP_DEGREE: bwc_tensor_model_parallel_world_size(mpu),
         }
     }
+
+
+class _EngineBackwardGraphState:
+
+    def __init__(self):
+        self.active = False
+        self.graph_task_ids = []
+
+
+_ENGINE_BACKWARD_GRAPH_CONTEXT = ContextVar("deepspeed_engine_backward_graph_context", default=())
+
+
+class _EngineBackwardGraphTracker:
+
+    def __init__(self):
+        self._lock = Lock()
+        self._graph_task_refcounts = {}
+        self._active_states = set()
+
+    @staticmethod
+    def supported():
+        return hasattr(torch._C, "_current_graph_task_id")
+
+    def new_state(self):
+        return _EngineBackwardGraphState()
+
+    @staticmethod
+    def _clear_current_context(state):
+        context = _ENGINE_BACKWARD_GRAPH_CONTEXT.get()
+        _ENGINE_BACKWARD_GRAPH_CONTEXT.set(
+            tuple(state_ref for state_ref in context if state_ref() is not None and state_ref() is not state))
+
+    def register_current_graph(self, grad, state):
+        graph_task_id = torch._C._current_graph_task_id() if self.supported() else -1
+        with self._lock:
+            if not state.active:
+                state.active = True
+                self._active_states.add(state)
+            if graph_task_id != -1 and graph_task_id not in state.graph_task_ids:
+                self._graph_task_refcounts[graph_task_id] = self._graph_task_refcounts.get(graph_task_id, 0) + 1
+                state.graph_task_ids.append(graph_task_id)
+
+        context = _ENGINE_BACKWARD_GRAPH_CONTEXT.get()
+        with self._lock:
+            context = tuple(state_ref for state_ref in context if state_ref() in self._active_states)
+        _ENGINE_BACKWARD_GRAPH_CONTEXT.set((*context, ref(state)))
+        torch.autograd.Variable._execution_engine.queue_callback(lambda: self._clear_current_context(state))
+        return grad
+
+    def unregister(self, state):
+        with self._lock:
+            if not state.active:
+                return
+            for graph_task_id in state.graph_task_ids:
+                refcount = self._graph_task_refcounts[graph_task_id] - 1
+                if refcount:
+                    self._graph_task_refcounts[graph_task_id] = refcount
+                else:
+                    del self._graph_task_refcounts[graph_task_id]
+            state.active = False
+            self._active_states.remove(state)
+
+    def is_current_graph_registered(self):
+        graph_task_id = torch._C._current_graph_task_id() if self.supported() else -1
+        context = _ENGINE_BACKWARD_GRAPH_CONTEXT.get()
+        with self._lock:
+            if graph_task_id in self._graph_task_refcounts:
+                return True
+            active_context = tuple(state_ref for state_ref in context if state_ref() in self._active_states)
+        if active_context != context:
+            _ENGINE_BACKWARD_GRAPH_CONTEXT.set(active_context)
+        return bool(active_context)
+
+    def active_registration_count(self):
+        with self._lock:
+            return len(self._active_states)
+
+
+_ENGINE_BACKWARD_GRAPH_TRACKER = _EngineBackwardGraphTracker()
 
 
 class DeepSpeedEngine(Module):
@@ -505,11 +587,11 @@ class DeepSpeedEngine(Module):
         # Otherwise, we fallback to DeepSpeed style backward only.
         # See `count_used_parameters_in_backward` for more details.
         self._running_engine_backward = False
+        self._running_engine_backward_count = 0
+        self._running_engine_backward_lock = Lock()
         # True only while step() runs; the unmanaged-mode accumulation boundary.
         self._running_engine_step = False
         self._support_torch_style_backward = False
-        # Flag to control whether gradients should be scaled by gradient accumulation steps
-        self._scale_wrt_gas = True
         if isinstance(self.optimizer, ZeROOptimizer) and check_internal_apis_for_count_used_parameters():
             self._support_torch_style_backward = True
             # These hooks are used for non-scalar backward support, such as `out.backward(out_grad)`,
@@ -3003,8 +3085,10 @@ class DeepSpeedEngine(Module):
     def _backward_prologue_per_tensor(self, grad):
         if is_functorch_transforming():
             return grad
-        # Only scale gradients if scale_wrt_gas is True, consistent with backward() parameter
-        if grad is not None and self._scale_wrt_gas:
+        graph_loss_scaled = _ENGINE_BACKWARD_GRAPH_TRACKER.is_current_graph_registered()
+        if graph_loss_scaled:
+            return grad
+        if grad is not None:
             return grad / self.gradient_accumulation_steps()
         return grad
 
@@ -3012,6 +3096,11 @@ class DeepSpeedEngine(Module):
         if is_functorch_transforming():
             return
         if not self._running_engine_backward:
+            # An interrupted engine.backward() leaves the ZeRO backward depth active. The next
+            # direct backward must not run an epilogue over that incomplete reduction state.
+            if isinstance(self.optimizer, ZeROOptimizer) and self.optimizer._backward_active_depth > 1:
+                return
+
             # Check if loss scaling was required but not applied
             needs_scaler = False
             if isinstance(self.optimizer, ZeROOptimizer):
@@ -3227,45 +3316,57 @@ class DeepSpeedEngine(Module):
         assert maybe_loss_for_backward(
             loss), "loss must be a scalar tensor. If you need to pass output gradients, backward() of output tensors"
 
-        self._running_engine_backward = True
-        # Store scale_wrt_gas so the hook can respect it
-        self._scale_wrt_gas = scale_wrt_gas
+        with self._running_engine_backward_lock:
+            self._running_engine_backward_count += 1
+            self._running_engine_backward = True
+        engine_backward_graph_state = _ENGINE_BACKWARD_GRAPH_TRACKER.new_state()
+        engine_backward_graph_hook = None
+        try:
+            # Unmanaged mode: count this backward so step() can advance global_samples by the actual micro-batch count.
+            if not self.managed_gradient_accumulation():
+                self._unmanaged_backward_count += 1
 
-        # Unmanaged mode: count this backward so step() can advance global_samples by the actual micro-batch count.
-        if not self.managed_gradient_accumulation():
-            self._unmanaged_backward_count += 1
+            # Set flag to prevent hooks from firing (we'll manually call prologue/epilogue)
+            backward_kwargs = {"retain_graph": retain_graph}
+            if self.eigenvalue_enabled():
+                backward_kwargs["create_graph"] = True
+                backward_kwargs["retain_graph"] = True
 
-        # Set flag to prevent hooks from firing (we'll manually call prologue/epilogue)
-        backward_kwargs = {"retain_graph": retain_graph}
-        if self.eigenvalue_enabled():
-            backward_kwargs["create_graph"] = True
-            backward_kwargs["retain_graph"] = True
+            loss = loss / self.gradient_accumulation_steps() if scale_wrt_gas else loss
+            gas_scaled_loss = loss
 
-        # Used only for return value
-        gas_scaled_loss = loss / self.gradient_accumulation_steps() if scale_wrt_gas else loss
+            # TODO: handle these scaling with direct calls to loss.backward()
+            if isinstance(self.optimizer, ZeROOptimizer):
+                loss = self.optimizer.scale_if_loss(loss)
+            elif self.torch_autocast_z0_gradscaler:
+                loss = self.torch_autocast_z0_gradscaler.scale(loss)
 
-        # TODO: handle these scaling with direct calls to loss.backward()
-        if isinstance(self.optimizer, ZeROOptimizer):
-            loss = self.optimizer.scale_if_loss(loss)
-        elif self.torch_autocast_z0_gradscaler:
-            loss = self.torch_autocast_z0_gradscaler.scale(loss)
+            if loss.requires_grad:
+                engine_backward_graph_hook = loss.register_hook(
+                    lambda grad: _ENGINE_BACKWARD_GRAPH_TRACKER.register_current_graph(
+                        grad, engine_backward_graph_state))
 
-        with compiled_autograd(self._is_compiled_autograd_enabled, self._compile_kwargs):
-            if self.zero_optimization() or not self.amp_enabled():
-                loss.backward(**backward_kwargs)
-            elif self.amp_enabled():
-                # AMP requires delaying unscale when inside gradient accumulation boundaries
-                # https://nvidia.github.io/apex/advanced.html#gradient-accumulation-across-iterations
-                delay_unscale = not self.is_gradient_accumulation_boundary()
-                with amp.scale_loss(loss, self.optimizer, delay_unscale=delay_unscale) as scaled_loss:
-                    scaled_loss.backward(**backward_kwargs)
+            with compiled_autograd(self._is_compiled_autograd_enabled, self._compile_kwargs):
+                if self.zero_optimization() or not self.amp_enabled():
+                    loss.backward(**backward_kwargs)
+                elif self.amp_enabled():
+                    # AMP requires delaying unscale when inside gradient accumulation boundaries
+                    # https://nvidia.github.io/apex/advanced.html#gradient-accumulation-across-iterations
+                    delay_unscale = not self.is_gradient_accumulation_boundary()
+                    with amp.scale_loss(loss, self.optimizer, delay_unscale=delay_unscale) as scaled_loss:
+                        scaled_loss.backward(**backward_kwargs)
 
-            # backward_epilogue is not called in a hook when self._support_torch_style_backward is False
-            self._backward_epilogue()
+                # backward_epilogue is not called in a hook when self._support_torch_style_backward is False
+                self._backward_epilogue()
 
-        self._running_engine_backward = False
-
-        return gas_scaled_loss
+            return gas_scaled_loss
+        finally:
+            if engine_backward_graph_hook is not None:
+                engine_backward_graph_hook.remove()
+            _ENGINE_BACKWARD_GRAPH_TRACKER.unregister(engine_backward_graph_state)
+            with self._running_engine_backward_lock:
+                self._running_engine_backward_count -= 1
+                self._running_engine_backward = self._running_engine_backward_count > 0
 
     def is_gradient_accumulation_boundary(self):
         """

--- a/tests/unit/runtime/zero/test_zero_shared_loss_gradient.py
+++ b/tests/unit/runtime/zero/test_zero_shared_loss_gradient.py
@@ -1,0 +1,227 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+import torch
+from torch.utils.checkpoint import checkpoint
+
+import deepspeed
+import deepspeed.comm as dist
+from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.engine import _ENGINE_BACKWARD_GRAPH_TRACKER
+from deepspeed.utils import safe_get_full_grad
+from unit.common import DistributedTest
+from unit.util import bf16_required_version_check
+
+
+class SharedLinear(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.shared = torch.nn.Linear(4, 4, bias=False)
+
+    def forward(self, inputs):
+        return self.shared(inputs)
+
+
+class _RaiseInBackward(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, inputs):
+        return inputs.clone()
+
+    @staticmethod
+    def backward(ctx, grad):
+        raise RuntimeError("intentional backward failure")
+
+
+class FailingSharedLinear(SharedLinear):
+
+    def forward(self, inputs):
+        return _RaiseInBackward.apply(super().forward(inputs))
+
+
+def _make_model(device, model_class=SharedLinear):
+    model = model_class().to(device=device, dtype=torch.bfloat16)
+    with torch.no_grad():
+        values = torch.arange(16, device=device, dtype=torch.float32).reshape(4, 4) / 16
+        model.shared.weight.copy_(values.to(torch.bfloat16))
+    return model
+
+
+def _inputs(device, rank, micro_step):
+    values = torch.arange(8, device=device, dtype=torch.float32).reshape(2, 4)
+    return (values + rank * 3 + micro_step).to(torch.bfloat16)
+
+
+def _make_engine(model, gradient_accumulation_steps):
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    config = {
+        "train_micro_batch_size_per_gpu": 2,
+        "gradient_accumulation_steps": gradient_accumulation_steps,
+        "bf16": {
+            "enabled": True,
+        },
+        "zero_allow_untested_optimizer": True,
+        "zero_optimization": {
+            "stage": 2,
+            "overlap_comm": True,
+            "contiguous_gradients": True,
+            "reduce_scatter": True,
+        },
+    }
+    engine, *_ = deepspeed.initialize(model=model, optimizer=optimizer, config=config)
+    return engine
+
+
+def _reference_grad(model, inputs):
+    model.zero_grad(set_to_none=True)
+    model(inputs).float().square().mean().backward()
+    grad = model.shared.weight.grad.detach().clone()
+    dist.all_reduce(grad)
+    grad.div_(dist.get_world_size())
+    return grad.float()
+
+
+def _advance_to_accumulation_boundary(engine, inputs, gradient_accumulation_steps):
+    for _ in range(gradient_accumulation_steps - 1):
+        engine.backward(engine(inputs).float().sum() * 0)
+        engine.step()
+
+
+class TestZero2SharedLossGradient(DistributedTest):
+    world_size = 2
+
+    def test_engine_and_module_branches_match_manual_reference(self):
+        if not bf16_required_version_check():
+            pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
+
+        gradient_accumulation_steps = 8
+        device = get_accelerator().current_device_name()
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+
+        reference_model = _make_model(device)
+        reference_grad = torch.zeros_like(reference_model.shared.weight, dtype=torch.float32)
+        for micro_step in range(gradient_accumulation_steps):
+            reference_model.zero_grad(set_to_none=True)
+            inputs = _inputs(device, rank, micro_step)
+            secondary_inputs = inputs * 0.5
+            output = reference_model(inputs) + reference_model(secondary_inputs)
+            loss = output.float().square().mean() / gradient_accumulation_steps
+            loss.backward()
+
+            microbatch_grad = reference_model.shared.weight.grad.detach().clone()
+            dist.all_reduce(microbatch_grad)
+            microbatch_grad.div_(world_size)
+            reference_grad.add_(microbatch_grad.float())
+
+        engine = _make_engine(_make_model(device), gradient_accumulation_steps)
+        try:
+            for micro_step in range(gradient_accumulation_steps):
+                inputs = _inputs(device, rank, micro_step)
+                secondary_inputs = inputs * 0.5
+                output = engine(inputs) + engine.module(secondary_inputs)
+                engine.backward(output.float().square().mean())
+                if micro_step + 1 < gradient_accumulation_steps:
+                    engine.step()
+
+            actual_grad = safe_get_full_grad(engine.module.shared.weight)
+            assert actual_grad is not None
+            torch.testing.assert_close(actual_grad.float(), reference_grad, rtol=5e-3, atol=2.0)
+        finally:
+            engine.destroy()
+
+    @pytest.mark.parametrize("graph_task_ids_available", [True, False], ids=["graph-task-id", "fallback"])
+    def test_two_engine_managed_backward_scales_each_branch_once(self, monkeypatch, graph_task_ids_available):
+        if not bf16_required_version_check():
+            pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
+
+        gradient_accumulation_steps = 8
+        device = get_accelerator().current_device_name()
+        rank = dist.get_rank()
+        inputs = [_inputs(device, rank, micro_step) for micro_step in range(2)]
+        reference_grads = [_reference_grad(_make_model(device), value) for value in inputs]
+        engines = [_make_engine(_make_model(device), gradient_accumulation_steps) for _ in range(2)]
+        try:
+            monkeypatch.setattr(type(_ENGINE_BACKWARD_GRAPH_TRACKER), "supported",
+                                staticmethod(lambda: graph_task_ids_available))
+            for engine, value in zip(engines, inputs):
+                _advance_to_accumulation_boundary(engine, value, gradient_accumulation_steps)
+            losses = [engine(value).float().square().mean() for engine, value in zip(engines, inputs)]
+            engines[0].backward(sum(losses))
+
+            for index, (engine, reference_grad) in enumerate(zip(engines, reference_grads)):
+                actual_grad = safe_get_full_grad(engine.module.shared.weight)
+                assert actual_grad is not None
+                torch.testing.assert_close(actual_grad.float(),
+                                           reference_grad / gradient_accumulation_steps,
+                                           rtol=5e-3,
+                                           atol=2.0,
+                                           msg=f"engine {index} gradient was not scaled exactly once")
+        finally:
+            for engine in engines:
+                engine.destroy()
+
+    def test_reentrant_checkpointed_engine_branches_are_scaled_once(self):
+        if not bf16_required_version_check():
+            pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
+
+        gradient_accumulation_steps = 8
+        device = get_accelerator().current_device_name()
+        rank = dist.get_rank()
+        inputs = [_inputs(device, rank, micro_step) for micro_step in range(2)]
+        reference_grads = [_reference_grad(_make_model(device), value) for value in inputs]
+        engines = [_make_engine(_make_model(device), gradient_accumulation_steps) for _ in range(2)]
+        try:
+            for engine, value in zip(engines, inputs):
+                _advance_to_accumulation_boundary(engine, value, gradient_accumulation_steps)
+            losses = [
+                checkpoint(engine, value.detach().requires_grad_(True), use_reentrant=True).float().square().mean()
+                for engine, value in zip(engines, inputs)
+            ]
+            engines[0].backward(sum(losses))
+
+            for index, (engine, reference_grad) in enumerate(zip(engines, reference_grads)):
+                actual_grad = safe_get_full_grad(engine.module.shared.weight)
+                assert actual_grad is not None
+                torch.testing.assert_close(actual_grad.float(),
+                                           reference_grad / gradient_accumulation_steps,
+                                           rtol=5e-3,
+                                           atol=2.0,
+                                           msg=f"reentrant engine {index} gradient was not scaled exactly once")
+        finally:
+            for engine in engines:
+                engine.destroy()
+
+    def test_managed_backward_context_restored_after_exception(self):
+        if not bf16_required_version_check():
+            pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
+
+        gradient_accumulation_steps = 8
+        device = get_accelerator().current_device_name()
+        rank = dist.get_rank()
+        inputs = _inputs(device, rank, 0)
+        reference_grad = _reference_grad(_make_model(device), inputs)
+        failing_engine = _make_engine(_make_model(device, FailingSharedLinear), gradient_accumulation_steps)
+        direct_backward_engine = _make_engine(_make_model(device), gradient_accumulation_steps)
+        try:
+            _advance_to_accumulation_boundary(direct_backward_engine, inputs, gradient_accumulation_steps)
+            failing_loss = failing_engine(inputs).float().square().mean()
+            with pytest.raises(RuntimeError, match="intentional backward failure"):
+                failing_engine.backward(failing_loss)
+            assert failing_engine._running_engine_backward is False
+            assert _ENGINE_BACKWARD_GRAPH_TRACKER.active_registration_count() == 0
+
+            direct_backward_engine(inputs).float().square().mean().backward()
+            actual_grad = safe_get_full_grad(direct_backward_engine.module.shared.weight)
+            assert actual_grad is not None
+            torch.testing.assert_close(actual_grad.float(),
+                                       reference_grad / gradient_accumulation_steps,
+                                       rtol=5e-3,
+                                       atol=2.0)
+        finally:
+            failing_engine.destroy()
+            direct_backward_engine.destroy()


### PR DESCRIPTION
## Problem

Fixes #8224.

With gradient accumulation enabled, a loss can combine a forward pass through the DeepSpeed engine with a forward pass through the model inside the engine. The engine-output hook divides only the gradient from the engine forward by the accumulation count. The gradient from the forward pass on the model inside the engine remains unscaled, producing an incorrect gradient for that parameter.

## Approach

Apply gradient-accumulation scaling to the complete loss passed through managed `engine.backward`. During that call, mark the loss graph as already scaled so engine-output hooks do not apply the scaling again, and restore all managed-backward state on every exit.

If a managed backward is interrupted, preserve the existing ZeRO retry behavior by not running a direct-backward epilogue over incomplete reduction state. Direct tensor backward, pipeline output hooks, and `scale_wrt_gas=False` otherwise retain their existing behavior.

## Testing

- `pytest -q tests/unit/runtime/zero/test_zero_shared_loss_gradient.py`
- Verified the existing ZeRO-3 exception-retry lifecycle behavior.
