### PR TITLE
Fix repeated FlopsProfiler metric accumulation

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -1013,14 +1013,17 @@ def _reload_functionals():
     F.interpolate = old_functions[F.interpolate.__str__]
     F.softmax = old_functions[F.softmax.__str__]
     F.embedding = old_functions[F.embedding.__str__]
+    if required_torch_version(min_version=2.0):
+        F.scaled_dot_product_attention = old_functions[F.scaled_dot_product_attention.__str__]
 
 
 def _reload_tensor_methods():
     torch.matmul = old_functions[torch.matmul.__str__]
     torch.Tensor.matmul = old_functions[torch.Tensor.matmul.__str__]
+    torch.Tensor.__matmul__ = old_functions[torch.Tensor.__matmul__.__str__]
     torch.mm = old_functions[torch.mm.__str__]
     torch.Tensor.mm = old_functions[torch.Tensor.mm.__str__]
-    torch.bmm = old_functions[torch.matmul.__str__]
+    torch.bmm = old_functions[torch.bmm.__str__]
     torch.Tensor.bmm = old_functions[torch.Tensor.bmm.__str__]
     torch.addmm = old_functions[torch.addmm.__str__]
     torch.Tensor.addmm = old_functions[torch.Tensor.addmm.__str__]

--- a/tests/unit/profiling/flops_profiler/test_flops_profiler.py
+++ b/tests/unit/profiling/flops_profiler/test_flops_profiler.py
@@ -14,9 +14,6 @@ from unit.common import DistributedTest
 from deepspeed.utils.torch import required_torch_version
 from deepspeed.accelerator import get_accelerator
 
-if torch.half not in get_accelerator().supported_dtypes():
-    pytest.skip(f"fp16 not supported, valid dtype: {get_accelerator().supported_dtypes()}", allow_module_level=True)
-
 pytestmark = pytest.mark.skipif(not required_torch_version(min_version=1.3),
                                 reason='requires Pytorch version 1.3 or above')
 
@@ -26,6 +23,34 @@ def within_range(val, target, tolerance):
 
 
 TOLERANCE = 0.05
+
+
+@pytest.mark.sequential
+@pytest.mark.skipif(not required_torch_version(min_version=2.0), reason="requires Pytorch version 2.0 or above")
+def test_repeated_profile_restores_operations():
+
+    class AttentionModel(torch.nn.Module):
+
+        def forward(self, query, key, value):
+            return torch.nn.functional.scaled_dot_product_attention(query, key, value)
+
+    model = AttentionModel()
+    inputs = [torch.randn(2, 4, 16, 8) for _ in range(3)]
+    prof = FlopsProfiler(model)
+    original_operations = (torch.nn.functional.scaled_dot_product_attention, torch.Tensor.__matmul__, torch.bmm)
+
+    profiles = []
+    for _ in range(3):
+        prof.start_profile()
+        model(*inputs)
+        prof.stop_profile()
+        profiles.append((prof.get_total_flops(), prof.get_total_macs()))
+        prof.end_profile()
+
+        restored_operations = (torch.nn.functional.scaled_dot_product_attention, torch.Tensor.__matmul__, torch.bmm)
+        assert restored_operations == original_operations
+
+    assert profiles == [(65536, 32768)] * 3
 
 
 class LeNet5(torch.nn.Module):
@@ -62,6 +87,9 @@ class TestFlopsProfiler(DistributedTest):
     world_size = 1
 
     def test(self):
+        if torch.half not in get_accelerator().supported_dtypes():
+            pytest.skip(f"fp16 not supported, valid dtype: {get_accelerator().supported_dtypes()}")
+
         config_dict = {
             "train_batch_size": 1,
             "steps_per_print": 1,


### PR DESCRIPTION
  ## Summary

  - restore `F.scaled_dot_product_attention` after profiling
  - restore `Tensor.__matmul__` after profiling
  - restore `torch.bmm` from its correct saved implementation
  - add a CPU regression test covering repeated profiling sessions and operation restoration
  - scope the existing FP16 skip to the test that actually requires FP16

  ## Problem

  `FlopsProfiler` temporarily replaces PyTorch operations with FLOP-counting wrappers. Its cleanup path did not restore `F.scaled_dot_product_attention` or
  `Tensor.__matmul__`, causing wrappers to accumulate across profiling sessions. As a result, identical model executions reported progressively increasing FLOPs and
  MACs.

  The `torch.bmm` cleanup was also incorrect:

  ```python
  torch.bmm = old_functions[torch.matmul.__str__]
 ```
  Because torch.matmul had already been restored, this rebound torch.bmm to torch.matmul for the rest of the process. This changed normal PyTorch behavior after
  profiling: torch.bmm began accepting inputs supported by broadcasting matmul but invalid for bmm.

  ## Fix

  Restore every patched operation from its matching saved original function. The patch and cleanup paths now cover the same set of operations with matching PyTorch
  version guards.

  ## Testing

  A CPU regression test profiles the same scaled-dot-product-attention operation three times and verifies:

  - every session reports identical FLOP and MAC totals
  - F.scaled_dot_product_attention, Tensor.__matmul__, and torch.bmm are restored to their original function objects after every session

  Observed totals:

  Before:
  [(65536, 32768), (131072, 65536), (196608, 98304)]

  After:
  [(65536, 32768), (65536, 32768), (65536, 32768)]

  All pre-commit checks pass.

  Fixes #7413