### PR TITLE
Upgrade pip in Python install-smoke jobs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -79,6 +79,7 @@ jobs:
         - name: Install PyTorch (CPU)
           if: needs.check-paths.outputs.should_run == 'true'
           run: |
+            python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
         - name: Install deepspeed
           if: needs.check-paths.outputs.should_run == 'true'


### PR DESCRIPTION
## Problem

The Python install-smoke matrix inherits different pip releases from its Python 3.10, 3.11, and 3.12 container images. The Python 3.10 image can start with pip 23.0.1, whose [PEP 658 name-normalization bug rejects valid dependency metadata](https://github.com/deepspeedai/DeepSpeed/actions/runs/31651849867/job/94299944361?pr=8204) before DeepSpeed installation, while the later Python images use unaffected pip releases.

## Approach

Upgrade pip in the shared matrix path immediately before PyTorch installation. Keeping the upgrade common to all three Python versions avoids image-specific pins and makes every cell select the current compatible pip release during the run.