### PR TITLE
Fix DeepCompile last use for unconsumed waits

### DIFF
--- a/deepspeed/compile/util.py
+++ b/deepspeed/compile/util.py
@@ -262,7 +262,7 @@ def get_last_uses(graph: Graph):
         known_last_use = None
 
         if user.target in no_copy_ops and n in node_to_last_use:
-            last_user = node_to_last_use[user]
+            last_user = node_to_last_use.get(user, user)
             last_use_position = position[last_user]
 
             known_last_use = node_to_last_use[n]
@@ -271,7 +271,7 @@ def get_last_uses(graph: Graph):
 
         if n not in node_to_last_use or update:
             if user.target in no_copy_ops:
-                user = node_to_last_use[user]
+                user = node_to_last_use.get(user, user)
 
             node_to_last_use[n] = user
             user_to_last_uses.setdefault(user, []).append(n)

--- a/tests/unit/compile/test_list_schedule.py
+++ b/tests/unit/compile/test_list_schedule.py
@@ -133,6 +133,27 @@ def _scheduled_names(graph):
     return [node.name for node in schedule_mod.fast_free_schedule(graph, 0, 0, debug_log=True).nodes]
 
 
+@pytest.mark.parametrize("case", ["only_consumer", "later_real_use"])
+def test_get_last_uses_unconsumed_no_copy_wait(case):
+    graph = Graph()
+    param = _placeholder(graph, f"{case}_param")
+    allgather = _allgather(graph, param, 1, case)
+    wait = _wait(graph, allgather, 1, case)
+
+    later_use = _neg(graph, allgather, f"{case}_later_use") if case == "later_real_use" else None
+    graph.output((later_use, ) if later_use is not None else ())
+    graph.lint()
+
+    node_to_last_use, user_to_last_uses = compile_util.get_last_uses(graph)
+    node_to_uses = compile_util.get_real_uses(graph)
+
+    expected_last_use = later_use if later_use is not None else wait
+    assert node_to_last_use[allgather] is expected_last_use
+    assert user_to_last_uses[expected_last_use] == [allgather]
+    assert user_to_last_uses.get(wait, []) == ([] if later_use is not None else [allgather])
+    assert node_to_uses[allgather] == ([] if later_use is None else [later_use])
+
+
 def test_fast_free_schedule_keeps_zero_free_acc_filter():
     graph = Graph()
 


### PR DESCRIPTION
With this PR, DeepCompile treats an unconsumed `wait_allgather` alias as its own last use to prevent `KeyError`, while preserving downstream propagation for consumed aliases.
Add synthetic FX regression coverage for both orphan-only and later-real-use cases.