### PR TITLE
Route ZeRO/SuperOffload pin sites through accelerator pin_memory

### DIFF
--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -268,6 +268,9 @@ class DeepSpeedAccelerator(ABC):
     def _torch_pin_memory(self, tensor):
         return tensor.pin_memory()
 
+    def _torch_empty_pinned(self, tensor, shape):
+        return tensor.new_empty(shape, pin_memory=True)
+
     def _torch_is_pinned(self, tensor):
         return tensor.is_pinned()
 
@@ -278,7 +281,12 @@ class DeepSpeedAccelerator(ABC):
         pins = get_active_native_pinned_memory()
         if pins is not None:
             return pins.pin(tensor, make_copy=make_copy, match_shape=match_shape)
-        return self._torch_pin_memory(tensor)
+        if make_copy:
+            return self._torch_pin_memory(tensor)
+        # ``tensor`` is only a shape/dtype template here, so page-lock a fresh
+        # buffer instead of faulting it in and copying it into a second one.
+        shape = tensor.shape if match_shape else (tensor.numel(), )
+        return self._torch_empty_pinned(tensor, shape)
 
     def is_pinned(self, tensor):
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory

--- a/accelerator/hpu_accelerator.py
+++ b/accelerator/hpu_accelerator.py
@@ -234,6 +234,11 @@ class HPU_Accelerator(DeepSpeedAccelerator):
     def _torch_pin_memory(self, tensor):
         return tensor.pin_memory(self.device())
 
+    def _torch_empty_pinned(self, tensor, shape):
+        # Pinning on HPU needs an explicit device, which the allocation API
+        # cannot express, so allocate and then pin.
+        return self._torch_pin_memory(tensor.new_empty(shape))
+
     def on_accelerator(self, tensor):
         device_str = str(tensor.device)
         if device_str.startswith('hpu:'):

--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -231,6 +231,11 @@ class XPU_Accelerator(DeepSpeedAccelerator):
     def _torch_pin_memory(self, tensor):
         return tensor.pin_memory(device=self.current_device_name())
 
+    def _torch_empty_pinned(self, tensor, shape):
+        # Pinning on XPU needs an explicit device, which the allocation API
+        # cannot express, so allocate and then pin.
+        return self._torch_pin_memory(tensor.new_empty(shape))
+
     def _torch_is_pinned(self, tensor):
         return tensor.is_pinned(device=self.current_device_name())
 

--- a/deepspeed/runtime/superoffload/superoffload_stage3.py
+++ b/deepspeed/runtime/superoffload/superoffload_stage3.py
@@ -56,7 +56,8 @@ class SuperOffloadOptimizer_Stage3(DeepSpeedZeroOptimizer_Stage3):
         cpuadam_cores_perc = kwargs.get("cpuadam_cores_perc", 0.8)
         self.superoffload_cpu_optimizer = SuperOffloadCPUOptimizer(optimizer_config=optimizer_configs,
                                                                    cpuadam_cores_perc=cpuadam_cores_perc,
-                                                                   max_grad_numel=self.max_grad_numel)
+                                                                   max_grad_numel=self.max_grad_numel,
+                                                                   pin_memory=self.offload_optimizer_pin_memory)
 
     def _create_fp16_sub_groups(self, params_group):
 

--- a/deepspeed/runtime/superoffload/superoffload_utils.py
+++ b/deepspeed/runtime/superoffload/superoffload_utils.py
@@ -13,6 +13,7 @@ import torch.multiprocessing as mp
 import psutil
 
 from deepspeed.ops.adam import DeepSpeedCPUAdam
+from deepspeed.accelerator import get_accelerator
 from deepspeed.utils import logger
 
 
@@ -82,7 +83,8 @@ def superoffload_optimizer_worker(param_queue: mp.SimpleQueue, result_queue: mp.
         return
 
     # Pre-allocate reusable pinned memory buffer for gradients
-    pinned_grad_buffer = torch.empty(max_grad_numel, dtype=torch.float32, device='cpu', pin_memory=True)
+    pinned_grad_buffer = get_accelerator().pin_memory(torch.empty(max_grad_numel, dtype=torch.float32, device='cpu'),
+                                                      make_copy=False)
 
     while True:
         try:

--- a/deepspeed/runtime/superoffload/superoffload_utils.py
+++ b/deepspeed/runtime/superoffload/superoffload_utils.py
@@ -36,8 +36,21 @@ class EventTypes:
     ROLLBACK = "rollback"
 
 
-def superoffload_optimizer_worker(param_queue: mp.SimpleQueue, result_queue: mp.SimpleQueue,
-                                  optimizer_config: Dict[str, Any], max_grad_numel: int) -> None:
+def _allocate_worker_grad_buffer(max_grad_numel: int, pin_memory: bool) -> torch.Tensor:
+    # Scratch destination for the GPU->CPU grad copy. Pinning is optional: it
+    # speeds DMA but is not required for correctness, so honor
+    # offload_optimizer.pin_memory rather than always page-locking.
+    buffer = torch.empty(max_grad_numel, dtype=torch.float32, device='cpu')
+    if pin_memory:
+        buffer = get_accelerator().pin_memory(buffer, make_copy=False)
+    return buffer
+
+
+def superoffload_optimizer_worker(param_queue: mp.SimpleQueue,
+                                  result_queue: mp.SimpleQueue,
+                                  optimizer_config: Dict[str, Any],
+                                  max_grad_numel: int,
+                                  pin_memory: bool = True) -> None:
     """
     This function runs in a separate process and continuously processes optimization
     tasks from the parameter queue. It creates a DeepSpeedCPUAdam optimizer and
@@ -49,6 +62,7 @@ def superoffload_optimizer_worker(param_queue: mp.SimpleQueue, result_queue: mp.
         optimizer_config: Configuration dictionary for the optimizer containing
                          lr, betas, eps, weight_decay, and amsgrad parameters
         max_grad_numel: Maximum number of elements expected in gradient tensors
+        pin_memory: Whether to page-lock the reusable grad scratch buffer
     """
     cpu_tensor = torch.randn(1, device="cpu")
     cpu_param = torch.nn.Parameter(cpu_tensor)
@@ -82,9 +96,8 @@ def superoffload_optimizer_worker(param_queue: mp.SimpleQueue, result_queue: mp.
         result_queue.put({"error": error_msg})
         return
 
-    # Pre-allocate reusable pinned memory buffer for gradients
-    pinned_grad_buffer = get_accelerator().pin_memory(torch.empty(max_grad_numel, dtype=torch.float32, device='cpu'),
-                                                      make_copy=False)
+    # Pre-allocate reusable host buffer for gradients
+    grad_buffer = _allocate_worker_grad_buffer(max_grad_numel, pin_memory)
 
     while True:
         try:
@@ -118,7 +131,7 @@ def superoffload_optimizer_worker(param_queue: mp.SimpleQueue, result_queue: mp.
                 result_queue.put({"error": error_msg})
                 break
 
-            param_grad_cpu = pinned_grad_buffer[:grad_numel].view_as(param_grad)
+            param_grad_cpu = grad_buffer[:grad_numel].view_as(param_grad)
             param_grad_cpu.copy_(param_grad, non_blocking=False)
 
             fp32_param = torch.nn.Parameter(param_data)
@@ -156,10 +169,13 @@ def superoffload_optimizer_worker(param_queue: mp.SimpleQueue, result_queue: mp.
             result_queue.put({"error": error_msg})
             break
 
-    # Clean up pinned memory buffer
-    if 'pinned_grad_buffer' in locals():
-        del pinned_grad_buffer
-        logger.debug("Cleaned up pinned memory buffer")
+    # Clean up the reusable host buffer. unpin_memory is a no-op on torch and
+    # frees immediately on the native backend.
+    if 'grad_buffer' in locals():
+        if pin_memory:
+            get_accelerator().unpin_memory(grad_buffer)
+        del grad_buffer
+        logger.debug("Cleaned up worker grad buffer")
 
     logger.debug("Worker process terminated")
 
@@ -169,7 +185,8 @@ class SuperOffloadCPUOptimizer:
     def __init__(self,
                  optimizer_config: Dict[str, Any],
                  cpuadam_cores_perc: float = 0.8,
-                 max_grad_numel: int = 1000000) -> None:
+                 max_grad_numel: int = 1000000,
+                 pin_memory: bool = True) -> None:
         if not 0 < cpuadam_cores_perc <= 1:
             raise ValueError("cpuadam_cores_perc must be between 0 and 1")
 
@@ -180,7 +197,7 @@ class SuperOffloadCPUOptimizer:
 
         self.cpuadam_process = self.mp_context.Process(
             target=superoffload_optimizer_worker,
-            args=(self.param_queue, self.result_queue, optimizer_config, max_grad_numel),
+            args=(self.param_queue, self.result_queue, optimizer_config, max_grad_numel, pin_memory),
             daemon=True,
         )
         self.cpuadam_process.start()

--- a/deepspeed/runtime/zero/offload_states.py
+++ b/deepspeed/runtime/zero/offload_states.py
@@ -27,10 +27,18 @@ def offload_optimizer_states(optimizer, device, pin_memory=False, non_blocking=F
 
 
 def reload_optimizer_states(optimizer, device, non_blocking=False):
+    """Move optimizer states back to ``device``.
+
+    Returns the replaced host tensors. A non-blocking copy may still be reading
+    them on return, so callers must keep them alive until they synchronize.
+    """
+    host_buffers = []
     for state in optimizer.state.values():
         for k, v in state.items():
             if torch.is_tensor(v):
+                host_buffers.append(v)
                 state[k] = v.to(device, non_blocking=non_blocking)
+    return host_buffers
 
 
 def offload_adam_states(optimizer, device, pin_memory: bool = False, non_blocking: bool = False):

--- a/deepspeed/runtime/zero/offload_states.py
+++ b/deepspeed/runtime/zero/offload_states.py
@@ -41,6 +41,21 @@ def reload_optimizer_states(optimizer, device, non_blocking=False):
     return host_buffers
 
 
+def unpin_offloaded_optimizer_states(optimizer):
+    """Release host buffers that offloading page-locked in the optimizer state.
+
+    Offload pins these regardless of the ZeRO CPU-offload config, so destroy()
+    must release them even when the optimizer itself owns no pinned memory.
+    """
+    accelerator = get_accelerator()
+    for state in optimizer.state.values():
+        for tensor in state.values():
+            if not torch.is_tensor(tensor) or tensor.device.type != 'cpu':
+                continue
+            if accelerator.is_pinned(tensor):
+                accelerator.unpin_memory(tensor)
+
+
 def offload_adam_states(optimizer, device, pin_memory: bool = False, non_blocking: bool = False):
     """Move optimizer states to device. Note that this assumes the state structure of DeepSpeed Adam."""
 

--- a/deepspeed/runtime/zero/offload_states.py
+++ b/deepspeed/runtime/zero/offload_states.py
@@ -19,7 +19,7 @@ def offload_optimizer_states(optimizer, device, pin_memory=False, non_blocking=F
         for k, v in state.items():
             if torch.is_tensor(v):
                 if pin_memory and v.device.type != 'cpu':
-                    pinned_buffer = torch.empty_like(v, device='cpu').pin_memory()
+                    pinned_buffer = get_accelerator().pin_memory(torch.empty_like(v, device='cpu'), make_copy=False)
                     pinned_buffer.copy_(v, non_blocking=non_blocking)
                     state[k] = pinned_buffer
                 else:

--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -1872,7 +1872,7 @@ class Init(InsertPostInitMethodToModuleSubClasses):
                                                            device=self.remote_device)
 
                 if self.pin_memory:
-                    secondary_partitioned_tensor = secondary_partitioned_tensor.pin_memory()
+                    secondary_partitioned_tensor = get_accelerator().pin_memory(secondary_partitioned_tensor)
                 # quantize the tensor if it's not trainable
                 if not param.requires_grad and self.quantized_nontrainable_weights:
                     secondary_partitioned_tensor, secondary_partitioned_tensor.ds_quant_scale = self.quantizer_module.quantize(

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -532,8 +532,6 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             hook.remove()
         print_rank_0("Removed grad acc hooks", force=False)
         self.ipg_buckets.clear()
-        # offload_states(non_blocking=True) can still be copying into the host
-        # buffers. Native unpin frees immediately and has no stream tracking.
         if get_accelerator().is_available():
             get_accelerator().synchronize()
         self._unpin_offload_buffers()

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -532,6 +532,10 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             hook.remove()
         print_rank_0("Removed grad acc hooks", force=False)
         self.ipg_buckets.clear()
+        # offload_states(non_blocking=True) can still be copying into the host
+        # buffers. Native unpin frees immediately and has no stream tracking.
+        if get_accelerator().is_available():
+            get_accelerator().synchronize()
         self._unpin_offload_buffers()
 
     def _unpin_offload_buffers(self):

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -29,7 +29,8 @@ from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum, OffloadStat
 from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload
 import deepspeed.runtime.zenflow.engine_stage3 as zf_engine_stage3
 from deepspeed.runtime.zero.utils import get_mapping_to_flat_buffer, defragment, get_norm_dtype
-from deepspeed.runtime.zero.offload_states import offload_adam_states, reload_adam_states
+from deepspeed.runtime.zero.offload_states import (offload_adam_states, reload_adam_states,
+                                                   unpin_offloaded_optimizer_states)
 from deepspeed.ops.adam import DeepSpeedCPUAdam
 from deepspeed.runtime.swap_tensor.partitioned_param_swapper import PartitionedParamStatus
 from deepspeed.runtime.swap_tensor.optimizer_utils import OptimizerSwapper
@@ -547,6 +548,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                 accelerator.unpin_memory(buffer)
         for buffer in getattr(self, 'hp_params_pin_buffers', []):
             accelerator.unpin_memory(buffer)
+        unpin_offloaded_optimizer_states(self.optimizer)
         if self.offload_optimizer_pin_memory:
             for fp32_partition in self.fp32_partitioned_groups_flat:
                 if fp32_partition.grad is not None:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -686,8 +686,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         for hook in self._grad_acc_hooks:
             hook.remove()
         self.print_rank_0("Removed grad acc hooks")
-        # offload_states(non_blocking=True) can still be copying into the host
-        # buffers. Native unpin frees immediately and has no stream tracking.
         if get_accelerator().is_available():
             get_accelerator().synchronize()
         self._unpin_offload_buffers()

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -686,6 +686,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         for hook in self._grad_acc_hooks:
             hook.remove()
         self.print_rank_0("Removed grad acc hooks")
+        # offload_states(non_blocking=True) can still be copying into the host
+        # buffers. Native unpin frees immediately and has no stream tracking.
+        if get_accelerator().is_available():
+            get_accelerator().synchronize()
         self._unpin_offload_buffers()
 
     def _unpin_offload_buffers(self):

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2941,7 +2941,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if pin_memory:
                 if not hasattr(self, "hp_params_pin_buffers"):
                     self.hp_params_pin_buffers = [
-                        torch.empty_like(t, device=device).pin_memory() for t in self.single_partition_of_fp32_groups
+                        get_accelerator().pin_memory(torch.empty_like(t, device=device), make_copy=False)
+                        for t in self.single_partition_of_fp32_groups
                     ]
                 for src_tensor, dest_buf in zip(self.single_partition_of_fp32_groups, self.hp_params_pin_buffers):
                     dest_buf.copy_(src_tensor, non_blocking=non_blocking)
@@ -2964,7 +2965,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if pin_memory:
                 if not hasattr(self, "lp_params_pin_buffers"):
                     self.lp_params_pin_buffers = [
-                        torch.empty_like(t, device=device).pin_memory() for t in self.bit16_groups_flat
+                        get_accelerator().pin_memory(torch.empty_like(t, device=device), make_copy=False)
+                        for t in self.bit16_groups_flat
                     ]
                 for src_tensor, dest_buf in zip(self.bit16_groups_flat, self.lp_params_pin_buffers):
                     dest_buf.copy_(src_tensor, non_blocking=non_blocking)

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -3015,12 +3015,18 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 If True, attempts to perform reload operations asynchronously. Defaults to False.
         """
         device = get_accelerator().current_device_name()
+        # Host sources of the copies queued below. The native (mlock) backend has
+        # no CUDA stream tracking and frees as soon as the last reference drops,
+        # unlike the torch pinned allocator, so hold them until after the
+        # synchronize at the end of this method.
+        pending_host_buffers = []
 
         # Reload FP32 Master Parameters (HP Params)
         if OffloadStateTypeEnum.hp_params in self.offloaded_states:
             for buf in self.single_partition_of_fp32_groups:
                 buf.data = buf.data.to(device, non_blocking=non_blocking)
             if hasattr(self, "hp_params_pin_buffers"):
+                pending_host_buffers.append(self.hp_params_pin_buffers)
                 del self.hp_params_pin_buffers
             self._link_all_hp_params()
             self.offloaded_states.remove(OffloadStateTypeEnum.hp_params)
@@ -3040,6 +3046,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self._update_model_bit16_weights(i)
 
             if hasattr(self, "lp_params_pin_buffers"):
+                pending_host_buffers.append(self.lp_params_pin_buffers)
                 del self.lp_params_pin_buffers
             self._link_all_hp_params()
             self.offloaded_states.remove(OffloadStateTypeEnum.lp_params)
@@ -3059,11 +3066,13 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
         # Reload Optimizer States
         if OffloadStateTypeEnum.optim_states in self.offloaded_states:
-            reload_optimizer_states(self.optimizer, device, non_blocking=non_blocking)
+            pending_host_buffers.append(reload_optimizer_states(self.optimizer, device, non_blocking=non_blocking))
             self.offloaded_states.remove(OffloadStateTypeEnum.optim_states)
 
         if non_blocking:
             get_accelerator().synchronize()
+        # The copies have completed, so the host sources can be released.
+        del pending_host_buffers
 
 
 def _handle_overflow(cpu_sum, x, i):

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -16,7 +16,8 @@ from deepspeed.runtime.zenflow import zenflow_utils
 import gc
 import math
 from typing import Container
-from deepspeed.runtime.zero.offload_states import offload_optimizer_states, reload_optimizer_states
+from deepspeed.runtime.zero.offload_states import (offload_optimizer_states, reload_optimizer_states,
+                                                   unpin_offloaded_optimizer_states)
 from deepspeed.runtime.base_optimizer import ZeROOptimizer
 from deepspeed.runtime.fp16.loss_scaler import CreateLossScaler
 from deepspeed.runtime.torch_autocast import get_autocast_dtype, get_all_comm_dtypes, is_autocast_initialized, sort_dtypes
@@ -691,9 +692,15 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # Release the page-locked host buffers we pinned for CPU offload. unpin_memory is a
         # no-op for the torch backend and only frees under DS_PIN_MEMORY_BACKEND=native,
         # where the mlocked allocation would otherwise persist until garbage collection.
+        accelerator = get_accelerator()
+        # offload_states(pin_memory=True) pins host buffers regardless of the ZeRO
+        # CPU-offload config, and destroy() may run while states are still offloaded.
+        for attr in ('hp_params_pin_buffers', 'lp_params_pin_buffers'):
+            for buffer in getattr(self, attr, []):
+                accelerator.unpin_memory(buffer)
+        unpin_offloaded_optimizer_states(self.optimizer)
         if not (self.cpu_offload and self.cpu_offload_pin_memory):
             return
-        accelerator = get_accelerator()
         for fp32_partition in self.single_partition_of_fp32_groups:
             accelerator.unpin_memory(fp32_partition)
             if fp32_partition.grad is not None:

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -391,6 +391,11 @@ matches ``torch.pin_memory`` as closely as possible:
   garbage collection. ZeRO / ZenFlow optimizers do this for their owned
   CPU-offload buffers in ``destroy()``.
 * After ``unpin_memory``, the tensor storage must not be used (use-after-free).
+* Unlike the torch pinned allocator, native allocations are **not** stream
+  tracked: they are freed as soon as the last reference drops, even if an
+  asynchronous copy is still reading them. Code that issues
+  ``non_blocking=True`` copies out of a native-pinned buffer must keep a
+  reference to it until it synchronizes.
 
 ``is_pinned`` reports ``True`` for both torch-pinned tensors and native-managed
 buffers, including slices/views whose storage falls inside a managed range.

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -316,8 +316,14 @@ buffer for later filling.
 Backend Selection
 =================
 
-The pinning implementation is selected with the ``DS_PIN_MEMORY_BACKEND``
-environment variable (default ``torch``).
+Whether to pin ZeRO CPU/NVMe offload buffers is controlled by
+``zero_optimization.offload_param.pin_memory`` /
+``zero_optimization.offload_optimizer.pin_memory`` (both default ``true``).
+That is independent of **how** pages are locked.
+
+The pinning **backend** (Torch vs DeepSpeed native) is selected only with the
+``DS_PIN_MEMORY_BACKEND`` environment variable (default ``torch``). There is
+no ``ds_config`` field for the backend.
 
 Both backends page-lock host memory for DMA, are visible to AIO/GDS I/O
 handles (so DeepNVMe can skip bounce buffers), and are counted by

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -311,7 +311,10 @@ APIs:
 
 ``pin_memory`` accepts ``make_copy`` and ``match_shape`` (both default ``True``) so
 callers can either allocate a shaped copy of ``tensor`` or obtain a flat locked
-buffer for later filling.
+buffer for later filling. With ``make_copy=False`` the input is only a
+shape/dtype template: both backends page-lock a fresh buffer and never read
+``tensor``, so scratch destinations do not pay for a second full-size
+allocation and a copy.
 
 Backend Selection
 =================
@@ -346,7 +349,7 @@ handles (so DeepNVMe can skip bounce buffers), and are counted by
      - None beyond the active accelerator / PyTorch
      - DeepSpeed **pin_memory** op must build and load; fails early if unavailable (no silent fallback)
    * - ``pin_memory`` extras
-     - ``make_copy`` / ``match_shape`` are ignored on this path
+     - Honors ``make_copy`` and ``match_shape`` (both default ``True``)
      - Honors ``make_copy`` and ``match_shape`` (both default ``True``)
    * - Pin recognition (``is_pinned``)
      - Torch pinned status (``tensor.is_pinned()``)

--- a/tests/unit/v1/accelerator/test_accelerator.py
+++ b/tests/unit/v1/accelerator/test_accelerator.py
@@ -13,6 +13,7 @@ import torch
 
 import deepspeed
 from deepspeed.accelerator import get_accelerator
+from deepspeed.accelerator.abstract_accelerator import DeepSpeedAccelerator
 
 DS_ACCEL_PATH = "deepspeed.accelerator"
 IGNORE_FILES = ["abstract_accelerator.py", "real_accelerator.py"]
@@ -91,6 +92,46 @@ def test_pin_memory_torch_backend(monkeypatch):
     assert accel.is_pinned(pinned) == pinned.is_pinned()
     # Unpinning a torch-pinned tensor is a no-op (freed on garbage collection).
     assert accel.unpin_memory(pinned) is None
+
+
+def test_pin_memory_torch_backend_make_copy_false_allocates_pinned(monkeypatch):
+    """make_copy=False must page-lock a new buffer instead of pinning a copy."""
+    monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)
+    calls = []
+
+    class _StubAccelerator:
+        # Exercise the shared dispatch without needing a real pinning device.
+        pin_memory = DeepSpeedAccelerator.pin_memory
+
+        def _torch_pin_memory(self, tensor):
+            calls.append(("pin_copy", tuple(tensor.shape)))
+            return tensor
+
+        def _torch_empty_pinned(self, tensor, shape):
+            calls.append(("empty_pinned", tuple(shape)))
+            return tensor.new_empty(shape)
+
+    accel = _StubAccelerator()
+    tensor = torch.randn(4, 8)
+
+    accel.pin_memory(tensor)
+    assert tuple(accel.pin_memory(tensor, make_copy=False).shape) == (4, 8)
+    assert tuple(accel.pin_memory(tensor, make_copy=False, match_shape=False).shape) == (32, )
+    assert calls == [("pin_copy", (4, 8)), ("empty_pinned", (4, 8)), ("empty_pinned", (32, ))]
+
+
+def test_pin_memory_torch_backend_no_copy_is_pinned(monkeypatch):
+    """The buffer returned for make_copy=False is really page-locked."""
+    monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)
+    accel = get_accelerator()
+    if accel.device_name() == "cpu":
+        pytest.skip("torch cannot pin CPU tensors on the CPU accelerator")
+
+    tensor = torch.randn(4, 8)
+    buffer = accel.pin_memory(tensor, make_copy=False)
+    assert buffer.is_pinned()
+    assert tuple(buffer.shape) == (4, 8)
+    assert buffer.data_ptr() != tensor.data_ptr()
 
 
 def test_pin_memory_native_backend(monkeypatch):

--- a/tests/unit/v1/pin_memory/test_destroy_unpin.py
+++ b/tests/unit/v1/pin_memory/test_destroy_unpin.py
@@ -158,8 +158,6 @@ class TestDestroyUnpinsNativeBuffers(DistributedTest):
 
     @pytest.mark.parametrize("stage", [1, 2, 3])
     def test_native_async_offload_destroy_synchronizes_before_unpin(self, stage, monkeypatch):
-        # destroy() after offload_states(non_blocking=True) must wait for the
-        # copies before native unpin frees the host sources.
         prev = os.environ.get("DS_PIN_MEMORY_BACKEND")
         try:
             native = _require_native()
@@ -198,8 +196,6 @@ class TestDestroyUnpinsNativeBuffers(DistributedTest):
             assert events and events[0] == "synchronize", f"destroy reached native unpin before completion: {events}"
             assert "unpin" in events
 
-            # DeepSpeedEngine.__del__ calls destroy() again after an explicit
-            # destroy, so the optimizer cleanup path must remain repeatable.
             events.clear()
             engine.destroy()
             assert events and events[0] == "synchronize", f"repeated destroy unpinned before sync: {events}"

--- a/tests/unit/v1/pin_memory/test_destroy_unpin.py
+++ b/tests/unit/v1/pin_memory/test_destroy_unpin.py
@@ -13,6 +13,7 @@ import os
 import pytest
 import torch
 import deepspeed
+from deepspeed.accelerator import get_accelerator
 from deepspeed.utils.pin_memory import get_active_native_pinned_memory
 
 from unit.common import DistributedTest, preferred_dtype
@@ -152,6 +153,57 @@ class TestDestroyUnpinsNativeBuffers(DistributedTest):
             engine.destroy()
             assert len(native._ranges) <= ranges_before, (f"offload_states pins not released on destroy: "
                                                           f"offloaded={ranges_offloaded} after={len(native._ranges)}")
+        finally:
+            _restore_pin_backend(prev)
+
+    @pytest.mark.parametrize("stage", [1, 2, 3])
+    def test_native_async_offload_destroy_synchronizes_before_unpin(self, stage, monkeypatch):
+        # destroy() after offload_states(non_blocking=True) must wait for the
+        # copies before native unpin frees the host sources.
+        prev = os.environ.get("DS_PIN_MEMORY_BACKEND")
+        try:
+            native = _require_native()
+            config, dtype = _config(stage, pin_memory=True, offload_optimizer=False)
+            hidden_dim = 16
+            model = SimpleModel(hidden_dim, nlayers=2)
+            engine, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+            _run_one_step(engine, hidden_dim, dtype)
+
+            accelerator = get_accelerator()
+            original_synchronize = accelerator.synchronize
+            original_unpin = accelerator.unpin_memory
+            events = []
+            safety_sync_done = False
+
+            def record_synchronize():
+                events.append("synchronize")
+                return original_synchronize()
+
+            def safely_record_unpin(tensor):
+                nonlocal safety_sync_done
+                if "synchronize" not in events and not safety_sync_done:
+                    original_synchronize()
+                    safety_sync_done = True
+                events.append("unpin")
+                return original_unpin(tensor)
+
+            monkeypatch.setattr(accelerator, "synchronize", record_synchronize)
+            monkeypatch.setattr(accelerator, "unpin_memory", safely_record_unpin)
+
+            ranges_before = len(native._ranges)
+            engine.offload_states(pin_memory=True, non_blocking=True)
+            assert len(native._ranges) > ranges_before, "expected offload_states to pin host buffers"
+            engine.destroy()
+
+            assert events and events[0] == "synchronize", f"destroy reached native unpin before completion: {events}"
+            assert "unpin" in events
+
+            # DeepSpeedEngine.__del__ calls destroy() again after an explicit
+            # destroy, so the optimizer cleanup path must remain repeatable.
+            events.clear()
+            engine.destroy()
+            assert events and events[0] == "synchronize", f"repeated destroy unpinned before sync: {events}"
+            assert "unpin" in events
         finally:
             _restore_pin_backend(prev)
 

--- a/tests/unit/v1/pin_memory/test_destroy_unpin.py
+++ b/tests/unit/v1/pin_memory/test_destroy_unpin.py
@@ -37,14 +37,13 @@ def _restore_pin_backend(prev):
         os.environ["DS_PIN_MEMORY_BACKEND"] = prev
 
 
-def _config(stage, pin_memory=True, offload_param=False):
-    zero = {
-        "stage": stage,
-        "offload_optimizer": {
+def _config(stage, pin_memory=True, offload_param=False, offload_optimizer=True):
+    zero = {"stage": stage}
+    if offload_optimizer:
+        zero["offload_optimizer"] = {
             "device": "cpu",
             "pin_memory": pin_memory,
-        },
-    }
+        }
     if offload_param:
         zero["offload_param"] = {
             "device": "cpu",
@@ -128,6 +127,31 @@ class TestDestroyUnpinsNativeBuffers(DistributedTest):
             ranges_after = len(native._ranges)
             assert ranges_after < ranges_before, (f"expected optimizer-owned pins to be freed on destroy: "
                                                   f"before={ranges_before} after={ranges_after}")
+        finally:
+            _restore_pin_backend(prev)
+
+    @pytest.mark.parametrize("stage", [2, 3])
+    def test_native_destroy_frees_offload_states_pins(self, stage):
+        # offload_states(pin_memory=True) pins host buffers even with no ZeRO
+        # CPU offload configured. destroy() must release them when the caller
+        # never reloaded the states.
+        prev = os.environ.get("DS_PIN_MEMORY_BACKEND")
+        try:
+            native = _require_native()
+            config, dtype = _config(stage, pin_memory=True, offload_optimizer=False)
+            hidden_dim = 16
+            model = SimpleModel(hidden_dim, nlayers=2)
+            engine, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+            _run_one_step(engine, hidden_dim, dtype)
+
+            ranges_before = len(native._ranges)
+            engine.offload_states(pin_memory=True)
+            ranges_offloaded = len(native._ranges)
+            assert ranges_offloaded > ranges_before, "expected offload_states to pin host buffers"
+
+            engine.destroy()
+            assert len(native._ranges) <= ranges_before, (f"offload_states pins not released on destroy: "
+                                                          f"offloaded={ranges_offloaded} after={len(native._ranges)}")
         finally:
             _restore_pin_backend(prev)
 

--- a/tests/unit/v1/pin_memory/test_offload_route.py
+++ b/tests/unit/v1/pin_memory/test_offload_route.py
@@ -3,11 +3,15 @@
 # DeepSpeed Team
 """Native-backend coverage for Phase 2 pin routing through offload helpers."""
 
+import gc
+
 import pytest
 import torch
 
 from deepspeed.accelerator import get_accelerator
-from deepspeed.runtime.zero.offload_states import offload_optimizer_states
+from deepspeed.runtime.zero.offload_config import OffloadStateTypeEnum
+from deepspeed.runtime.zero.offload_states import offload_optimizer_states, reload_optimizer_states
+from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 from deepspeed.utils.pin_memory import get_active_native_pinned_memory
 
 
@@ -18,6 +22,15 @@ def _require_native(monkeypatch):
             pytest.skip("native backend not selected")
     except Exception:
         pytest.skip("pin_memory op could not be built; native pinning unavailable")
+
+
+def _require_gpu_native(monkeypatch):
+    _require_native(monkeypatch)
+    accel = get_accelerator()
+    # Async host-to-device copies only exist off the CPU accelerator.
+    if accel.device_name() == "cpu":
+        pytest.skip("requires non-CPU accelerator")
+    return accel
 
 
 def test_offload_helper_pin_pattern_native(monkeypatch):
@@ -53,3 +66,69 @@ def test_offload_optimizer_states_native_is_pinned(monkeypatch):
     assert buf.device.type == "cpu"
     assert accel.is_pinned(buf) is True
     assert accel.unpin_memory(buf) is True
+
+
+def test_reload_optimizer_states_returns_host_sources(monkeypatch):
+    """Callers need the replaced host tensors to outlive a non-blocking copy."""
+    accel = _require_gpu_native(monkeypatch)
+    device = accel.current_device_name()
+
+    class _Opt:
+        pass
+
+    opt = _Opt()
+    opt.state = {0: {"exp_avg": torch.randn(32, device=device)}}
+    offload_optimizer_states(opt, device="cpu", pin_memory=True, non_blocking=False)
+    pinned = opt.state[0]["exp_avg"]
+
+    host_buffers = reload_optimizer_states(opt, device, non_blocking=True)
+    accel.synchronize()
+
+    assert len(host_buffers) == 1
+    assert host_buffers[0] is pinned
+    assert opt.state[0]["exp_avg"].device.type != "cpu"
+    assert accel.unpin_memory(pinned) is True
+
+
+def test_reload_states_holds_pin_buffers_until_sync(monkeypatch):
+    """ZeRO-1/2 reload must not free native pinned sources while copies are in flight."""
+    accel = _require_gpu_native(monkeypatch)
+    manager = get_active_native_pinned_memory()
+    device = accel.current_device_name()
+
+    hp_param = torch.randn(1024, device=device)
+    pinned = accel.pin_memory(torch.empty_like(hp_param, device="cpu"), make_copy=False)
+    pinned.copy_(hp_param)
+    # Mirrors offload_states(): the hp param now points at the pinned host buffer.
+    hp_param.data = pinned
+    begin = pinned.data_ptr()
+
+    class _FakeZeroOptimizer:
+        # Run the real method against the minimal state its hp_params branch touches.
+        reload_states = DeepSpeedZeroOptimizer.reload_states
+
+        def _link_all_hp_params(self):
+            pass
+
+    optimizer = _FakeZeroOptimizer()
+    optimizer.offloaded_states = {OffloadStateTypeEnum.hp_params}
+    optimizer.single_partition_of_fp32_groups = [hp_param]
+    optimizer.hp_params_pin_buffers = [pinned]
+    # reload_states now owns the only reference to the pinned buffer.
+    del pinned
+
+    registered_while_syncing = []
+    real_synchronize = accel.synchronize
+
+    def _recording_synchronize():
+        registered_while_syncing.append(begin in manager._ranges)
+        real_synchronize()
+
+    monkeypatch.setattr(accel, "synchronize", _recording_synchronize)
+    optimizer.reload_states(non_blocking=True)
+
+    assert registered_while_syncing == [True]
+    assert hp_param.device.type != "cpu"
+    gc.collect()
+    # Released once the copies are known to have completed.
+    assert begin not in manager._ranges

--- a/tests/unit/v1/pin_memory/test_offload_route.py
+++ b/tests/unit/v1/pin_memory/test_offload_route.py
@@ -20,13 +20,27 @@ def _require_native(monkeypatch):
         pytest.skip("pin_memory op could not be built; native pinning unavailable")
 
 
+def test_offload_helper_pin_pattern_native(monkeypatch):
+    """Empty scratch pin used by offload_optimizer_states must be is_pinned under native."""
+    _require_native(monkeypatch)
+    accel = get_accelerator()
+    # Mirrors offload_optimizer_states: allocate empty host buffer, then copy.
+    src = torch.randn(32)
+    pinned_buffer = accel.pin_memory(torch.empty_like(src, device="cpu"), make_copy=False)
+    pinned_buffer.copy_(src)
+    assert accel.is_pinned(pinned_buffer) is True
+    assert accel.unpin_memory(pinned_buffer) is True
+
+
 def test_offload_optimizer_states_native_is_pinned(monkeypatch):
     """offload_optimizer_states must route through accelerator pin_memory."""
     _require_native(monkeypatch)
-    if not get_accelerator().is_available():
-        pytest.skip("accelerator required to exercise GPU->pinned CPU offload")
+    accel = get_accelerator()
+    # The pin path only runs when the source tensor is not already on CPU.
+    if accel.device_name() == "cpu":
+        pytest.skip("requires non-CPU accelerator for GPU->pinned CPU offload path")
 
-    device = get_accelerator().current_device_name()
+    device = accel.current_device_name()
 
     class _Opt:
         pass
@@ -37,5 +51,5 @@ def test_offload_optimizer_states_native_is_pinned(monkeypatch):
     offload_optimizer_states(opt, device="cpu", pin_memory=True, non_blocking=False)
     buf = opt.state[0]["exp_avg"]
     assert buf.device.type == "cpu"
-    assert get_accelerator().is_pinned(buf) is True
-    assert get_accelerator().unpin_memory(buf) is True
+    assert accel.is_pinned(buf) is True
+    assert accel.unpin_memory(buf) is True

--- a/tests/unit/v1/pin_memory/test_offload_route.py
+++ b/tests/unit/v1/pin_memory/test_offload_route.py
@@ -132,3 +132,20 @@ def test_reload_states_holds_pin_buffers_until_sync(monkeypatch):
     gc.collect()
     # Released once the copies are known to have completed.
     assert begin not in manager._ranges
+
+
+def test_superoffload_grad_buffer_unpinned_when_disabled():
+    """offload_optimizer.pin_memory=False must allocate a regular CPU buffer."""
+    from deepspeed.runtime.superoffload.superoffload_utils import _allocate_worker_grad_buffer
+    buffer = _allocate_worker_grad_buffer(32, pin_memory=False)
+    assert get_accelerator().is_pinned(buffer) is False
+
+
+def test_superoffload_grad_buffer_pinned_when_enabled(monkeypatch):
+    """offload_optimizer.pin_memory=True keeps the current pinned allocation."""
+    _require_native(monkeypatch)
+    from deepspeed.runtime.superoffload.superoffload_utils import _allocate_worker_grad_buffer
+    accel = get_accelerator()
+    buffer = _allocate_worker_grad_buffer(32, pin_memory=True)
+    assert accel.is_pinned(buffer) is True
+    assert accel.unpin_memory(buffer) is True

--- a/tests/unit/v1/pin_memory/test_offload_route.py
+++ b/tests/unit/v1/pin_memory/test_offload_route.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""Native-backend coverage for Phase 2 pin routing through offload helpers."""
+
+import pytest
+import torch
+
+from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.zero.offload_states import offload_optimizer_states
+from deepspeed.utils.pin_memory import get_active_native_pinned_memory
+
+
+def _require_native(monkeypatch):
+    monkeypatch.setenv("DS_PIN_MEMORY_BACKEND", "native")
+    try:
+        if get_active_native_pinned_memory() is None:
+            pytest.skip("native backend not selected")
+    except Exception:
+        pytest.skip("pin_memory op could not be built; native pinning unavailable")
+
+
+def test_offload_optimizer_states_native_is_pinned(monkeypatch):
+    """offload_optimizer_states must route through accelerator pin_memory."""
+    _require_native(monkeypatch)
+    if not get_accelerator().is_available():
+        pytest.skip("accelerator required to exercise GPU->pinned CPU offload")
+
+    device = get_accelerator().current_device_name()
+
+    class _Opt:
+        pass
+
+    opt = _Opt()
+    opt.state = {0: {"exp_avg": torch.randn(32, device=device)}}
+
+    offload_optimizer_states(opt, device="cpu", pin_memory=True, non_blocking=False)
+    buf = opt.state[0]["exp_avg"]
+    assert buf.device.type == "cpu"
+    assert get_accelerator().is_pinned(buf) is True
+    assert get_accelerator().unpin_memory(buf) is True


### PR DESCRIPTION
## Summary
- Route ZeRO-1/2 `offload_states` hp/lp pins, `offload_optimizer_states`, ZeRO++ secondary shards, and SuperOffload grad buffers through `get_accelerator().pin_memory()` so `DS_PIN_MEMORY_BACKEND=native` applies.
- Use `make_copy=False` for empty scratch destinations to avoid an extra host alloc/copy under the native backend.
- Clarify in `memory.rst` that ZeRO `offload_*.pin_memory` (whether) is orthogonal to `DS_PIN_MEMORY_BACKEND` (how); env-only, no ds_config backend field.
- Add `tests/unit/v1/pin_memory/test_offload_route.py` covering `offload_optimizer_states` under native.

## Test plan
- [x] `pre-commit run --files` on touched paths (already run locally)
- [x] `DS_PIN_MEMORY_BACKEND=native` + `pytest tests/unit/v1/pin_memory/test_offload_route.py` (+ pin_memory/accelerator UTs) on H200 host with pin_memory op — **23 passed** (incl. both offload_route tests)
- [x] Smoke ZeRO-1/2 CPU offload with default torch backend — `test_offload_states.py` + `test_destroy_unpin.py` — **133 passed**
- [x] SuperOffload worker pin site: source uses `get_accelerator().pin_memory(..., make_copy=False)`; native empty-buffer pin/unpin smoke OK

Evidence: autorun `job-20260818T143819Z` on `e6dc5f9d` / `tjruwase/pin-memory-route-zero` (EXIT 0). GitHub CI also green on the tip commit.
