### PR TITLE
Route FPDT and checkpoint writer pins through accelerator pin_memory

### DIFF
--- a/deepspeed/runtime/model_checkpointing/writer_factory.py
+++ b/deepspeed/runtime/model_checkpointing/writer_factory.py
@@ -75,7 +75,16 @@ class CheckpointWriterFactory(object):
         self._writer = None
 
     def _setup_for_aio(self, aio_config):
-        self._io_buffer = torch.zeros(self._io_buffer_size, dtype=torch.uint8, device='cpu').pin_memory()
+        # Empty + make_copy=False avoids a useless memcpy under native; zero after pin.
+        # CPUAccelerator+torch is a historical no-op, so fall back to Tensor.pin_memory()
+        # so DeepNVMe can still skip bounce buffers on CUDA-capable hosts.
+        self._io_buffer = get_accelerator().pin_memory(torch.empty(self._io_buffer_size,
+                                                                   dtype=torch.uint8,
+                                                                   device='cpu'),
+                                                       make_copy=False)
+        if not get_accelerator().is_pinned(self._io_buffer):
+            self._io_buffer = self._io_buffer.pin_memory()
+        self._io_buffer.zero_()
         self._dnvme_handle = AsyncIOBuilder().load().aio_handle(
             block_size=aio_config[AIO_BLOCK_SIZE],
             queue_depth=aio_config[AIO_QUEUE_DEPTH],

--- a/deepspeed/sequence/fpdt_layer.py
+++ b/deepspeed/sequence/fpdt_layer.py
@@ -502,9 +502,9 @@ class SequenceChunk:
         self.chunk_dtype = chunk.dtype
         self.device = chunk.device if device is None else device
 
-        cpu_chunk = torch.empty(chunk.shape, dtype=chunk.dtype, device='cpu', pin_memory=True)
-
         if get_accelerator().on_accelerator(chunk):
+            cpu_chunk = get_accelerator().pin_memory(torch.empty(chunk.shape, dtype=chunk.dtype, device='cpu'),
+                                                     make_copy=False)
             cpu_chunk.copy_(chunk, non_blocking=True)
         else:
             cpu_chunk = chunk
@@ -831,8 +831,9 @@ class _FPDTGPUOffloadingAttentionImpl_(torch.autograd.Function):
             dq = [
                 SequenceChunk(torch.zeros(global_q[0].chunk_shape, dtype=torch.float, device=device), is_in_use=True)
             ] + [
-                SequenceChunk(torch.zeros(global_q[0].chunk_shape, dtype=torch.float, device='cpu', pin_memory=True),
-                              device) for _ in range(num_chunks - 1)
+                SequenceChunk(
+                    get_accelerator().pin_memory(torch.empty(global_q[0].chunk_shape, dtype=torch.float, device='cpu'),
+                                                 make_copy=False).zero_(), device) for _ in range(num_chunks - 1)
             ]
             dk_accum = torch.zeros(global_k[0].chunk_shape, dtype=torch.float, device=device)
             dv_accum = torch.zeros(global_v[0].chunk_shape, dtype=torch.float, device=device)


### PR DESCRIPTION
## Summary
- Route FPDT `SequenceChunk` and backward zero-chunk pins through `get_accelerator().pin_memory()`, pinning only when the chunk is on-accelerator (avoid pin-then-discard on CPU inputs).
- Route FastFileWriter AIO buffer through accelerator pin with `make_copy=False`, and fall back to `Tensor.pin_memory()` when the CPU accelerator torch path no-ops so DeepNVMe can still skip bounce buffers.

## Test plan
- [x] `pre-commit run --files` on touched paths (already run locally)
- [x] FPDT path smoke: `SequenceChunk` GPU pin + CPU reuse under native and torch; `TestFPDTAttention` combo `[32-4-128-2048-4]` **PASSED**
- [x] Checkpoint FastFileWriter / AIO write with default torch backend: `test_fast_file_writer_fd_close.py` **3 passed**; writer pin pattern `is_pinned=True`
- [x] `DS_PIN_MEMORY_BACKEND=native` writer buffer: `is_pinned=True`, `aio.is_pinned(buf)=True`, unpin OK; `test_pinned_manager.py` **5 passed**

Evidence: H200 autorun `job-20260819T184219Z` + `job-20260819T184528Z` on `13131752` / `tjruwase/pin-memory-route-fpdt-writer` (follow-up EXIT 0). GitHub CI green.
