### PR TITLE
Add compile.offload_activation_pin_memory for DeepCompile activation offload

### DIFF
--- a/csrc/compile/deepcompile.cpp
+++ b/csrc/compile/deepcompile.cpp
@@ -26,6 +26,7 @@ bool sync_before_reduce;     // for debugging
 bool sync_after_reduce;      // for debugging
 bool sync_before_allgather;  // for debugging
 bool sync_after_allgather;   // for debugging
+bool offload_activation_pin_memory = true;
 
 std::vector<int64_t> sizes_to_int_vector(at::IntArrayRef sizes)
 {
@@ -161,6 +162,7 @@ void init(c10::intrusive_ptr<c10d::ProcessGroup> pg,
     sync_after_reduce = get_config<bool>(config, "sync_after_reduce");
     sync_before_allgather = get_config<bool>(config, "sync_before_allgather");
     sync_after_allgather = get_config<bool>(config, "sync_after_allgather");
+    offload_activation_pin_memory = get_config<bool>(config, "offload_activation_pin_memory");
 }
 
 void start_forward()

--- a/csrc/compile/z3.cpp
+++ b/csrc/compile/z3.cpp
@@ -344,7 +344,11 @@ public:
             offload_comp_done_events_[id] =
                 std::make_shared<at::cuda::CUDAEvent>(cudaEventDisableTiming);
 
-            const auto options = at::TensorOptions().pinned_memory(true).device(torch::kCPU);
+            // Pin by default so async D2H/H2D can use full PCIe bandwidth; controlled by
+            // compile.offload_activation_pin_memory.
+            const auto options = at::TensorOptions()
+                                     .pinned_memory(offload_activation_pin_memory)
+                                     .device(torch::kCPU);
             offload_buffers_[id] = at::empty_like(tensor, options);
         }
 

--- a/csrc/includes/deepcompile.h
+++ b/csrc/includes/deepcompile.h
@@ -106,6 +106,7 @@ extern bool sync_before_reduce;     // for debugging
 extern bool sync_after_reduce;      // for debugging
 extern bool sync_before_allgather;  // for debugging
 extern bool sync_after_allgather;   // for debugging
+extern bool offload_activation_pin_memory;
 
 std::vector<int64_t> sizes_to_int_vector(at::IntArrayRef sizes);
 void enable_profiling(bool enable);

--- a/deepspeed/compile/config.py
+++ b/deepspeed/compile/config.py
@@ -24,6 +24,11 @@ class CompileConfig(DeepSpeedConfigModel):
     offload_activation: bool = False
     """ Turn on/off the activation offloading """
 
+    offload_activation_pin_memory: bool = True
+    """ Pin host buffers used for DeepCompile activation offload. Required for
+    full-bandwidth async GPU<->CPU copies. Disable only under tight memlock
+    limits (ulimit -l). Defaults to True to match ZeRO offload pin_memory. """
+
     offload_opt_states: bool = False
     """ Offload optimizer states (fp32 master parameters and Adam moments) to pinned host memory
     during forward/backward and reload them for the optimizer step, keeping resident whatever the

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -2211,6 +2211,24 @@ and the pass reuses the same tensor-parallel group.
 
 
 
+### DeepCompile activation offload
+
+These fields live under `compile` and apply when DeepCompile activation offload is scheduled.
+The offload pass is **not** in the default DeepCompile schedule; enable it only via a custom
+`schedule=` when calling DeepCompile init. Setting `offload_activation` alone has no effect.
+
+<i>**offload_activation**</i>: [boolean]
+
+| Description | Default |
+| ----------- | ------- |
+| Config field for DeepCompile activation offload. Requires a custom schedule that includes the offload pass; not enabled by the default `init_z3` / `init_z1` schedules. | `false` |
+
+<i>**offload_activation_pin_memory**</i>: [boolean]
+
+| Description | Default |
+| ----------- | ------- |
+| When activation offload runs, pin host buffers via ATen `pinned_memory` (Torch host pin). Does **not** use `DS_PIN_MEMORY_BACKEND`. Defaults to `true`; set `false` under tight memlock limits (`ulimit -l`). | `true` |
+
 ### Data Type options
 
 ```json


### PR DESCRIPTION
## Summary
- Add `compile.offload_activation_pin_memory` (default `true`) on `CompileConfig` and wire it into DeepCompile C++ `offloadTensor` via `at::TensorOptions().pinned_memory(...)`.
- Document honestly: the offload pass is not in the default schedule (`offload_activation` alone does nothing); pinning here uses ATen/Torch host pin and does **not** consult `DS_PIN_MEMORY_BACKEND`.

## Test plan
- [ ] `pre-commit run --files` on touched paths (already run locally)
- [ ] Rebuild deepcompile extension and confirm default still pins host offload buffers when the offload pass is scheduled
- [ ] With a custom schedule that includes activation offload, `offload_activation_pin_memory: false` yields pageable host buffers
