### PR TITLE
Fix Triton NFS detection crash when df wraps long device names

### DIFF
--- a/deepspeed/ops/transformer/inference/triton/matmul_ext.py
+++ b/deepspeed/ops/transformer/inference/triton/matmul_ext.py
@@ -33,17 +33,18 @@ def is_nfs_path(path):
             break
         path = parent
 
-    # Use the 'df' command to find the file system type for the given path
+    # POSIX output keeps long device names from wrapping onto a separate line.
     try:
-        output = subprocess.check_output(['df', '-T', path], encoding='utf-8', stderr=subprocess.DEVNULL)
+        output = subprocess.check_output(['df', '-PT', path], encoding='utf-8', stderr=subprocess.DEVNULL)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False  # Command failed or 'df' not available
 
-    # Process the output of 'df -T' to check for 'nfs' in the filesystem type column
+    # Process the output of 'df -PT' to check for 'nfs' in the filesystem type column.
     lines = output.strip().split('\n')
     if len(lines) > 1:  # The first line is headers
-        fs_type = lines[1].split()[1].lower()  # File system type is the second column
-        return 'nfs' in fs_type
+        fields = lines[1].split()
+        if len(fields) > 1:
+            return 'nfs' in fields[1].lower()
     return False
 
 

--- a/tests/unit/ops/transformer/inference/test_matmul_ext.py
+++ b/tests/unit/ops/transformer/inference/test_matmul_ext.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable, cast
+from unittest.mock import patch
+
+MATMUL_EXT_PATH = Path(
+    __file__).resolve().parents[5] / "deepspeed" / "ops" / "transformer" / "inference" / "triton" / "matmul_ext.py"
+
+
+def load_is_nfs_path() -> Callable[[Path], bool]:
+    tree = ast.parse(MATMUL_EXT_PATH.read_text(), filename=str(MATMUL_EXT_PATH))
+    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "is_nfs_path")
+    module = ast.Module(body=[function], type_ignores=[])
+    namespace = {"os": os, "subprocess": subprocess}
+    exec(compile(module, str(MATMUL_EXT_PATH), "exec"), namespace)
+    return cast(Callable[[Path], bool], namespace["is_nfs_path"])
+
+
+def test_is_nfs_path_handles_wrapped_device_name(tmp_path):
+    is_nfs_path = load_is_nfs_path()
+    busybox_output = """Filesystem           Type       1K-blocks      Used Available Use% Mounted on
+/dev/dvol0123456789abcdef0
+                     ext4       2112647088   3439616 2109191088   0% /mount
+"""
+
+    with patch.object(subprocess, "check_output", return_value=busybox_output) as check_output:
+        assert not is_nfs_path(tmp_path)
+
+    check_output.assert_called_once_with(['df', '-PT', str(tmp_path)], encoding='utf-8', stderr=subprocess.DEVNULL)

--- a/tests/unit/ops/transformer/inference/test_matmul_ext.py
+++ b/tests/unit/ops/transformer/inference/test_matmul_ext.py
@@ -3,28 +3,22 @@
 
 # DeepSpeed Team
 
-import ast
-import os
 import subprocess
-from pathlib import Path
-from typing import Callable, cast
 from unittest.mock import patch
 
-MATMUL_EXT_PATH = Path(
-    __file__).resolve().parents[5] / "deepspeed" / "ops" / "transformer" / "inference" / "triton" / "matmul_ext.py"
+import pytest
 
-
-def load_is_nfs_path() -> Callable[[Path], bool]:
-    tree = ast.parse(MATMUL_EXT_PATH.read_text(), filename=str(MATMUL_EXT_PATH))
-    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "is_nfs_path")
-    module = ast.Module(body=[function], type_ignores=[])
-    namespace = {"os": os, "subprocess": subprocess}
-    exec(compile(module, str(MATMUL_EXT_PATH), "exec"), namespace)
-    return cast(Callable[[Path], bool], namespace["is_nfs_path"])
+try:
+    import torch  # noqa: F401
+    import triton  # noqa: F401
+    from deepspeed.ops.transformer.inference.triton.matmul_ext import is_nfs_path
+except ImportError:
+    pytest.skip("Triton matmul extension is not available on this system", allow_module_level=True)
 
 
 def test_is_nfs_path_handles_wrapped_device_name(tmp_path):
-    is_nfs_path = load_is_nfs_path()
+    # BusyBox df wraps device names longer than ~20 characters onto their own
+    # row; the malformed short row must read as not-NFS instead of raising.
     busybox_output = """Filesystem           Type       1K-blocks      Used Available Use% Mounted on
 /dev/dvol0123456789abcdef0
                      ext4       2112647088   3439616 2109191088   0% /mount
@@ -34,3 +28,12 @@ def test_is_nfs_path_handles_wrapped_device_name(tmp_path):
         assert not is_nfs_path(tmp_path)
 
     check_output.assert_called_once_with(['df', '-PT', str(tmp_path)], encoding='utf-8', stderr=subprocess.DEVNULL)
+
+
+def test_is_nfs_path_detects_nfs_mount(tmp_path):
+    nfs_output = """Filesystem           Type      1K-blocks      Used Available Use% Mounted on
+fileserver:/export  nfs       2112647088  3439616 2109191088   0% /mount
+"""
+
+    with patch.object(subprocess, "check_output", return_value=nfs_output):
+        assert is_nfs_path(tmp_path)


### PR DESCRIPTION
## Description

`is_nfs_path()` reads the fs type from the second column of the second `df` output row. With BusyBox `df` and a device name longer than ~20 characters (common on AWS, where the EBS device is derived from the volume id), the device wraps onto its own line, the row has a single field, and the `[1]` lookup raises `IndexError`.

Since the check runs while printing an informational NFS warning during `import deepspeed`, that exception kills the whole import in BusyBox-based containers.

I changed the call to `df -PT` so POSIX output keeps every filesystem on one line (BusyBox and coreutils both honour `-P` with `-T`), and made the parse treat a short or malformed row as not-NFS instead of raising, so any other unexpected `df` output just skips the warning.

## Testing

- `pytest -q tests/unit/ops/transformer/inference/test_matmul_ext.py` — new mocked regression test covering the wrapped-device case passes, and fails with IndexError on the old parsing
- `pre-commit run --files deepspeed/ops/transformer/inference/triton/matmul_ext.py tests/unit/ops/transformer/inference/test_matmul_ext.py` — all hooks pass
- mocked POSIX `nfs4` row is still detected as NFS, so real NFS warnings keep working

Fixes #8249