### PR TITLE
Fallback for unsupported Hybrid Engine policies

### DIFF
--- a/deepspeed/runtime/hybrid_engine.py
+++ b/deepspeed/runtime/hybrid_engine.py
@@ -134,6 +134,12 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
                     self.inference_policies.update({orig_layer_class: (self.new_inference_container, plcy)})
             elif plcy._orig_layer_class is not None:
                 self.inference_policies.update({plcy._orig_layer_class: (self.new_inference_container, plcy)})
+
+        has_transformer_policy = any(module.__class__ in self.inference_policies for module in self.module.modules())
+        if not has_transformer_policy:
+            self.inference_policies = {}
+            return
+
         self.inference_policies.update({
             nn.Linear: (LinearLayer, ),
             nn.Embedding: (EmbeddingLayer, ),

--- a/deepspeed/runtime/hybrid_engine.py
+++ b/deepspeed/runtime/hybrid_engine.py
@@ -137,6 +137,12 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
 
         has_transformer_policy = any(module.__class__ in self.inference_policies for module in self.module.modules())
         if not has_transformer_policy:
+            logger.warning(
+                "No compatible DeepSpeed inference policy found for model type %s. "
+                "Hybrid Engine inference acceleration is unavailable; rollout will "
+                "use the model's native generate() path.",
+                type(self.module).__name__,
+            )
             self.inference_policies = {}
             return
 

--- a/tests/unit/hybrid_engine/test_he_policy.py
+++ b/tests/unit/hybrid_engine/test_he_policy.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # DeepSpeed Team
 
+from unittest.mock import patch
+
 import torch.nn as nn
 
 import deepspeed.runtime.hybrid_engine as hybrid_engine
@@ -29,14 +31,17 @@ def _make_engine(module):
     return engine
 
 
-def test_unsupported_model_uses_native_fallback(monkeypatch, caplog):
+def test_unsupported_model_uses_native_fallback(monkeypatch):
     monkeypatch.setattr(hybrid_engine, 'replace_policies', [SupportedPolicy])
     engine = _make_engine(nn.Sequential(UnsupportedLayer(), nn.Linear(2, 2), nn.LayerNorm(2)))
 
-    engine.populate_all_inference_policies()
+    with patch.object(hybrid_engine.logger, 'warning') as mock_warning:
+        engine.populate_all_inference_policies()
 
     assert engine.inference_policies == {}
-    assert "Hybrid Engine inference acceleration is unavailable" in caplog.text
+    mock_warning.assert_called_once()
+    assert "Hybrid Engine inference acceleration is unavailable" in mock_warning.call_args.args[0]
+    assert mock_warning.call_args.args[1] == "Sequential"
 
 
 def test_supported_model_registers_auxiliary_policies(monkeypatch):

--- a/tests/unit/hybrid_engine/test_he_policy.py
+++ b/tests/unit/hybrid_engine/test_he_policy.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import torch.nn as nn
+
+import deepspeed.runtime.hybrid_engine as hybrid_engine
+from deepspeed.runtime.hybrid_engine import DeepSpeedHybridEngine
+from deepspeed.module_inject.layers import LinearLayer
+
+
+class SupportedLayer(nn.Module):
+    pass
+
+
+class UnsupportedLayer(nn.Module):
+    pass
+
+
+class SupportedPolicy:
+    _orig_layer_class = SupportedLayer
+
+    def __init__(self, client_module, inference=False):
+        pass
+
+
+def _make_engine(module):
+    engine = DeepSpeedHybridEngine.__new__(DeepSpeedHybridEngine)
+    object.__setattr__(engine, 'module', module)
+    return engine
+
+
+def test_unsupported_model_uses_native_fallback(monkeypatch):
+    monkeypatch.setattr(hybrid_engine, 'replace_policies', [SupportedPolicy])
+    engine = _make_engine(nn.Sequential(UnsupportedLayer(), nn.Linear(2, 2), nn.LayerNorm(2)))
+
+    engine.populate_all_inference_policies()
+
+    assert engine.inference_policies == {}
+
+
+def test_supported_model_registers_auxiliary_policies(monkeypatch):
+    monkeypatch.setattr(hybrid_engine, 'replace_policies', [SupportedPolicy])
+    engine = _make_engine(nn.Sequential(SupportedLayer(), nn.Linear(2, 2)))
+
+    engine.populate_all_inference_policies()
+
+    assert SupportedLayer in engine.inference_policies
+    assert engine.inference_policies[nn.Linear][0] is LinearLayer

--- a/tests/unit/hybrid_engine/test_he_policy.py
+++ b/tests/unit/hybrid_engine/test_he_policy.py
@@ -29,13 +29,14 @@ def _make_engine(module):
     return engine
 
 
-def test_unsupported_model_uses_native_fallback(monkeypatch):
+def test_unsupported_model_uses_native_fallback(monkeypatch, caplog):
     monkeypatch.setattr(hybrid_engine, 'replace_policies', [SupportedPolicy])
     engine = _make_engine(nn.Sequential(UnsupportedLayer(), nn.Linear(2, 2), nn.LayerNorm(2)))
 
     engine.populate_all_inference_policies()
 
     assert engine.inference_policies == {}
+    assert "Hybrid Engine inference acceleration is unavailable" in caplog.text
 
 
 def test_supported_model_registers_auxiliary_policies(monkeypatch):


### PR DESCRIPTION
## Summary

- register Hybrid Engine auxiliary Linear/Embedding/LayerNorm policies only when the model contains a supported complete transformer policy
- allow unsupported architectures such as Qwen2.5 to retain the native `generate()` fallback
- add CPU-only unit coverage for supported and unsupported policy registration

Fixes #8263.

## Why

The generic wrappers are auxiliary pieces of a complete transformer injection policy. Registering them when no transformer layer matches creates a partial inference path. With a ZeRO-3-partitioned Qwen model, container construction can then reach `_mark_uc_metadata()` with a one-dimensional normalization weight and fail on `weight.shape[1]`.

The change first builds the complete-policy map and checks it against the model's module classes. If no complete policy matches, the map remains empty, no partial containers are created, and Hybrid Engine leaves the model's native generation method intact. Supported model behavior is unchanged.

## Validation

- `pytest -q tests/unit/hybrid_engine/test_he_policy.py` (`2 passed`)
- `pre-commit run --files deepspeed/runtime/hybrid_engine.py tests/unit/hybrid_engine/test_he_policy.py`
- Qwen2.5-0.5B / Qwen2.5-Math-7B OPSD completed a full prompt epoch and a separate 200-step run on 8 x MI250 with the fallback

