### PR TITLE
Fix zero reduce bucket size validation

### DIFF
--- a/deepspeed/runtime/zero/config.py
+++ b/deepspeed/runtime/zero/config.py
@@ -110,7 +110,7 @@ class DeepSpeedZeroConfig(DeepSpeedConfigModel):
     Uses reduce or reduce scatter instead of allreduce to average gradients
     """
 
-    reduce_bucket_size: int = Field(pp_int(5e8), ge=0)
+    reduce_bucket_size: int = Field(pp_int(5e8), gt=0)
     """
     Number of elements reduced/allreduced at a time. Limits the memory required
     for the allgather for large model sizes

--- a/tests/unit/runtime/zero/test_zero_config.py
+++ b/tests/unit/runtime/zero/test_zero_config.py
@@ -3,7 +3,16 @@
 
 # DeepSpeed Team
 
+import pytest
+
 from deepspeed.runtime.zero.config import DeepSpeedZeroConfig, DeepSpeedZeroOffloadParamConfig, DeepSpeedZeroOffloadOptimizerConfig
+
+
+def test_zero_config_reduce_bucket_size():
+    assert DeepSpeedZeroConfig(reduce_bucket_size=1).reduce_bucket_size == 1
+
+    with pytest.raises(ValueError):
+        DeepSpeedZeroConfig(reduce_bucket_size=0)
 
 
 def test_zero_config_deprecatedfields():


### PR DESCRIPTION
## Summary

Reject `zero_optimization.reduce_bucket_size=0` during configuration validation instead of allowing ZeRO to fail later with a division by zero during backward.

This changes the field constraint from non-negative to strictly positive and adds a boundary regression test covering `1` as valid and `0` as invalid.

Fixes #8260

## Testing

- `python -m pytest tests/unit/runtime/zero/test_zero_config.py -q` (7 passed)
- `pre-commit run --files deepspeed/runtime/zero/config.py tests/unit/runtime/zero/test_zero_config.py`
