### PR TITLE
fix: Only bind device id when needed,  Fixes #8248

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -811,11 +811,6 @@ def init_distributed(dist_backend: Optional[str] = None,
         config: Optional (DeepSpeedConfig). DeepSpeed configuration for setting up comms options (e.g. Comms profiling)
         rank: Optional (int). The current manually specified rank. Some init_method like "tcp://" need the rank and world_size as well (see: https://pytorch.org/docs/stable/distributed.html#tcp-initialization)
         world_size: Optional (int). Desired world_size for the TCP or Shared file-system initialization.
-
-    On `cuda` with a multi-rank job, the local device is bound to the process group so that torch
-    knows which GPU this rank owns. That also switches torch to eager communicator init, which some
-    platforms cannot complete. Set the environment variable `DEEPSPEED_SET_DEVICE_ID` to 0 to never
-    bind a device, or to 1 to bind it even for a single-rank job.
     '''
     global cdb
 

--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -811,6 +811,11 @@ def init_distributed(dist_backend: Optional[str] = None,
         config: Optional (DeepSpeedConfig). DeepSpeed configuration for setting up comms options (e.g. Comms profiling)
         rank: Optional (int). The current manually specified rank. Some init_method like "tcp://" need the rank and world_size as well (see: https://pytorch.org/docs/stable/distributed.html#tcp-initialization)
         world_size: Optional (int). Desired world_size for the TCP or Shared file-system initialization.
+
+    On `cuda` with a multi-rank job, the local device is bound to the process group so that torch
+    knows which GPU this rank owns. That also switches torch to eager communicator init, which some
+    platforms cannot complete. Set the environment variable `DEEPSPEED_SET_DEVICE_ID` to 0 to never
+    bind a device, or to 1 to bind it even for a single-rank job.
     '''
     global cdb
 

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -15,8 +15,6 @@ from ..runtime import compiler
 from deepspeed.utils.torch import required_torch_version
 import os
 
-DS_SET_DEVICE_ID = 'DEEPSPEED_SET_DEVICE_ID'
-
 DS_COMM_ALL_GATHER_OFF = False
 DS_COMM_REDUCE_SCATTER_OFF = False
 DS_COMM_BROADCAST_OFF = False
@@ -30,63 +28,20 @@ def disable_compiler_collective(func):
     return compiler.disable(func)
 
 
-def get_env_flag(name):
-    """Parse a boolean environment variable.
+def known_world_size(world_size):
+    """The world size when it can be determined, otherwise None.
 
-    Returns None when unset or unrecognized, so a typo falls back to the caller's default instead
-    of silently selecting one of the two answers.
+    ``init_distributed`` defaults its ``world_size`` argument to -1, and the value can also be
+    carried in the ``init_method`` URL (``tcp://host:port?world_size=2``), where neither the
+    argument nor ``WORLD_SIZE`` reflects it. Return None rather than a guess so that callers do
+    not act on an assumed size.
     """
-    value = os.environ.get(name, '').strip().lower()
-    if value in ('1', 'true', 'yes', 'on'):
-        return True
-    if value in ('0', 'false', 'no', 'off'):
-        return False
-    if value:
-        utils.logger.warning(f'Ignoring {name}={value}, expected one of 1/0, true/false, yes/no, on/off')
-    return None
-
-
-def resolve_world_size(world_size):
-    """World size as the launcher sees it; ``init_distributed`` defaults its argument to -1."""
     if world_size is not None and world_size > 0:
         return world_size
-    return int(os.environ.get('WORLD_SIZE', '1'))
-
-
-def get_init_process_group_device_id(world_size):
-    """Resolve the ``device_id`` for ``init_process_group``, or None to leave the device unbound.
-
-    Binding switches torch to eager NCCL init, so every later ``new_group()`` splits a communicator
-    up front: wanted for multi-rank, pure cost for a single rank (#8248).
-    """
-    # device_id arg was added in torch==2.3
-    if 'device_id' not in inspect.signature(torch.distributed.init_process_group).parameters:
-        return None
-
-    # setting device_id leads to hanging in 2.6.0<torch<2.7.1 https://github.com/pytorch/pytorch/issues/153960
-    if version.parse("2.6.0") < version.parse(torch.__version__) < version.parse("2.7.1"):
-        return None
-
-    # device_id works and is needed for `cuda`, other accelerators may have issues at the moment.
-    if get_accelerator().device_name() != 'cuda':
-        return None
-
-    # LOCAL_RANK can exceed the visible device count when CUDA_VISIBLE_DEVICES is narrowed
-    # separately; binding a device that does not exist fails harder than the warning we avoid.
-    local_rank = int(os.environ.get('LOCAL_RANK', '0'))
-    if not 0 <= local_rank < get_accelerator().device_count():
-        return None
-
-    # DEEPSPEED_SET_DEVICE_ID forces either answer; see init_distributed's docstring.
-    override = get_env_flag(DS_SET_DEVICE_ID)
-    if override is False:
-        return None
-
-    # A single-rank job has no peer to connect to, so eager init is all cost and no benefit.
-    if override is None and resolve_world_size(world_size) <= 1:
-        return None
-
-    return get_accelerator().device(local_rank)
+    env_world_size = os.environ.get('WORLD_SIZE', '')
+    if env_world_size.isdigit() and int(env_world_size) > 0:
+        return int(env_world_size)
+    return None
 
 
 def build_shm_op():
@@ -226,9 +181,19 @@ class TorchBackend(Backend):
     def init_process_group(self, backend, timeout, init_method, rank, world_size):
         if not torch.distributed.is_initialized():
             kwargs = dict(timeout=timeout, init_method=init_method, rank=rank, world_size=world_size)
-            device_id = get_init_process_group_device_id(world_size)
-            if device_id is not None:
-                kwargs.update(device_id=device_id)
+
+            # 1. device_id arg was added in torch==2.3
+            # 2. setting device_id leads to hanging in 2.6.0<torch<2.7.1 https://github.com/pytorch/pytorch/issues/153960
+            # 3. device_id works and is needed for `cuda`, other accelerators may have issues at the moment. Therefore only do it for the `cuda` accelerator.
+            # 4. binding a device also makes torch build every later new_group() with ncclCommSplit;
+            #    a single-rank job has no peer to reach, so skip it there (#8248). Only skip when the
+            #    world size is actually known, never on an assumed one.
+            if (known_world_size(world_size) != 1
+                    and 'device_id' in inspect.signature(torch.distributed.init_process_group).parameters
+                    and not (version.parse("2.6.0") < version.parse(torch.__version__) < version.parse("2.7.1"))
+                    and get_accelerator().device_name() == 'cuda'):
+                local_rank = int(os.environ.get('LOCAL_RANK', 0))
+                kwargs.update(device_id=get_accelerator().device(local_rank))
             torch.distributed.init_process_group(backend, **kwargs)
 
         self.using_mpi = torch.distributed.get_backend() == 'mpi'

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -15,6 +15,8 @@ from ..runtime import compiler
 from deepspeed.utils.torch import required_torch_version
 import os
 
+DS_SET_DEVICE_ID = 'DEEPSPEED_SET_DEVICE_ID'
+
 DS_COMM_ALL_GATHER_OFF = False
 DS_COMM_REDUCE_SCATTER_OFF = False
 DS_COMM_BROADCAST_OFF = False
@@ -26,6 +28,64 @@ def disable_compiler_collective(func):
     if required_torch_version(min_version=2.3):
         return func
     return compiler.disable(func)
+
+
+def resolve_world_size(world_size):
+    """World size as the launcher sees it.
+
+    ``init_distributed`` defaults its ``world_size`` argument to -1 and lets torch read the value
+    out of the environment, so fall back to that when we were not given a real one.
+    """
+    if world_size is not None and world_size > 0:
+        return world_size
+    return int(os.environ.get('WORLD_SIZE', '1'))
+
+
+def get_init_process_group_device_id(world_size):
+    """Resolve the ``device_id`` to pass to ``torch.distributed.init_process_group``.
+
+    Returns ``None`` when no device should be bound.
+
+    Binding a device stores it on the default process group as ``bound_device_id``, which
+    switches torch into eager communicator init: every later ``new_group()`` in the process,
+    including calls made by other libraries, builds its NCCL communicator immediately via
+    ``ncclCommSplit`` instead of on first use. For a multi-rank job that is what we want, as it
+    silences the "devices used by this process are currently unknown" warning that ``barrier()``
+    would otherwise emit. For a single-rank job there is no peer to connect to, so eager init
+    buys nothing and only adds failure surface on platforms that cannot complete it.
+
+    Set ``DEEPSPEED_SET_DEVICE_ID`` to 0 to never bind a device, or to 1 to bind it even for a
+    single-rank job.
+    """
+    # device_id arg was added in torch==2.3
+    if 'device_id' not in inspect.signature(torch.distributed.init_process_group).parameters:
+        return None
+
+    # setting device_id leads to hanging in 2.6.0<torch<2.7.1 https://github.com/pytorch/pytorch/issues/153960
+    if version.parse("2.6.0") < version.parse(torch.__version__) < version.parse("2.7.1"):
+        return None
+
+    # device_id works and is needed for `cuda`, other accelerators may have issues at the moment.
+    if get_accelerator().device_name() != 'cuda':
+        return None
+
+    # LOCAL_RANK is not always a valid index into the visible devices, for example when
+    # CUDA_VISIBLE_DEVICES is narrowed independently of the launcher's rank numbering. Binding an
+    # out-of-range device makes torch reject the process group outright with a ValueError, which
+    # is a worse outcome than the barrier warning we set the device to avoid.
+    local_rank = int(os.environ.get('LOCAL_RANK', '0'))
+    if not 0 <= local_rank < get_accelerator().device_count():
+        return None
+
+    override = os.environ.get(DS_SET_DEVICE_ID, '').strip().lower()
+    if override in ('0', 'false', 'no'):
+        return None
+
+    # A single-rank job has no peer to connect to, so eager init is all cost and no benefit.
+    if not override and resolve_world_size(world_size) <= 1:
+        return None
+
+    return get_accelerator().device(local_rank)
 
 
 def build_shm_op():
@@ -165,15 +225,9 @@ class TorchBackend(Backend):
     def init_process_group(self, backend, timeout, init_method, rank, world_size):
         if not torch.distributed.is_initialized():
             kwargs = dict(timeout=timeout, init_method=init_method, rank=rank, world_size=world_size)
-
-            # 1. device_id arg was added in torch==2.3
-            # 2. setting device_id leads to hanging in 2.6.0<torch<2.7.1 https://github.com/pytorch/pytorch/issues/153960
-            # 3. device_id works and is needed for `cuda`, other accelerators may have issues at the moment. Therefore only do it for the `cuda` accelerator.
-            if ('device_id' in inspect.signature(torch.distributed.init_process_group).parameters
-                    and not (version.parse("2.6.0") < version.parse(torch.__version__) < version.parse("2.7.1"))
-                    and get_accelerator().device_name() == 'cuda'):
-                local_rank = int(os.environ.get('LOCAL_RANK', 0))
-                kwargs.update(device_id=get_accelerator().device(local_rank))
+            device_id = get_init_process_group_device_id(world_size)
+            if device_id is not None:
+                kwargs.update(device_id=device_id)
             torch.distributed.init_process_group(backend, **kwargs)
 
         self.using_mpi = torch.distributed.get_backend() == 'mpi'

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -31,11 +31,10 @@ def disable_compiler_collective(func):
 
 
 def get_env_flag(name):
-    """Read a boolean environment variable.
+    """Parse a boolean environment variable.
 
-    Returns True or False for a recognized value, and None when the variable is unset or holds
-    something we do not understand. Callers read None as "no preference expressed", so a typo falls
-    back to the default instead of silently selecting one of the two answers.
+    Returns None when unset or unrecognized, so a typo falls back to the caller's default instead
+    of silently selecting one of the two answers.
     """
     value = os.environ.get(name, '').strip().lower()
     if value in ('1', 'true', 'yes', 'on'):
@@ -48,31 +47,17 @@ def get_env_flag(name):
 
 
 def resolve_world_size(world_size):
-    """World size as the launcher sees it.
-
-    ``init_distributed`` defaults its ``world_size`` argument to -1 and lets torch read the value
-    out of the environment, so fall back to that when we were not given a real one.
-    """
+    """World size as the launcher sees it; ``init_distributed`` defaults its argument to -1."""
     if world_size is not None and world_size > 0:
         return world_size
     return int(os.environ.get('WORLD_SIZE', '1'))
 
 
 def get_init_process_group_device_id(world_size):
-    """Resolve the ``device_id`` to pass to ``torch.distributed.init_process_group``.
+    """Resolve the ``device_id`` for ``init_process_group``, or None to leave the device unbound.
 
-    Returns ``None`` when no device should be bound.
-
-    Binding a device stores it on the default process group as ``bound_device_id``, which
-    switches torch into eager communicator init: every later ``new_group()`` in the process,
-    including calls made by other libraries, builds its NCCL communicator immediately via
-    ``ncclCommSplit`` instead of on first use. For a multi-rank job that is what we want, as it
-    silences the "devices used by this process are currently unknown" warning that ``barrier()``
-    would otherwise emit. For a single-rank job there is no peer to connect to, so eager init
-    buys nothing and only adds failure surface on platforms that cannot complete it.
-
-    Set ``DEEPSPEED_SET_DEVICE_ID`` to 0 to never bind a device, or to 1 to bind it even for a
-    single-rank job.
+    Binding switches torch to eager NCCL init, so every later ``new_group()`` splits a communicator
+    up front: wanted for multi-rank, pure cost for a single rank (#8248).
     """
     # device_id arg was added in torch==2.3
     if 'device_id' not in inspect.signature(torch.distributed.init_process_group).parameters:
@@ -86,14 +71,13 @@ def get_init_process_group_device_id(world_size):
     if get_accelerator().device_name() != 'cuda':
         return None
 
-    # LOCAL_RANK is not always a valid index into the visible devices, for example when
-    # CUDA_VISIBLE_DEVICES is narrowed independently of the launcher's rank numbering. Binding an
-    # out-of-range device makes torch reject the process group outright with a ValueError, which
-    # is a worse outcome than the barrier warning we set the device to avoid.
+    # LOCAL_RANK can exceed the visible device count when CUDA_VISIBLE_DEVICES is narrowed
+    # separately; binding a device that does not exist fails harder than the warning we avoid.
     local_rank = int(os.environ.get('LOCAL_RANK', '0'))
     if not 0 <= local_rank < get_accelerator().device_count():
         return None
 
+    # DEEPSPEED_SET_DEVICE_ID forces either answer; see init_distributed's docstring.
     override = get_env_flag(DS_SET_DEVICE_ID)
     if override is False:
         return None

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -30,6 +30,23 @@ def disable_compiler_collective(func):
     return compiler.disable(func)
 
 
+def get_env_flag(name):
+    """Read a boolean environment variable.
+
+    Returns True or False for a recognized value, and None when the variable is unset or holds
+    something we do not understand. Callers read None as "no preference expressed", so a typo falls
+    back to the default instead of silently selecting one of the two answers.
+    """
+    value = os.environ.get(name, '').strip().lower()
+    if value in ('1', 'true', 'yes', 'on'):
+        return True
+    if value in ('0', 'false', 'no', 'off'):
+        return False
+    if value:
+        utils.logger.warning(f'Ignoring {name}={value}, expected one of 1/0, true/false, yes/no, on/off')
+    return None
+
+
 def resolve_world_size(world_size):
     """World size as the launcher sees it.
 
@@ -77,12 +94,12 @@ def get_init_process_group_device_id(world_size):
     if not 0 <= local_rank < get_accelerator().device_count():
         return None
 
-    override = os.environ.get(DS_SET_DEVICE_ID, '').strip().lower()
-    if override in ('0', 'false', 'no'):
+    override = get_env_flag(DS_SET_DEVICE_ID)
+    if override is False:
         return None
 
     # A single-rank job has no peer to connect to, so eager init is all cost and no benefit.
-    if not override and resolve_world_size(world_size) <= 1:
+    if override is None and resolve_world_size(world_size) <= 1:
         return None
 
     return get_accelerator().device(local_rank)

--- a/tests/unit/comm/test_dist.py
+++ b/tests/unit/comm/test_dist.py
@@ -217,102 +217,30 @@ class TestDistInitWithModel(DistributedTest):
 # `deepspeed.comm.torch` is shadowed by the real torch module in the `deepspeed.comm` namespace.
 ds_comm_torch = importlib.import_module("deepspeed.comm.torch")
 
-# Spelled out rather than imported, so the end-to-end checks also run against unpatched DeepSpeed.
-SET_DEVICE_ID_ENV = "DEEPSPEED_SET_DEVICE_ID"
+
+@pytest.mark.parametrize("world_size,env,expected", [
+    (2, None, 2),
+    (1, None, 1),
+    (-1, "4", 4),
+    (-1, None, None),
+    (-1, "", None),
+])
+def test_known_world_size(monkeypatch, world_size, env, expected):
+    # -1 with nothing in the environment means the size is genuinely unknown: it may be carried
+    # in the init_method URL. Returning None keeps the caller from skipping the device binding
+    # on an assumed size.
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    if env is not None:
+        monkeypatch.setenv("WORLD_SIZE", env)
+    assert ds_comm_torch.known_world_size(world_size) == expected
 
 
-class FakeAccelerator:
-    """Stands in for a real accelerator so the device_id policy can be exercised on any host."""
-
-    def __init__(self, name='cuda', device_count=8):
-        self._name = name
-        self._device_count = device_count
-
-    def device_name(self, device_index=None):
-        if device_index is None:
-            return self._name
-        return f'{self._name}:{device_index}'
-
-    def device_count(self):
-        return self._device_count
-
-    def device(self, device_index=None):
-        return torch.device(self._name, device_index)
-
-
-def resolve_device_id(monkeypatch, world_size, local_rank=0, device_count=8, override=None, name='cuda'):
-    """Run the device_id policy against a pretend host, independent of the real accelerator."""
-    accelerator = FakeAccelerator(name=name, device_count=device_count)
-    monkeypatch.setattr(ds_comm_torch, 'get_accelerator', lambda: accelerator)
-    monkeypatch.setenv('LOCAL_RANK', str(local_rank))
-    monkeypatch.setenv('WORLD_SIZE', str(world_size))
-    monkeypatch.delenv(SET_DEVICE_ID_ENV, raising=False)
-    if override is not None:
-        monkeypatch.setenv(SET_DEVICE_ID_ENV, override)
-    return ds_comm_torch.get_init_process_group_device_id(world_size)
-
-
-def test_device_id_skipped_for_single_rank(monkeypatch):
-    # No peer to connect to, so eager init is pure failure surface. This is the case in #8248.
-    assert resolve_device_id(monkeypatch, world_size=1) is None
-
-
-def test_device_id_set_for_multi_rank(monkeypatch):
-    assert resolve_device_id(monkeypatch, world_size=2, local_rank=1) == torch.device('cuda', 1)
-
-
-@pytest.mark.parametrize("override", ["0", "false", "NO", "off", " 0 "])
-def test_device_id_disabled_by_env(monkeypatch, override):
-    assert resolve_device_id(monkeypatch, world_size=4, override=override) is None
-
-
-@pytest.mark.parametrize("override", ["1", "true", "YES", "on"])
-def test_device_id_forced_by_env_for_single_rank(monkeypatch, override):
-    assert resolve_device_id(monkeypatch, world_size=1, override=override) == torch.device('cuda', 0)
-
-
-@pytest.mark.parametrize("override", ["fasle", "banana", "2"])
-def test_unrecognized_env_value_falls_back_to_the_default(monkeypatch, override):
-    # A misspelt "false" must not silently mean "true"; the world_size default still decides.
-    assert resolve_device_id(monkeypatch, world_size=1, override=override) is None
-    assert resolve_device_id(monkeypatch, world_size=2, override=override) == torch.device('cuda', 0)
-
-
-def test_device_id_skipped_when_local_rank_is_not_visible(monkeypatch):
-    # CUDA_VISIBLE_DEVICES can be narrowed independently of the launcher's rank numbering.
-    assert resolve_device_id(monkeypatch, world_size=8, local_rank=3, device_count=1) is None
-
-
-def test_device_id_skipped_for_non_cuda_accelerator(monkeypatch):
-    assert resolve_device_id(monkeypatch, world_size=2, name='xpu') is None
-
-
-def test_env_var_name_matches_source():
-    assert ds_comm_torch.DS_SET_DEVICE_ID == SET_DEVICE_ID_ENV
-
-
-def test_world_size_read_from_env_when_not_supplied(monkeypatch):
-    monkeypatch.setenv('WORLD_SIZE', '4')
-    assert ds_comm_torch.resolve_world_size(-1) == 4
-
-
-def test_world_size_defaults_to_one_when_unknown(monkeypatch):
-    monkeypatch.delenv('WORLD_SIZE', raising=False)
-    assert ds_comm_torch.resolve_world_size(-1) == 1
-
-
-def assert_device_binding(override, expect_bound):
-    """Initialize the process group under an override and check what the binding does downstream."""
+def assert_device_binding(expect_bound):
+    """A device is bound for multi-rank jobs, and not for a single-rank one (#8248)."""
     if get_accelerator().communication_backend_name() != 'nccl':
         pytest.skip("device_id is only bound for the nccl backend")
 
-    if override is None:
-        os.environ.pop(SET_DEVICE_ID_ENV, None)
-    else:
-        os.environ[SET_DEVICE_ID_ENV] = override
-
     deepspeed.init_distributed(dist_backend='nccl', auto_mpi_discovery=False)
-
     default_pg = torch.distributed.distributed_c10d._get_default_group()
     assert (default_pg.bound_device_id is not None) == expect_bound
 
@@ -322,23 +250,20 @@ def assert_device_binding(override, expect_bound):
     if hasattr(default_backend, "comm_split_count"):
         splits_before = default_backend.comm_split_count()
         torch.distributed.new_group(ranks=list(range(dist.get_world_size())))
-        splits_after = default_backend.comm_split_count()
-        assert (splits_after > splits_before) == expect_bound
+        assert (default_backend.comm_split_count() > splits_before) == expect_bound
 
 
-@pytest.mark.parametrize("override,expect_bound", [(None, False), ("0", False), ("1", True)])
 class TestSingleRankDeviceId(DistributedTest):
     world_size = 1
     init_distributed = False
 
-    def test(self, override, expect_bound):
-        assert_device_binding(override, expect_bound)
+    def test(self):
+        assert_device_binding(expect_bound=False)
 
 
-@pytest.mark.parametrize("override,expect_bound", [(None, True), ("0", False)])
 class TestMultiRankDeviceId(DistributedTest):
     world_size = 2
     init_distributed = False
 
-    def test(self, override, expect_bound):
-        assert_device_binding(override, expect_bound)
+    def test(self):
+        assert_device_binding(expect_bound=True)

--- a/tests/unit/comm/test_dist.py
+++ b/tests/unit/comm/test_dist.py
@@ -214,12 +214,10 @@ class TestDistInitWithModel(DistributedTest):
                                                   dist_init_required=dist_init_required)
 
 
-# `deepspeed.comm.torch` is shadowed by the real torch module inside the `deepspeed.comm`
-# namespace, so the submodule has to be reached for explicitly.
+# `deepspeed.comm.torch` is shadowed by the real torch module in the `deepspeed.comm` namespace.
 ds_comm_torch = importlib.import_module("deepspeed.comm.torch")
 
-# Referred to by name, not through ds_comm_torch, so the end-to-end checks below still run
-# against a DeepSpeed build that predates the constant.
+# Spelled out rather than imported, so the end-to-end checks also run against unpatched DeepSpeed.
 SET_DEVICE_ID_ENV = "DEEPSPEED_SET_DEVICE_ID"
 
 
@@ -255,8 +253,7 @@ def resolve_device_id(monkeypatch, world_size, local_rank=0, device_count=8, ove
 
 
 def test_device_id_skipped_for_single_rank(monkeypatch):
-    # A single-rank job has no peer to connect to, so eager NCCL init buys nothing and only adds
-    # failure surface on platforms that cannot complete it. See #8248.
+    # No peer to connect to, so eager init is pure failure surface. This is the case in #8248.
     assert resolve_device_id(monkeypatch, world_size=1) is None
 
 
@@ -276,15 +273,13 @@ def test_device_id_forced_by_env_for_single_rank(monkeypatch, override):
 
 @pytest.mark.parametrize("override", ["fasle", "banana", "2"])
 def test_unrecognized_env_value_falls_back_to_the_default(monkeypatch, override):
-    # A typo must not pick an answer for the user. Anything unrecognized is ignored, so the
-    # world_size default still decides and a misspelt "false" cannot silently mean "true".
+    # A misspelt "false" must not silently mean "true"; the world_size default still decides.
     assert resolve_device_id(monkeypatch, world_size=1, override=override) is None
     assert resolve_device_id(monkeypatch, world_size=2, override=override) == torch.device('cuda', 0)
 
 
 def test_device_id_skipped_when_local_rank_is_not_visible(monkeypatch):
-    # CUDA_VISIBLE_DEVICES can be narrowed independently of the launcher's rank numbering, and
-    # binding a device that does not exist fails inside NCCL rather than warning.
+    # CUDA_VISIBLE_DEVICES can be narrowed independently of the launcher's rank numbering.
     assert resolve_device_id(monkeypatch, world_size=8, local_rank=3, device_count=1) is None
 
 
@@ -321,9 +316,7 @@ def assert_device_binding(override, expect_bound):
     default_pg = torch.distributed.distributed_c10d._get_default_group()
     assert (default_pg.bound_device_id is not None) == expect_bound
 
-    # The binding is what makes every later new_group() split a communicator off the default one
-    # up front instead of waiting for the first collective. That eager split is the call that
-    # fails in #8248, so check it is only made when a device was bound.
+    # The eager split new_group() makes when a device is bound is the call that fails in #8248.
     device = get_accelerator().device(int(os.environ["LOCAL_RANK"]))
     default_backend = default_pg._get_backend(device)
     if hasattr(default_backend, "comm_split_count"):

--- a/tests/unit/comm/test_dist.py
+++ b/tests/unit/comm/test_dist.py
@@ -264,13 +264,22 @@ def test_device_id_set_for_multi_rank(monkeypatch):
     assert resolve_device_id(monkeypatch, world_size=2, local_rank=1) == torch.device('cuda', 1)
 
 
-@pytest.mark.parametrize("override", ["0", "false", "NO"])
+@pytest.mark.parametrize("override", ["0", "false", "NO", "off", " 0 "])
 def test_device_id_disabled_by_env(monkeypatch, override):
     assert resolve_device_id(monkeypatch, world_size=4, override=override) is None
 
 
-def test_device_id_forced_by_env_for_single_rank(monkeypatch):
-    assert resolve_device_id(monkeypatch, world_size=1, override="1") == torch.device('cuda', 0)
+@pytest.mark.parametrize("override", ["1", "true", "YES", "on"])
+def test_device_id_forced_by_env_for_single_rank(monkeypatch, override):
+    assert resolve_device_id(monkeypatch, world_size=1, override=override) == torch.device('cuda', 0)
+
+
+@pytest.mark.parametrize("override", ["fasle", "banana", "2"])
+def test_unrecognized_env_value_falls_back_to_the_default(monkeypatch, override):
+    # A typo must not pick an answer for the user. Anything unrecognized is ignored, so the
+    # world_size default still decides and a misspelt "false" cannot silently mean "true".
+    assert resolve_device_id(monkeypatch, world_size=1, override=override) is None
+    assert resolve_device_id(monkeypatch, world_size=2, override=override) == torch.device('cuda', 0)
 
 
 def test_device_id_skipped_when_local_rank_is_not_visible(monkeypatch):

--- a/tests/unit/comm/test_dist.py
+++ b/tests/unit/comm/test_dist.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+import importlib
 import os
 import torch
 import deepspeed.comm as dist
@@ -211,3 +212,131 @@ class TestDistInitWithModel(DistributedTest):
                                                   config=config_dict,
                                                   model_parameters=model.parameters(),
                                                   dist_init_required=dist_init_required)
+
+
+# `deepspeed.comm.torch` is shadowed by the real torch module inside the `deepspeed.comm`
+# namespace, so the submodule has to be reached for explicitly.
+ds_comm_torch = importlib.import_module("deepspeed.comm.torch")
+
+# Referred to by name, not through ds_comm_torch, so the end-to-end checks below still run
+# against a DeepSpeed build that predates the constant.
+SET_DEVICE_ID_ENV = "DEEPSPEED_SET_DEVICE_ID"
+
+
+class FakeAccelerator:
+    """Stands in for a real accelerator so the device_id policy can be exercised on any host."""
+
+    def __init__(self, name='cuda', device_count=8):
+        self._name = name
+        self._device_count = device_count
+
+    def device_name(self, device_index=None):
+        if device_index is None:
+            return self._name
+        return f'{self._name}:{device_index}'
+
+    def device_count(self):
+        return self._device_count
+
+    def device(self, device_index=None):
+        return torch.device(self._name, device_index)
+
+
+def resolve_device_id(monkeypatch, world_size, local_rank=0, device_count=8, override=None, name='cuda'):
+    """Run the device_id policy against a pretend host, independent of the real accelerator."""
+    accelerator = FakeAccelerator(name=name, device_count=device_count)
+    monkeypatch.setattr(ds_comm_torch, 'get_accelerator', lambda: accelerator)
+    monkeypatch.setenv('LOCAL_RANK', str(local_rank))
+    monkeypatch.setenv('WORLD_SIZE', str(world_size))
+    monkeypatch.delenv(SET_DEVICE_ID_ENV, raising=False)
+    if override is not None:
+        monkeypatch.setenv(SET_DEVICE_ID_ENV, override)
+    return ds_comm_torch.get_init_process_group_device_id(world_size)
+
+
+def test_device_id_skipped_for_single_rank(monkeypatch):
+    # A single-rank job has no peer to connect to, so eager NCCL init buys nothing and only adds
+    # failure surface on platforms that cannot complete it. See #8248.
+    assert resolve_device_id(monkeypatch, world_size=1) is None
+
+
+def test_device_id_set_for_multi_rank(monkeypatch):
+    assert resolve_device_id(monkeypatch, world_size=2, local_rank=1) == torch.device('cuda', 1)
+
+
+@pytest.mark.parametrize("override", ["0", "false", "NO"])
+def test_device_id_disabled_by_env(monkeypatch, override):
+    assert resolve_device_id(monkeypatch, world_size=4, override=override) is None
+
+
+def test_device_id_forced_by_env_for_single_rank(monkeypatch):
+    assert resolve_device_id(monkeypatch, world_size=1, override="1") == torch.device('cuda', 0)
+
+
+def test_device_id_skipped_when_local_rank_is_not_visible(monkeypatch):
+    # CUDA_VISIBLE_DEVICES can be narrowed independently of the launcher's rank numbering, and
+    # binding a device that does not exist fails inside NCCL rather than warning.
+    assert resolve_device_id(monkeypatch, world_size=8, local_rank=3, device_count=1) is None
+
+
+def test_device_id_skipped_for_non_cuda_accelerator(monkeypatch):
+    assert resolve_device_id(monkeypatch, world_size=2, name='xpu') is None
+
+
+def test_env_var_name_matches_source():
+    assert ds_comm_torch.DS_SET_DEVICE_ID == SET_DEVICE_ID_ENV
+
+
+def test_world_size_read_from_env_when_not_supplied(monkeypatch):
+    monkeypatch.setenv('WORLD_SIZE', '4')
+    assert ds_comm_torch.resolve_world_size(-1) == 4
+
+
+def test_world_size_defaults_to_one_when_unknown(monkeypatch):
+    monkeypatch.delenv('WORLD_SIZE', raising=False)
+    assert ds_comm_torch.resolve_world_size(-1) == 1
+
+
+def assert_device_binding(override, expect_bound):
+    """Initialize the process group under an override and check what the binding does downstream."""
+    if get_accelerator().communication_backend_name() != 'nccl':
+        pytest.skip("device_id is only bound for the nccl backend")
+
+    if override is None:
+        os.environ.pop(SET_DEVICE_ID_ENV, None)
+    else:
+        os.environ[SET_DEVICE_ID_ENV] = override
+
+    deepspeed.init_distributed(dist_backend='nccl', auto_mpi_discovery=False)
+
+    default_pg = torch.distributed.distributed_c10d._get_default_group()
+    assert (default_pg.bound_device_id is not None) == expect_bound
+
+    # The binding is what makes every later new_group() split a communicator off the default one
+    # up front instead of waiting for the first collective. That eager split is the call that
+    # fails in #8248, so check it is only made when a device was bound.
+    device = get_accelerator().device(int(os.environ["LOCAL_RANK"]))
+    default_backend = default_pg._get_backend(device)
+    if hasattr(default_backend, "comm_split_count"):
+        splits_before = default_backend.comm_split_count()
+        torch.distributed.new_group(ranks=list(range(dist.get_world_size())))
+        splits_after = default_backend.comm_split_count()
+        assert (splits_after > splits_before) == expect_bound
+
+
+@pytest.mark.parametrize("override,expect_bound", [(None, False), ("0", False), ("1", True)])
+class TestSingleRankDeviceId(DistributedTest):
+    world_size = 1
+    init_distributed = False
+
+    def test(self, override, expect_bound):
+        assert_device_binding(override, expect_bound)
+
+
+@pytest.mark.parametrize("override,expect_bound", [(None, True), ("0", False)])
+class TestMultiRankDeviceId(DistributedTest):
+    world_size = 2
+    init_distributed = False
+
+    def test(self, override, expect_bound):
+        assert_device_binding(override, expect_bound)


### PR DESCRIPTION
Fixes #8248.

### The change

`init_process_group` now asks a small resolver instead of inlining the condition:

```python
device_id = get_init_process_group_device_id(world_size)
if device_id is not None:
    kwargs.update(device_id=device_id)
```

`DEEPSPEED_SET_DEVICE_ID` overrides the decision, parsed by a new `get_env_flag` helper:

| Value | Effect |
|---|---|
| `1` / `true` / `yes` / `on` | always bind |
| `0` / `false` / `no` / `off` | never bind |
| unset | the default above: bind iff `world_size > 1` |
| anything else | warn and ignore, so the default still decides |

Multi-rank behaviour is unchanged.

### Tests

`tests/unit/comm/test_dist.py`