### PR TITLE
Fix ZeRO-3 crash in AutoTP universal-checkpoint metadata

### DIFF
--- a/deepspeed/module_inject/layers.py
+++ b/deepspeed/module_inject/layers.py
@@ -381,6 +381,18 @@ class TensorParallel_Layer(nn.Module, ABC):
             setattr(weight, DS_TENSOR_MODEL_PARALLEL, True)
             setattr(weight, DS_IS_REPLACED_MODULE, True)
 
+    @staticmethod
+    def _shape_before_zero3_partition(param):
+        """Shape of ``param`` as it was before ZeRO-3 partitioned it.
+
+        ZeRO-3 replaces a partitioned parameter's local data with an empty 1-D
+        tensor, so ``param.shape`` no longer describes the layer and indexing it
+        raises. ZeRO-3 records the pre-partition shape as ``ds_shape``, which is
+        what the universal-checkpoint metadata needs.
+        """
+        ds_shape = getattr(param, 'ds_shape', None)
+        return tuple(param.shape) if ds_shape is None else tuple(ds_shape)
+
     def _set_param_uc_meta(self,
                            param,
                            *,
@@ -704,7 +716,8 @@ class LinearAllreduce(TensorParallel_Layer):
             params_list[idx].data = _partition
 
     def _mark_uc_metadata(self):
-        original_weight_shape = (self.weight.shape[0], self.weight.shape[1] * self.tp_world_size)
+        weight_shape = self._shape_before_zero3_partition(self.weight)
+        original_weight_shape = (weight_shape[0], weight_shape[1] * self.tp_world_size)
         self._set_param_uc_meta(self.weight,
                                 partition_type='row',
                                 partition_dim=1,
@@ -712,12 +725,13 @@ class LinearAllreduce(TensorParallel_Layer):
                                 output_shape=(original_weight_shape[0], ),
                                 original_shape=original_weight_shape)
         if self.bias is not None:
+            bias_shape = self._shape_before_zero3_partition(self.bias)
             self._set_param_uc_meta(self.bias,
                                     partition_type='row',
                                     partition_dim=None,
-                                    logical_shape=tuple(self.bias.shape),
-                                    output_shape=tuple(self.bias.shape),
-                                    original_shape=tuple(self.bias.shape),
+                                    logical_shape=bias_shape,
+                                    output_shape=bias_shape,
+                                    original_shape=bias_shape,
                                     is_bias=True,
                                     replicated=True)
 
@@ -803,8 +817,9 @@ class LinearLayer(TensorParallel_Layer):
             params_list[idx].data = _partition
 
     def _mark_uc_metadata(self):
-        original_out_dim = self.weight.shape[0] * self.tp_world_size
-        original_weight_shape = (original_out_dim, self.weight.shape[1])
+        weight_shape = self._shape_before_zero3_partition(self.weight)
+        original_out_dim = weight_shape[0] * self.tp_world_size
+        original_weight_shape = (original_out_dim, weight_shape[1])
         self._set_param_uc_meta(self.weight,
                                 partition_type='column',
                                 partition_dim=0,
@@ -812,7 +827,7 @@ class LinearLayer(TensorParallel_Layer):
                                 output_shape=(original_out_dim, ),
                                 original_shape=original_weight_shape)
         if self.bias is not None:
-            original_bias_shape = (self.bias.shape[0] * self.tp_world_size, )
+            original_bias_shape = (self._shape_before_zero3_partition(self.bias)[0] * self.tp_world_size, )
             self._set_param_uc_meta(self.bias,
                                     partition_type='column',
                                     partition_dim=0,

--- a/tests/unit/runtime/tensor_parallel/test_autotp_universal_checkpoint.py
+++ b/tests/unit/runtime/tensor_parallel/test_autotp_universal_checkpoint.py
@@ -65,6 +65,45 @@ def test_collect_autotp_universal_checkpoint_info_subparams_preserves_shape_meta
     assert uc_info[PARAMETER_WITH_SUB_PARAMS][0]["shape"] == [(2, 10), 12]
 
 
+def _simulate_zero3_partition(module):
+    """Make ``module``'s parameters look the way ZeRO-3 leaves them.
+
+    ZeRO-3 empties each partitioned parameter's local data and records the
+    pre-partition shape on the parameter as ``ds_shape``.
+    """
+    for param in (module.weight, module.bias):
+        if param is None:
+            continue
+        param.ds_shape = param.shape
+        param.data = torch.empty(0, dtype=param.dtype)
+
+
+def test_column_parallel_uc_metadata_uses_zero3_shape():
+    module = torch.nn.Linear(16, 8, bias=True)
+    _simulate_zero3_partition(module)
+
+    layer = LinearLayer(module, mp_group=None, name="dense")
+
+    weight_meta = getattr(layer.weight, DS_AUTOTP_UC_META)
+    bias_meta = getattr(layer.bias, DS_AUTOTP_UC_META)
+
+    assert tuple(weight_meta["original_shape"]) == (8, 16)
+    assert tuple(bias_meta["original_shape"]) == (8, )
+
+
+def test_row_parallel_uc_metadata_uses_zero3_shape():
+    module = torch.nn.Linear(16, 8, bias=True)
+    _simulate_zero3_partition(module)
+
+    layer = LinearAllreduce(module, mp_group=None, name="proj")
+
+    weight_meta = getattr(layer.weight, DS_AUTOTP_UC_META)
+    bias_meta = getattr(layer.bias, DS_AUTOTP_UC_META)
+
+    assert tuple(weight_meta["original_shape"]) == (8, 16)
+    assert tuple(bias_meta["original_shape"]) == (8, )
+
+
 def test_subparam_layer_marks_standardized_param_metadata():
     layer = SubParamLinearLayer(torch.nn.Linear(12, 12, bias=True),
                                 mp_group=None,


### PR DESCRIPTION
## Problem

`DeepSpeedHybridEngine` cannot be initialized with ZeRO-3. `deepspeed.initialize()` raises before training starts:

```
File "deepspeed/runtime/hybrid_engine.py", line 354, in create_inference_module
  self.create_inference_containers(self.module)
File "deepspeed/runtime/hybrid_engine.py", line 294, in create_inference_containers
  self._other_layers.append(self.inference_policies[child.__class__][0](module=child, ...))
File "deepspeed/module_inject/layers.py", line 739, in __init__
  self._mark_uc_metadata()
File "deepspeed/module_inject/layers.py", line 807, in _mark_uc_metadata
  original_weight_shape = (original_out_dim, self.weight.shape[1])
IndexError: tuple index out of range
```

ZeRO-3 + HybridEngine is the standard DeepSpeed-Chat actor configuration, so this blocks the engine's primary use case.

## Cause

`_mark_uc_metadata()` was added in #7908 (universal checkpoint for AutoTP) and runs unconditionally from `LinearLayer.__init__` / `LinearAllreduce.__init__`. It reads `param.shape[1]` to reconstruct the pre-TP parameter shape.

Under ZeRO-3 a partitioned parameter's local data is an empty 1-D tensor, so that index is out of range. Observed on `facebook/opt-1.3b`, ZeRO-3, single GPU:

```
LinearLayer weight: shape=(0,) numel=0 ds_id=0
                    ds_shape=torch.Size([50272, 2048])
                    ds_status=ZeroParamStatus.NOT_AVAILABLE  tp_world=1
```

HybridEngine constructs a `LinearLayer` for every non-transformer layer (embeddings, `lm_head`, final norm) regardless of TP size, so it hits this path even with `inference_tp_size=1`.

## Fix

Read the pre-partition shape from `ds_shape` instead of the local `.shape`.

ZeRO-3 sets `param.ds_shape = param.shape` in `partition_parameters.py` *before* flattening the parameter's data, so `ds_shape` is exactly the value these call sites were already trying to read. When ZeRO-3 is not in use the attribute is absent and `param.shape` is used, so the existing AutoTP path is unchanged.

The helper lives on `TensorParallel_Layer` and is used by both the column-parallel (`LinearLayer`) and row-parallel (`LinearAllreduce`) implementations, which had the same bug.

`SubParamLinearLayer` / `SubParamLinearAllreduce` take their shapes from precomputed `_logical_shape` / `_orig_weight_shape` attributes rather than indexing `param.shape`, so they are not affected and are left alone.

## Tests

Two regression tests added to `tests/unit/runtime/tensor_parallel/test_autotp_universal_checkpoint.py`, covering both the column-parallel and row-parallel paths. They construct a parameter in the state ZeRO-3 leaves it in and assert the recorded metadata carries the pre-partition shape.

Both fail on master with the exact `IndexError` (at lines 707 and 807) and pass with this change. The 10 existing tests in that file continue to pass.

## Verification

End-to-end RLHF-style loop (`eval()` → `generate()` → `train()` → `forward`/`backward`/`step()`), `facebook/opt-1.3b`, batch 8, 256-token prompt, 128 new tokens, H100:

- **ZeRO-3** — fails on master at `deepspeed.initialize()`; runs to completion with this change (2.63 s/iter steady state).
- **ZeRO-2** — unaffected (796 ms/iter before and after).
