### PR TITLE
Add CUDA graph support for HybridEngine generation

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -519,6 +519,7 @@ class HybridEngineConfig(DeepSpeedConfigModel):
     release_inference_cache: bool = False
     pin_parameters: bool = True
     tp_gather_partition_size: int = 8
+    enable_cuda_graph: bool = False
 
 
 def get_hybrid_engine_config(param_dict):

--- a/deepspeed/runtime/hybrid_engine.py
+++ b/deepspeed/runtime/hybrid_engine.py
@@ -19,6 +19,7 @@ from torch import nn
 from deepspeed.utils import logger
 from deepspeed.module_inject.layers import LinearLayer, Normalize, EmbeddingLayer, OPTEmbedding
 from ..ops.transformer.inference.op_binding.workspace import WorkspaceOp
+from .hybrid_engine_graph import (DecodeGraphCache, decode_steps_from_generate_kwargs, validate_cuda_graph_support)
 
 try:
     import transformers
@@ -61,6 +62,17 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
 
         self.is_lora_fused = False
         self.workspace = WorkspaceOp()
+
+        self._orig_module_forward = None
+        self._decode_graphs = None
+        if self._config.hybrid_engine.enable_cuda_graph and len(self._inference_containers) > 0:
+            unsupported = validate_cuda_graph_support(self._config.hybrid_engine, self._config.zero_config.stage)
+            if unsupported is not None:
+                logger.warning(f"HybridEngine: running without CUDA graphs. {unsupported}.")
+            else:
+                self._orig_module_forward = self.module.forward
+                self._decode_graphs = DecodeGraphCache(self._orig_module_forward,
+                                                       max_positions=self._config.hybrid_engine.max_out_tokens)
 
     def convert_to_linear_transposed(self, model):
 
@@ -172,6 +184,9 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
             self._total_batch_size = bsz * dist.get_world_size()
 
         self._t0 = time.time()
+
+        if self._decode_graphs is not None:
+            self._decode_graphs.begin_sequence(decode_steps_from_generate_kwargs(kwargs))
 
         if self.Z3_enabled and self.gather_all_layers:
             if self._config.hybrid_engine.inference_tp_size > 1:
@@ -414,6 +429,8 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
             if not self.Z3_enabled or self.gather_all_layers:
                 for orig_module, inference_layer in zip(self._orig_modules_others, self._other_layers):
                     orig_module.forward = inference_layer.forward
+        if self._decode_graphs is not None:
+            self.module.forward = self._decode_graphs
         if self.Z3_enabled:
             gc.collect()
             get_accelerator().empty_cache()
@@ -428,6 +445,8 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
                 orig_module.forward = orig_fwd
             for orig_module, orig_fwd in zip(self._orig_modules_others, self._orig_fwds_others):
                 orig_module.forward = orig_fwd
+            if self._decode_graphs is not None:
+                self.module.forward = self._orig_module_forward
         super().train(mode)
         if mode:
             self._training_start_time = time.time()

--- a/deepspeed/runtime/hybrid_engine_graph.py
+++ b/deepspeed/runtime/hybrid_engine_graph.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+"""CUDA graph capture for HybridEngine token generation.
+
+Generation in the HybridEngine is bound by CPU work rather than by the GPU: a
+single decode step issues on the order of a thousand kernel launches, and the
+kernels finish well before the host can queue the next step. Capturing the decode
+forward into a CUDA graph replaces all of those launches with one replay.
+
+Two properties of the inference kernels shape this design.
+
+First, a single graph cannot serve every decode position. The kernels read the
+current sequence length from a host-side counter
+(``InferenceContext::current_tokens()``) and pass it to kernels as a launch
+parameter. Capture freezes launch parameters, so a graph captured at one position
+would keep reading and writing that same position. Host code *does* run during
+capture, so capturing one graph per position records the correct offsets into
+each.
+
+Second, that counter is advanced from host code and is not reachable from Python.
+Replay runs no host code, so it leaves the counter behind. An eager decode step
+after a replay would therefore use a stale sequence length and silently corrupt
+the KV cache. Eager and replayed decode steps must never be mixed within one
+sequence, which is why the decision is made once per sequence, up front, in
+``begin_sequence``.
+"""
+
+import torch
+
+from deepspeed.accelerator import get_accelerator
+from deepspeed.utils import logger
+
+
+def _tensor_kwargs(kwargs):
+    """Names of the keyword arguments that hold a tensor."""
+    return [name for name, value in kwargs.items() if torch.is_tensor(value)]
+
+
+class DecodeGraphCache:
+    """Dispatches generation forwards to a per-position CUDA graph.
+
+    Args:
+        forward: The original ``forward``, used both for capture and as the
+            eager fallback.
+        max_positions: Upper bound on how many decode positions may be captured,
+            which bounds the memory the cache can consume.
+    """
+
+    def __init__(self, forward, max_positions):
+        self._forward = forward
+        self._max_positions = max_positions
+
+        self._graphs = {}
+        self._static_kwargs = {}
+        self._static_outputs = {}
+        self._pool = None
+
+        self._position = 0
+        self._captured_length = None
+        self._use_graphs = False
+        self._disabled = False
+
+    @property
+    def captured_positions(self):
+        return len(self._graphs)
+
+    def invalidate(self):
+        """Drop every captured graph and the memory pool backing them."""
+        self._graphs.clear()
+        self._static_kwargs.clear()
+        self._static_outputs.clear()
+        self._pool = None
+        self._captured_length = None
+
+    def begin_sequence(self, num_decode_steps):
+        """Decide once, before any decode step, whether this sequence uses graphs.
+
+        Args:
+            num_decode_steps: How many single-token forwards this generate call
+                will make, or ``None`` when that is not known ahead of time.
+
+        A sequence runs entirely on graphs or entirely eagerly. Deciding here
+        rather than per step is what keeps the host-side sequence counter
+        consistent: a capture pass advances it on every step, and a replay pass
+        never reads it.
+        """
+        self._position = 0
+
+        if self._disabled or num_decode_steps is None or num_decode_steps <= 0:
+            self._use_graphs = False
+            return
+
+        if num_decode_steps > self._max_positions:
+            self._use_graphs = False
+            return
+
+        # A different generation length needs its own set of graphs, because each
+        # graph has both its sequence offset and its attention-mask width baked in.
+        if self._captured_length is not None and self._captured_length != num_decode_steps:
+            logger.info(f"HybridEngine CUDA graph: generation length changed "
+                        f"{self._captured_length} -> {num_decode_steps}, recapturing.")
+            self.invalidate()
+
+        self._captured_length = num_decode_steps
+        self._use_graphs = True
+
+    def _capture(self, position, args, kwargs):
+        """Record a graph for ``position`` and keep its static input buffers."""
+        static = {name: kwargs[name].clone() for name in _tensor_kwargs(kwargs)}
+        capture_kwargs = dict(kwargs)
+        capture_kwargs.update(static)
+
+        graph = get_accelerator().create_graph()
+        if self._pool is None:
+            with get_accelerator().capture_to_graph(graph):
+                output = self._forward(*args, **capture_kwargs)
+            self._pool = graph.pool()
+        else:
+            with get_accelerator().capture_to_graph(graph, pool=self._pool):
+                output = self._forward(*args, **capture_kwargs)
+
+        self._graphs[position] = graph
+        self._static_kwargs[position] = static
+        self._static_outputs[position] = output
+
+    def _replay(self, position, kwargs):
+        for name, buffer in self._static_kwargs[position].items():
+            buffer.copy_(kwargs[name])
+        get_accelerator().replay_graph(self._graphs[position])
+        return self._static_outputs[position]
+
+    def _shapes_match(self, position, kwargs):
+        captured = self._static_kwargs[position]
+        if set(captured) != set(_tensor_kwargs(kwargs)):
+            return False
+        return all(captured[name].shape == kwargs[name].shape for name in captured)
+
+    def _fall_back(self, reason, args, kwargs):
+        """Give up on graphs for good and run eagerly.
+
+        Only safe before any replay has happened in the current sequence, which
+        is why this is reachable only from the capture path.
+        """
+        logger.warning(f"HybridEngine CUDA graph disabled: {reason}")
+        self.invalidate()
+        self._disabled = True
+        self._use_graphs = False
+        return self._forward(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        input_ids = kwargs.get("input_ids")
+        is_decode_step = (input_ids is not None and input_ids.dim() == 2 and input_ids.shape[1] == 1)
+
+        if not self._use_graphs or not is_decode_step:
+            return self._forward(*args, **kwargs)
+
+        position = self._position
+        self._position += 1
+
+        if position >= self._max_positions:
+            # begin_sequence() bounds the length, so this means the caller ran
+            # longer than it declared. Replays have already happened, so eager
+            # execution would read a stale sequence counter.
+            raise RuntimeError(f"HybridEngine CUDA graph: generation exceeded the declared length "
+                               f"({self._max_positions} decode steps). Set hybrid_engine.max_out_tokens "
+                               f"to cover the longest generation, or disable hybrid_engine.enable_cuda_graph.")
+
+        if position in self._graphs:
+            if self._shapes_match(position, kwargs):
+                return self._replay(position, kwargs)
+            return self._fall_back("input shapes changed mid-sequence", args, kwargs)
+
+        try:
+            self._capture(position, args, kwargs)
+        except Exception as err:
+            return self._fall_back(f"capture failed at position {position}: {err}", args, kwargs)
+
+        # Capture records the work without running it, so the first execution must
+        # come from a replay. That is also what fills the KV cache for this position.
+        return self._replay(position, kwargs)
+
+
+def decode_steps_from_generate_kwargs(kwargs):
+    """How many single-token forwards a generate call will make, if knowable.
+
+    HF emits one prompt forward that produces the first new token, then one
+    forward per remaining token. Only a pinned length is usable here: with an
+    open-ended limit the sequence may stop early, and a sequence that runs
+    *longer* than its captured graphs cannot fall back safely.
+    """
+    max_new = kwargs.get("max_new_tokens")
+    min_new = kwargs.get("min_new_tokens")
+    if max_new is None or min_new is None or max_new != min_new:
+        return None
+    return int(max_new) - 1
+
+
+def validate_cuda_graph_support(config, zero_stage):
+    """Return the reason CUDA graphs cannot be used, or ``None`` if they can."""
+    if not get_accelerator().is_available() or get_accelerator().device_name() != "cuda":
+        return "CUDA graphs require the CUDA accelerator"
+
+    if zero_stage == 3:
+        # Under ZeRO-3 the inference containers hold no persistent weights; the
+        # parameters are gathered into fresh buffers for each generate call. A
+        # graph would keep replaying whichever buffers existed at capture time,
+        # which is silently wrong rather than merely slow.
+        return "CUDA graphs are not supported with ZeRO stage 3"
+
+    if config.release_inference_cache:
+        # Releasing the workspace frees the buffers the graphs write into.
+        return "CUDA graphs are not supported with release_inference_cache"
+
+    if config.inference_tp_size > 1:
+        return "CUDA graphs are not supported with inference_tp_size > 1"
+
+    return None

--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -876,6 +876,36 @@ When a HuggingFace model provides a built-in `tp_plan` (via `model.config.base_m
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | Unused parameters in modules may be unexpected in static networks, but could be normal in dynamic networks. This controls whether or not training should terminate with an error message when unused parameters are detected. This is set to `True` by default, which means unused parameters are ignored and training continues. Now is just used in stage 2. | `True`  |
 
+### Hybrid Engine
+
+The Hybrid Engine (`DeepSpeedHybridEngine`) switches a model between training mode and DeepSpeed's inference kernels within a single training loop, which is what RLHF pipelines such as DeepSpeed-Chat use for the actor model.
+
+```json
+  "hybrid_engine": {
+    "enabled": true,
+    "max_out_tokens": 512,
+    "inference_tp_size": 1,
+    "release_inference_cache": false,
+    "pin_parameters": true,
+    "tp_gather_partition_size": 8,
+    "enable_cuda_graph": false
+  }
+```
+
+***enable_cuda_graph***: [boolean]
+
+| Description                                                                                                                                                                                                                                                                                                                                        | Default |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Capture token generation into CUDA graphs. Generation issues on the order of a thousand kernel launches per token and is bound by CPU launch overhead rather than by the GPU, so replaying a captured graph removes most of the per-token cost. One graph is captured per decode position, and generated tokens are unchanged. | `false` |
+
+`enable_cuda_graph` requires a pinned generation length (`min_new_tokens` equal to `max_new_tokens`) and `max_out_tokens` large enough to cover the longest generation. It is ignored, with a warning, when any of the following apply, since captured graphs would not stay valid:
+
+* ZeRO stage 3, where parameters are gathered into fresh buffers for each generation
+* `release_inference_cache: true`, which frees the buffers the graphs write into
+* `inference_tp_size` greater than 1
+
+The first generation after enabling captures one graph per decode position and is therefore slower; subsequent generations replay them.
+
 ### Expert Parallel (AutoEP)
 Configure AutoEP expert parallelism for MoE models. AutoEP automatically detects MoE layers in HuggingFace models and replaces them with EP-enabled versions using TorchTitan's grouped GEMM kernels. Requires zero model code changes. Supports ZeRO stages 0, 1, 2, and constrained ZeRO Stage 3.
 ```json

--- a/tests/unit/hybrid_engine/test_he_cuda_graph.py
+++ b/tests/unit/hybrid_engine/test_he_cuda_graph.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+
+import os
+import pytest
+import torch
+import deepspeed
+from deepspeed.accelerator import get_accelerator
+from deepspeed.ops.op_builder import InferenceBuilder, OpBuilder
+from deepspeed.runtime.hybrid_engine_graph import (DecodeGraphCache, decode_steps_from_generate_kwargs,
+                                                   validate_cuda_graph_support)
+from unit.common import DistributedTest
+
+# ---------------------------------------------------------------------------
+# Pure-logic tests: no accelerator or model needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kwargs,expected", [
+    ({
+        "max_new_tokens": 32,
+        "min_new_tokens": 32
+    }, 31),
+    ({
+        "max_new_tokens": 1,
+        "min_new_tokens": 1
+    }, 0),
+    ({
+        "max_new_tokens": 32
+    }, None),
+    ({
+        "max_new_tokens": 32,
+        "min_new_tokens": 8
+    }, None),
+    ({
+        "max_length": 64
+    }, None),
+    ({}, None),
+])
+def test_decode_steps_only_for_pinned_length(kwargs, expected):
+    # An open-ended length is unusable: a sequence that outruns its captured
+    # graphs cannot fall back to eager without a stale sequence counter.
+    assert decode_steps_from_generate_kwargs(kwargs) == expected
+
+
+class _StubConfig:
+
+    def __init__(self, release_inference_cache=False, inference_tp_size=1):
+        self.release_inference_cache = release_inference_cache
+        self.inference_tp_size = inference_tp_size
+
+
+def test_validate_rejects_zero3():
+    assert "ZeRO stage 3" in validate_cuda_graph_support(_StubConfig(), zero_stage=3)
+
+
+def test_validate_rejects_released_cache():
+    reason = validate_cuda_graph_support(_StubConfig(release_inference_cache=True), zero_stage=2)
+    assert reason is not None
+
+
+def test_validate_rejects_inference_tp():
+    reason = validate_cuda_graph_support(_StubConfig(inference_tp_size=2), zero_stage=2)
+    assert reason is not None
+
+
+class _CountingForward:
+    """Stands in for the wrapped module forward."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        return "eager"
+
+
+def _decode_kwargs():
+    return {"input_ids": torch.zeros((2, 1), dtype=torch.long)}
+
+
+def test_unknown_length_runs_eager():
+    forward = _CountingForward()
+    cache = DecodeGraphCache(forward, max_positions=8)
+    cache.begin_sequence(None)
+
+    assert cache(**_decode_kwargs()) == "eager"
+    assert cache.captured_positions == 0
+    assert forward.calls == 1
+
+
+def test_length_beyond_max_positions_runs_eager():
+    forward = _CountingForward()
+    cache = DecodeGraphCache(forward, max_positions=4)
+    cache.begin_sequence(16)
+
+    assert cache(**_decode_kwargs()) == "eager"
+    assert forward.calls == 1
+
+
+def test_prompt_forward_never_uses_graphs():
+    forward = _CountingForward()
+    cache = DecodeGraphCache(forward, max_positions=8)
+    cache.begin_sequence(4)
+
+    prompt = {"input_ids": torch.zeros((2, 16), dtype=torch.long)}
+    assert cache(**prompt) == "eager"
+    assert cache.captured_positions == 0
+
+
+def test_changing_generation_length_invalidates_graphs():
+    cache = DecodeGraphCache(_CountingForward(), max_positions=64)
+    cache.begin_sequence(8)
+    # Populate the cache the way a capture pass would, without touching CUDA.
+    cache._graphs[0] = object()
+    cache._static_kwargs[0] = {}
+    cache._static_outputs[0] = object()
+
+    cache.begin_sequence(8)
+    assert cache.captured_positions == 1, "same length must reuse captured graphs"
+
+    cache.begin_sequence(16)
+    assert cache.captured_positions == 0, "new length must discard stale graphs"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end equivalence: needs a GPU and the inference kernels
+# ---------------------------------------------------------------------------
+
+if not deepspeed.ops.__compatible_ops__[InferenceBuilder.NAME]:
+    pytest.skip("This op had not been implemented on this system.", allow_module_level=True)
+
+if OpBuilder.installed_rocm_version() != (0, 0):
+    pytest.skip("skip inference tests on rocm for now", allow_module_level=True)
+
+
+@pytest.mark.seq_inference
+class TestHybridEngineCudaGraphEquivalence(DistributedTest):
+    world_size = 1
+
+    def test_graph_generation_matches_eager(self):
+        from transformers import AutoModelForCausalLM
+
+        model_name = "facebook/opt-125m"
+        prompt_len, gen_len, bsz = 32, 16, 2
+        local_rank = int(os.getenv("LOCAL_RANK", "0"))
+        device = f"{get_accelerator().device_name()}:{local_rank}"
+
+        config = {
+            "train_batch_size": bsz,
+            "train_micro_batch_size_per_gpu": bsz,
+            "steps_per_print": 10**9,
+            "zero_optimization": {
+                "stage": 2
+            },
+            "fp16": {
+                "enabled": True
+            },
+            "hybrid_engine": {
+                "enabled": True,
+                "max_out_tokens": prompt_len + gen_len,
+                "enable_cuda_graph": True,
+            },
+            "optimizer": {
+                "type": "AdamW",
+                "params": {
+                    "lr": 1e-7
+                }
+            },
+        }
+
+        model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.half)
+        model.config.use_cache = True
+        engine, *_ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+        assert engine._decode_graphs is not None, "CUDA graphs should be active for this config"
+
+        torch.manual_seed(0)
+        input_ids = torch.randint(100, 1000, (bsz, prompt_len), device=device)
+        gen_kwargs = dict(input_ids=input_ids,
+                          attention_mask=torch.ones_like(input_ids),
+                          max_new_tokens=gen_len,
+                          min_new_tokens=gen_len,
+                          do_sample=False,
+                          pad_token_id=1,
+                          synced_gpus=False)
+
+        engine.eval()
+        with torch.no_grad():
+            graphed = engine.generate(**gen_kwargs).clone()
+        assert engine._decode_graphs.captured_positions == gen_len - 1
+
+        # Detach the graph dispatcher and repeat the same generation eagerly.
+        engine.module.forward = engine._orig_module_forward
+        engine._decode_graphs = None
+        with torch.no_grad():
+            eager = engine.generate(**gen_kwargs).clone()
+
+        assert torch.equal(graphed, eager), "CUDA graph generation diverged from eager generation"


### PR DESCRIPTION
## Motivation

Token generation dominates a HybridEngine RLHF iteration, and it is bound by CPU work rather than by the GPU.

Measured on `facebook/opt-1.3b`, ZeRO-2, single H100, 256-token prompt, 128 new tokens:

| batch | ms / decode step | tok/s |
| ----: | ---------------: | ----: |
| 1     | 5.00             | 200   |
| 4     | 5.10             | 785   |
| 8     | 5.17             | 1549  |
| 16    | 5.58             | 2865  |
| 32    | 5.37             | 5956  |

32× the batch costs 1.07× the latency. The GPU is idle waiting on the host. A single decode step issues roughly 1300 kernel launches, and of the 5.22 ms step, 4.52 ms is the model forward while summed kernel time is only ~2.75 ms.

Replaying a captured CUDA graph replaces those launches with one call.

## Design

Adds an opt-in `hybrid_engine.enable_cuda_graph` flag. Two properties of the inference kernels shape the design.

**One graph per decode position.** The kernels read the current sequence length from a host-side counter (`InferenceContext::current_tokens()` in `csrc/transformer/inference/csrc/pt_binding.cpp`) and pass it to kernels as a launch parameter. Capture freezes launch parameters, so a single graph would keep reading and writing one position forever. Host code *does* run during capture, so capturing one graph per position records the correct sequence offsets into each.

**All-or-nothing per sequence.** That counter is advanced from host code (`advance_tokens()`) and is not exposed to Python. Replay runs no host code, so it leaves the counter behind, and an eager decode step after a replay would use a stale sequence length and corrupt the KV cache. Eager and replayed steps therefore must never be mixed within a sequence. `begin_sequence()` makes the decision once, up front, from the pinned generation length, before any decode step runs.

Capture is followed immediately by a replay, since capture records work without executing it; the replay is what actually fills the KV cache for that position.

## Safety

Graphs are refused, with a warning, wherever captured pointers would not stay valid:

* **ZeRO stage 3** — parameters are gathered into fresh buffers for each generate call, and the inference containers hold no persistent weights (`attn_qkvw is None`). A graph would replay whichever buffers existed at capture time, which is silently wrong rather than merely slow.
* **`release_inference_cache`** — frees the workspace buffers the graphs write into.
* **`inference_tp_size > 1`** — untested here.
* **Unpinned generation length** — a sequence that outruns its captured graphs cannot fall back to eager safely, so graphs engage only when `min_new_tokens == max_new_tokens`.

Capture failures fall back to eager execution and disable graphs, rather than failing the training job.

Weight updates were verified explicitly: `reset_params()` writes into the same inference buffers in place, so the captured pointers stay valid across optimizer steps. After a step that moved the logits by 11.75, replay matched a fresh eager forward to within 0.09 and differed from the pre-step result by the full 11.75 — i.e. graphs track updated weights rather than replaying stale ones.

## Results

`facebook/opt-1.3b`, ZeRO-2, batch 8, 256-token prompt, 128 new tokens, single H100, averaged over 4 measured iterations of an RLHF-style loop (`eval` → `generate` → `train` → forward/backward/step):

| phase       | eager    | CUDA graph | speedup |
| ----------- | -------- | ---------- | ------- |
| generate    | 676.7 ms | 360.8 ms   | 1.88×   |
| train step  | 134.8 ms | 141.0 ms   | 0.97×   |
| **iteration** | **812.8 ms** | **503.5 ms** | **1.61×** |

* **Generated tokens are unchanged**: 1024/1024 token agreement with the eager path, all 8 sequences identical end to end.
* **Peak memory**: 27.83 → 27.96 GiB (+132 MiB for 127 captured positions).
* **One-time capture cost**: the first generation captures the graphs and takes ~12 s; every later generation replays.

## Tests

`tests/unit/hybrid_engine/test_he_cuda_graph.py`:

* 13 CPU-only tests covering the generation-length gate, the ZeRO-3 / `release_inference_cache` / `inference_tp_size` rejections, and the dispatch state machine (unknown length, over-long length, prompt forwards, and invalidation when the generation length changes).
* One GPU end-to-end test (`seq_inference` marker, `opt-125m`) asserting that a graphed generation is token-identical to the same generation run eagerly.

Docs: a Hybrid Engine section added to `docs/_pages/config-json.md`, covering the config block and the new flag's requirements and restrictions.

## Scope

Default is off, so nothing changes unless the flag is set; the eager path measured identically before and after this change (676.7 ms generate both ways). Only ZeRO-2 with `inference_tp_size=1` was benchmarked, which is what the guards allow.
