### PR TITLE
Reject invalid ZenFlow ratio and update interval boundaries

### DIFF
--- a/deepspeed/runtime/zenflow/zenflow_config.py
+++ b/deepspeed/runtime/zenflow/zenflow_config.py
@@ -60,6 +60,9 @@ class ZenFlowConfig(DeepSpeedConfigModel):
         if isinstance(self.update_interval, str) and self.update_interval != "auto":
             raise ValueError('If update_interval is a string, it must be "auto"')
 
+        if isinstance(self.update_interval, int) and self.update_interval < 1:
+            raise ValueError("If update_interval is a number, it must be at least 1")
+
         if not isinstance(self.full_warm_up_rounds, int):
             raise ValueError('full_warm_up_rounds must be an integer')
 

--- a/deepspeed/runtime/zenflow/zenflow_config.py
+++ b/deepspeed/runtime/zenflow/zenflow_config.py
@@ -12,8 +12,8 @@ from deepspeed.runtime.config_utils import DeepSpeedConfigModel
 class ZenFlowConfig(DeepSpeedConfigModel):
     """Configuration options for ZenFlow optimization module."""
 
-    topk_ratio: float = Field(0.1, ge=0.0, le=1.0)
-    """Ratio of top-k important gradient columns to retain (range: 0.0 to 1.0)."""
+    topk_ratio: float = Field(0.1, gt=0.0, lt=1.0)
+    """Ratio of top-k important gradient columns to retain (must be greater than 0.0 and less than 1.0)."""
 
     select_strategy: str = "auto"
     """Strategy for selecting important gradient indices.

--- a/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
+++ b/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
@@ -44,6 +44,12 @@ SELECTIVE_OPTIMIZER_TIMERS = [
 ]
 
 
+def _num_selected_columns(num_columns, topk_ratio):
+    if num_columns == 0:
+        return 0
+    return max(1, int(num_columns * topk_ratio))
+
+
 class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
 
     def __init__(
@@ -211,7 +217,7 @@ class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
                 num_row, num_col = param.shape if len(param.shape) == 2 else (1, param.shape[0])
                 start_column = 0 if not offset else int((offset - 1) / num_row) + 1
                 end_column = int((offset + numel) / num_row)
-                num_select = int(self.topk_ratio * (end_column - start_column))
+                num_select = _num_selected_columns(end_column - start_column, self.topk_ratio)
 
                 if partition_id == rank:
 
@@ -320,7 +326,10 @@ class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
                 num_row, num_col = param.shape if len(param.shape) == 2 else (1, param.shape[0])
                 start_column = 0 if not offset else int((offset - 1) / num_row) + 1
                 end_column = int((offset + numel) / num_row)
-                num_select = int(self.topk_ratio * (end_column - start_column)) if len(param.shape) == 2 else numel
+                if len(param.shape) == 2:
+                    num_select = _num_selected_columns(end_column - start_column, self.topk_ratio)
+                else:
+                    num_select = numel
                 grad_size = num_select * num_row
 
                 if partition_id == rank:
@@ -482,8 +491,7 @@ class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
                     partition_ids_w_offsets.append((partition_id, offset))
                 partition_ids_w_offsets.sort(key=lambda t: t[1])
 
-                num_row, num_col = param.shape if len(param.shape) == 2 else (1, param.shape[0])
-                curr_column_size += int(num_col * self.topk_ratio) if num_row != 1 else 0
+                num_row, _ = param.shape if len(param.shape) == 2 else (1, param.shape[0])
 
                 # Calculate rank and offsets for grad slices
                 for idx in range(len(partition_ids_w_offsets)):
@@ -497,6 +505,15 @@ class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
                         # Set numel to next partition's offset
                         numel = partition_ids_w_offsets[idx + 1][1] - offset
 
+                    if len(param.shape) == 2:
+                        start_column = 0 if not offset else int((offset - 1) / num_row) + 1
+                        end_column = int((offset + numel) / num_row)
+                        num_select = _num_selected_columns(end_column - start_column, self.topk_ratio)
+                        curr_column_size += num_select
+                        curr_selected_reduce_size += num_select * num_row
+                    else:
+                        curr_selected_reduce_size += numel
+
                     # Merge bucket ranges if they belong to the same rank
                     if partition_id == prev_id and process_group == prev_process_group:
                         prev_pid, prev_size, prev_numel = rank_and_offsets[-1]
@@ -505,7 +522,6 @@ class ZenFlowZeroOptimizer(DeepSpeedZeroOptimizer):
                         rank_and_offsets.append((partition_id, curr_size, numel))
                         real_dp_process_group.append(process_group)
                     curr_size += numel
-                    curr_selected_reduce_size += int(numel * self.topk_ratio) if num_row != 1 else numel
 
                     prev_id, prev_process_group = partition_id, process_group
 

--- a/tests/unit/runtime/zenflow/test_zf.py
+++ b/tests/unit/runtime/zenflow/test_zf.py
@@ -6,10 +6,20 @@
 import pytest
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
+from deepspeed.runtime.zenflow.zenflow_stage_1_and_2 import _num_selected_columns
 
 from unit.common import DistributedTest
 from unit.simple_model import SimpleModel, random_dataloader
 import deepspeed
+
+
+@pytest.mark.parametrize("num_columns,topk_ratio,expected", [
+    (0, 0.01, 0),
+    (50, 0.01, 1),
+    (200, 0.01, 2),
+])
+def test_num_selected_columns_has_nonzero_floor(num_columns, topk_ratio, expected):
+    assert _num_selected_columns(num_columns, topk_ratio) == expected
 
 
 class BaseZenFlowTest:

--- a/tests/unit/runtime/zenflow/test_zf.py
+++ b/tests/unit/runtime/zenflow/test_zf.py
@@ -27,8 +27,14 @@ class BaseZenFlowTest:
     batch_size = 4
     grad_acc_steps = 1
 
-    def get_config_dict(self, stage, offload_selective_optimizer, select_strategy, select_interval, update_interval,
-                        full_warm_up_rounds):
+    def get_config_dict(self,
+                        stage,
+                        offload_selective_optimizer,
+                        select_strategy,
+                        select_interval,
+                        update_interval,
+                        full_warm_up_rounds,
+                        topk_ratio=0.2):
         config = {
             "train_batch_size": self.batch_size,
             "gradient_accumulation_steps": self.grad_acc_steps,
@@ -46,7 +52,7 @@ class BaseZenFlowTest:
                 },
                 "overlap_comm": True,
                 "zenflow": {
-                    "topk_ratio": 0.2,
+                    "topk_ratio": topk_ratio,
                     "select_strategy": select_strategy,
                     "select_interval": select_interval,
                     "update_interval": update_interval,
@@ -118,6 +124,16 @@ class TestZenFlowDistributed(DistributedTest, BaseZenFlowTest):
                                  update_interval, full_warm_up_rounds):
         config_dict = self.get_config_dict(stage, offload_selective_optimizer, select_strategy, select_interval,
                                            update_interval, full_warm_up_rounds)
+        self.run_training_distributed(config_dict)
+
+
+@pytest.mark.parametrize("stage", [1, 2])
+class TestZenFlowSmallTopKRatio(DistributedTest, BaseZenFlowTest):
+    world_size = 2
+    hidden_dim = 50
+
+    def test_small_positive_topk_ratio(self, stage):
+        config_dict = self.get_config_dict(stage, False, "step", 1, 1, 0, topk_ratio=0.01)
         self.run_training_distributed(config_dict)
 
 

--- a/tests/unit/runtime/zenflow/test_zf_config.py
+++ b/tests/unit/runtime/zenflow/test_zf_config.py
@@ -59,6 +59,12 @@ def test_invalid_zenflow_type_raises():
         DeepSpeedZeroConfig(zenflow=123)
 
 
+@pytest.mark.parametrize("topk_ratio", [0.0, 1.0])
+def test_topk_ratio_excludes_endpoints(topk_ratio):
+    with pytest.raises(ValidationError):
+        ZenFlowConfig(topk_ratio=topk_ratio)
+
+
 def test_offload_and_zenflow_combined():
     """
     offload_optimizer and zenflow can be used together under stage 2

--- a/tests/unit/runtime/zenflow/test_zf_config.py
+++ b/tests/unit/runtime/zenflow/test_zf_config.py
@@ -65,6 +65,12 @@ def test_topk_ratio_excludes_endpoints(topk_ratio):
         ZenFlowConfig(topk_ratio=topk_ratio)
 
 
+@pytest.mark.parametrize("update_interval", [0, -5])
+def test_update_interval_rejects_non_positive_values(update_interval):
+    with pytest.raises(ValidationError):
+        ZenFlowConfig(update_interval=update_interval)
+
+
 def test_offload_and_zenflow_combined():
     """
     offload_optimizer and zenflow can be used together under stage 2

--- a/tests/unit/runtime/zenflow/test_zf_config.py
+++ b/tests/unit/runtime/zenflow/test_zf_config.py
@@ -71,6 +71,13 @@ def test_update_interval_rejects_non_positive_values(update_interval):
         ZenFlowConfig(update_interval=update_interval)
 
 
+@pytest.mark.parametrize("update_interval", [1, "auto"])
+def test_update_interval_accepts_valid_boundary_values(update_interval):
+    config = ZenFlowConfig(update_interval=update_interval)
+
+    assert config.update_interval == update_interval
+
+
 def test_offload_and_zenflow_combined():
     """
     offload_optimizer and zenflow can be used together under stage 2


### PR DESCRIPTION
## Summary

- require `zenflow.topk_ratio` to be strictly between 0 and 1
- require numeric `zenflow.update_interval` values to be at least 1
- add regression coverage for the invalid ratio endpoints and non-positive update intervals

## Why

ZenFlow's automatic update path normalizes selected gradients by `topk_ratio` and unselected gradients by `1 - topk_ratio`. The explicit update path selects its overlap buffer using `micro_step // update_interval`.

The previous validation accepted ratio endpoints as well as zero and negative numeric update intervals. These values could therefore trigger division by zero or invalid scheduling after training had already initialized. Rejecting them during configuration parsing provides an immediate validation error while preserving all usable configurations.

## Testing

- `python -m pytest -q tests/unit/runtime/zero/test_zero_config.py tests/unit/runtime/zenflow/test_zf_config.py tests/unit/runtime/zenflow/test_zf.py::test_split_affinity` — 21 passed
- `pre-commit run --files deepspeed/runtime/zenflow/zenflow_config.py tests/unit/runtime/zenflow/test_zf_config.py`
