### PR TITLE
Add Google TPU accelerator backend via torch_xla (initial scaffolding)

### DIFF
--- a/accelerator/real_accelerator.py
+++ b/accelerator/real_accelerator.py
@@ -20,7 +20,7 @@ try:
 except ImportError as e:
     dsa2 = None
 
-SUPPORTED_ACCELERATOR_LIST = ['cuda', 'cpu', 'xpu', 'npu', 'mps', 'hpu', 'mlu', 'sdaa', 'supa']
+SUPPORTED_ACCELERATOR_LIST = ['cuda', 'cpu', 'xpu', 'npu', 'mps', 'hpu', 'mlu', 'sdaa', 'supa', 'tpu']
 
 ds_accelerator = None
 
@@ -103,6 +103,11 @@ def get_accelerator():
                 import torch_supa  # noqa: F401 # type: ignore
             except ImportError as e:
                 raise ValueError("SUPA_Accelerator requires torch_supa, which is not installed on this system.")
+        elif accelerator_name == "tpu":
+            try:
+                import torch_xla  # noqa: F401 # type: ignore
+            except ImportError as e:
+                raise ValueError("TPU_Accelerator requires torch_xla, which is not installed on this system.")
         elif accelerator_name not in SUPPORTED_ACCELERATOR_LIST:
             raise ValueError(f'DS_ACCELERATOR must be one of {SUPPORTED_ACCELERATOR_LIST}. '
                              f'Value "{accelerator_name}" is not supported')
@@ -180,6 +185,15 @@ def get_accelerator():
                 pass
         if accelerator_name is None:
             try:
+                # Detect Google TPU. torch_xla is only importable on a machine
+                # with an XLA/TPU runtime, so treat a successful import as TPU.
+                import torch_xla  # noqa: F401,F811 # type: ignore
+
+                accelerator_name = "tpu"
+            except ImportError as e:
+                pass
+        if accelerator_name is None:
+            try:
                 import torch
 
                 # Determine if we are on a GPU or x86 CPU with torch.
@@ -240,6 +254,10 @@ def get_accelerator():
         from .supa_accelerator import SUPA_Accelerator
 
         ds_accelerator = SUPA_Accelerator()
+    elif accelerator_name == 'tpu':
+        from .tpu_accelerator import TPU_Accelerator
+
+        ds_accelerator = TPU_Accelerator()
     _validate_accelerator(ds_accelerator)
     if accel_logger is not None:
         accel_logger.info(f"Setting ds_accelerator to {ds_accelerator._name} ({ds_set_method})")

--- a/accelerator/tpu_accelerator.py
+++ b/accelerator/tpu_accelerator.py
@@ -1,0 +1,329 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import os
+import pkgutil
+import importlib
+
+import torch
+
+from .abstract_accelerator import DeepSpeedAccelerator
+
+# During setup stage torch_xla may not be installed, so guard the import and let
+# op-builder related APIs still be importable without a TPU runtime present.
+try:
+    import torch_xla
+    import torch_xla.core.xla_model as xm
+except ImportError:
+    torch_xla = None
+    xm = None
+
+
+class TPU_Accelerator(DeepSpeedAccelerator):
+    """Google Cloud TPU backend, driven through PyTorch/XLA (torch_xla).
+
+    TPUs are lazy, graph-compiled, asynchronous devices: XLA owns memory,
+    collectives run through torch_xla, and device work is committed by
+    xm.mark_step(). Several eager/CUDA-oriented hooks are therefore stubbed out
+    the same way MPS/HPU stub theirs, and will be refined once validated on real
+    TPU hardware.
+    """
+
+    def __init__(self):
+        self._name = 'tpu'
+        # XLA registers an 'xla' process-group backend with the torch distributed
+        # layer, so the default TorchBackend path can drive TPU collectives.
+        self._communication_backend_name = 'xla'
+        # torch_xla's TorchDynamo backend.
+        self._compile_backend = "openxla"
+        if torch_xla is None:
+            raise ValueError("TPU_Accelerator requires torch_xla, which is not installed on this system.")
+        self.xm = xm
+
+    def is_synchronized_device(self):
+        # XLA execution is asynchronous/lazy.
+        return False
+
+    def use_host_timers(self):
+        # No device-side event timers on XLA; fall back to host timers.
+        return True
+
+    def resolves_data_dependency(self):
+        return self.is_synchronized_device()
+
+    def handles_memory_backpressure(self):
+        return self.is_synchronized_device()
+
+    # Device APIs
+    def device_name(self, device_index=None):
+        if device_index is None:
+            return 'xla'
+        return 'xla:{}'.format(device_index)
+
+    def device(self, device_index=None):
+        return self.xm.xla_device(device_index)
+
+    def set_device(self, device_index):
+        # XLA selects the device per-process; there is no global set_device.
+        return
+
+    def current_device(self):
+        return self.xm.get_local_ordinal()
+
+    def current_device_name(self):
+        return str(self.xm.xla_device())
+
+    def device_count(self):
+        return len(self.xm.get_xla_supported_devices())
+
+    def synchronize(self, device_index=None):
+        # Block until all pending XLA device operations have completed.
+        return self.xm.wait_device_ops()
+
+    # RNG APIs
+    def random(self):
+        return torch.random
+
+    def set_rng_state(self, new_state, device_index=None):
+        return self.xm.set_rng_state(new_state, device=self.device(device_index))
+
+    def get_rng_state(self, device_index=None):
+        return self.xm.get_rng_state(device=self.device(device_index))
+
+    def manual_seed(self, seed):
+        return self.xm.set_rng_state(seed)
+
+    def manual_seed_all(self, seed):
+        return self.xm.set_rng_state(seed)
+
+    def initial_seed(self):
+        return
+
+    def default_generator(self, device_index):
+        return
+
+    # Streams/Events
+    @property
+    def Stream(self):
+        return None
+
+    def stream(self, stream):
+        return None
+
+    def current_stream(self, device_index=None):
+        return None
+
+    def default_stream(self, device_index=None):
+        return None
+
+    @property
+    def Event(self):
+        return None
+
+    # Memory management
+    # XLA manages device memory itself; detailed accounting can be wired to
+    # xm.get_memory_info() once confirmed on hardware. Stubbed like MPS for now.
+    def empty_cache(self):
+        return
+
+    def memory_allocated(self, device_index=None):
+        return
+
+    def max_memory_allocated(self, device_index=None):
+        return
+
+    def reset_max_memory_allocated(self, device_index=None):
+        return
+
+    def memory_cached(self, device_index=None):
+        return
+
+    def max_memory_cached(self, device_index=None):
+        return
+
+    def reset_max_memory_cached(self, device_index=None):
+        return
+
+    def memory_stats(self, device_index=None):
+        return
+
+    def reset_peak_memory_stats(self, device_index=None):
+        return
+
+    def memory_reserved(self, device_index=None):
+        return
+
+    def max_memory_reserved(self, device_index=None):
+        return
+
+    def total_memory(self, device_index=None):
+        return
+
+    def available_memory(self, device_index=None):
+        return
+
+    # Data types
+    def is_bf16_supported(self):
+        # bfloat16 is the native TPU compute dtype.
+        return True
+
+    def is_fp16_supported(self):
+        # TPUs have no native float16.
+        return False
+
+    def supported_dtypes(self):
+        return [torch.float, torch.bfloat16]
+
+    # Misc
+    def is_available(self):
+        if torch_xla is None:
+            return False
+        try:
+            return len(self.xm.get_xla_supported_devices()) > 0
+        except Exception:
+            return False
+
+    def range_push(self, msg, domain=None, category=None):
+        return
+
+    def range_pop(self, domain=None):
+        return
+
+    def lazy_call(self, callback):
+        return callback()
+
+    def communication_backend_name(self):
+        return self._communication_backend_name
+
+    def is_triton_supported(self):
+        return False
+
+    # Graph operations
+    def create_graph(self):
+        return None
+
+    def capture_to_graph(self, graph, pool=None, stream=None):
+        from deepspeed.runtime.utils import noop_context
+        return noop_context()
+
+    def replay_graph(self, graph):
+        return
+
+    # Tensor operations
+    @property
+    def BFloat16Tensor(self):
+        return
+
+    @property
+    def ByteTensor(self):
+        return
+
+    @property
+    def DoubleTensor(self):
+        return
+
+    @property
+    def FloatTensor(self):
+        return
+
+    @property
+    def HalfTensor(self):
+        return
+
+    @property
+    def IntTensor(self):
+        return
+
+    @property
+    def LongTensor(self):
+        return
+
+    def is_pinned(self, tensor):
+        return tensor.is_pinned()
+
+    def on_accelerator(self, tensor):
+        device_str = str(tensor.device)
+        if device_str.startswith('xla'):
+            return True
+        else:
+            return False
+
+    def op_builder_dir(self):
+        try:
+            # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
+            # if successful this also means we're doing a local install and not JIT compile path
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+            return "op_builder.tpu"
+        except ImportError:
+            return "deepspeed.ops.op_builder.tpu"
+
+    # dict that holds class name <--> class type mapping i.e.
+    # 'NotImplementedBuilder': <class 'op_builder.tpu.no_impl.NotImplementedBuilder'>
+    # this dict will be filled at init stage
+    class_dict = None
+
+    def _lazy_init_class_dict(self):
+        if self.class_dict is not None:
+            return
+        else:
+            self.class_dict = {}
+            # begin initialize for create_op_builder()
+            # put all valid class name <--> class type mapping into class_dict
+            op_builder_dir = self.op_builder_dir()
+            op_builder_module = importlib.import_module(op_builder_dir)
+            op_builder_absolute_path = os.path.dirname(op_builder_module.__file__)
+            for _, module_name, _ in pkgutil.iter_modules([op_builder_absolute_path]):
+                # avoid self references,
+                # skip sub_directories which contains ops for other backend(cpu, npu, etc.).
+                if module_name != 'all_ops' and module_name != 'builder' and not os.path.isdir(
+                        os.path.join(op_builder_absolute_path, module_name)):
+                    module = importlib.import_module("{}.{}".format(op_builder_dir, module_name))
+                    for member_name in module.__dir__():
+                        if member_name.endswith('Builder') and member_name != "OpBuilder" \
+                                and member_name != "CPUOpBuilder" and member_name != "TPUOpBuilder":  # avoid abstract classes
+                            if not member_name in self.class_dict:
+                                self.class_dict[member_name] = getattr(module, member_name)
+            # end initialize for create_op_builder()
+
+    # create an instance of op builder and return, name specified by class_name
+    def create_op_builder(self, class_name):
+        self._lazy_init_class_dict()
+        if class_name in self.class_dict:
+            return self.class_dict[class_name]()
+        else:
+            return None
+
+    # return an op builder class, name specified by class_name
+    def get_op_builder(self, class_name):
+        self._lazy_init_class_dict()
+        if class_name in self.class_dict:
+            return self.class_dict[class_name]
+        else:
+            return self.class_dict['NotImplementedBuilder'] if 'NotImplementedBuilder' in self.class_dict else None
+
+    def build_extension(self):
+        from torch.utils.cpp_extension import BuildExtension
+        return BuildExtension
+
+    def export_envs(self):
+        return []
+
+    def visible_devices_envs(self):
+        return ['TPU_VISIBLE_CHIPS']
+
+    def set_visible_devices_envs(self, current_env, local_accelerator_ids):
+        for env in self.visible_devices_envs():
+            current_env[env] = ",".join(map(str, local_accelerator_ids))
+
+    def get_compile_backend(self):
+        return self._compile_backend
+
+    def set_compile_backend(self, backend):
+        supported_backends = torch._dynamo.list_backends(exclude_tags=())
+        if backend in supported_backends:
+            self._compile_backend = backend
+        else:
+            raise ValueError(
+                f"{backend} not supported by {self.device_name()}. Supported Backends are {supported_backends}")

--- a/docs/_tutorials/accelerator-setup-guide.md
+++ b/docs/_tutorials/accelerator-setup-guide.md
@@ -10,6 +10,7 @@ tags: getting-started training accelerator
 - [Intel XPU](#intel-xpu)
 - [Huawei Ascend NPU](#huawei-ascend-npu)
 - [Intel Gaudi](#intel-gaudi)
+- [Google TPU](#google-tpu)
 
 # Introduction
 DeepSpeed supports different accelerators from different companies.   Setup steps to run DeepSpeed on certain accelerators might be different.  This guide allows user to lookup setup instructions for the accelerator family and hardware they are using.
@@ -276,3 +277,25 @@ PyTorch models can be run on Intel® Gaudi® AI accelerator using DeepSpeed. Ref
 * [DeepSpeed User Guide for Training](https://docs.habana.ai/en/latest/PyTorch/DeepSpeed/DeepSpeed_User_Guide/DeepSpeed_User_Guide.html#deepspeed-user-guide)
 * [Optimizing Large Language Models](https://docs.habana.ai/en/latest/PyTorch/DeepSpeed/Optimizing_LLM.html#llms-opt)
 * [Inference Using DeepSpeed](https://docs.habana.ai/en/latest/PyTorch/DeepSpeed/Inference_Using_DeepSpeed.html#deepspeed-inference-user-guide)
+
+# Google TPU
+DeepSpeed supports Google Cloud TPU through the [PyTorch/XLA](https://github.com/pytorch/xla) (`torch_xla`) runtime.
+
+> **Note:** TPU support is experimental and under active development. The current release wires the DeepSpeed accelerator abstraction to TPU (device, RNG, and op-builder plumbing) so `get_accelerator()` resolves to TPU; advanced features such as ZeRO are not yet supported on TPU.
+
+## Installation steps for Google TPU
+1. Provision a Cloud TPU VM and install the matching `torch` and `torch_xla` wheels by following the [PyTorch/XLA installation guide](https://github.com/pytorch/xla#installation).
+2. Install DeepSpeed:
+```
+pip install deepspeed
+```
+
+## How to use DeepSpeed on Google TPU
+When `torch_xla` is installed, DeepSpeed auto-detects the TPU accelerator. You can also select it explicitly with an environment variable:
+```
+export DS_ACCELERATOR=tpu
+```
+To confirm the accelerator DeepSpeed selected:
+```
+python -c "from deepspeed.accelerator import get_accelerator; print(get_accelerator().device_name())"
+```

--- a/op_builder/tpu/__init__.py
+++ b/op_builder/tpu/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+'''Copyright The Microsoft DeepSpeed Team'''
+
+from .no_impl import NotImplementedBuilder

--- a/op_builder/tpu/builder.py
+++ b/op_builder/tpu/builder.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import os
+
+try:
+    # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
+    # if successful this also means we're doing a local install and not JIT compile path
+    from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+    from op_builder.builder import OpBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.builder import OpBuilder
+
+
+class TPUOpBuilder(OpBuilder):
+    # TPU kernels run through XLA, so any C++/CUDA extension is built as a plain
+    # host-side CppExtension. No custom TPU ops ship yet; this base exists so op
+    # builders added later (e.g. a fused optimizer) have somewhere to hang.
+
+    def builder(self):
+        from torch.utils.cpp_extension import CppExtension as ExtensionBuilder
+        include_dirs = [os.path.abspath(x) for x in self.strip_empty_entries(self.include_paths())]
+        compile_args = {'cxx': self.strip_empty_entries(self.cxx_args())}
+
+        cpp_ext = ExtensionBuilder(name=self.absolute_name(),
+                                   sources=self.strip_empty_entries(self.sources()),
+                                   include_dirs=include_dirs,
+                                   libraries=self.strip_empty_entries(self.libraries_args()),
+                                   extra_compile_args=compile_args)
+
+        return cpp_ext
+
+    def cxx_args(self):
+        args = ['-O3', '-g', '-Wno-reorder']
+        return args
+
+    def libraries_args(self):
+        return []

--- a/op_builder/tpu/no_impl.py
+++ b/op_builder/tpu/no_impl.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .builder import TPUOpBuilder
+
+
+class NotImplementedBuilder(TPUOpBuilder):
+    BUILD_VAR = "DS_BUILD_NOT_IMPLEMENTED"
+    NAME = "deepspeed_not_implemented"
+
+    def __init__(self, name=None):
+        name = self.NAME if name is None else name
+        super().__init__(name=name)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.comm.{self.NAME}_op'
+
+    def load(self, verbose=True):
+        raise ValueError("This op had not been implemented on TPU backend.")
+
+    def sources(self):
+        return []


### PR DESCRIPTION
Adds an initial Google Cloud TPU accelerator backend via PyTorch/XLA (`torch_xla`), so `get_accelerator()` resolves to TPU. Roadmap item #8104 : DeepSpeed TPU accelerators support.

This is scaffolding only; it wires TPU into the accelerator abstraction. ZeRO, offload, custom kernels, and CUDA graphs are not addressed here and would follow as separate PRs. Opening as a draft to confirm scope before going further.

## Changes

- `accelerator/tpu_accelerator.py` - new `TPU_Accelerator` class:
  - Device and RNG calls delegate to `torch_xla`.
  - Memory and CUDA-only hooks are no-ops, since XLA manages memory and runs lazily (same as MPS/HPU).
  - Comm backend is `xla`, routed through the default `TorchBackend`.
- `accelerator/real_accelerator.py` - register `tpu` in `SUPPORTED_ACCELERATOR_LIST`, the `DS_ACCELERATOR` override, auto-detection, and dispatch.
- `op_builder/tpu/` - minimal op-builder package (`NotImplementedBuilder`) so unimplemented ops fall back gracefully; no custom kernels yet.
- `docs/_tutorials/accelerator-setup-guide.md` - add a Google TPU section.

## Open questions for maintainers

1. Is `torch_xla` the intended integration path?
2. How should TPU be tested in CI, given there are no TPU runners?
3. Is `xla` an acceptable comm backend name, or is a dedicated one preferred?

## Testing

- yapf + flake8 clean; `check-torchdist` / `check-torchcuda` pass.
- `tests/unit/accelerator/test_accelerator.py` auto-discovers `tpu_accelerator.py` and checks the abstract contract.
- Validation on real TPU hardware is pending and will come with the follow-up training PR.

---
_Portions drafted with AI assistance (Claude Code); authored and reviewed by @jahnavi-yelamanchi._
