### PR TITLE
Fix ZeRO-1/2 with zero-sized parameters

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1192,6 +1192,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     ############### Independent Partition Gradient ########################
     def reduce_independent_p_g_buckets_and_remove_grads(self, param, i):
 
+        if param.numel() == 0:
+            return
+
         grad_reduc = self.get_gradient_for_reduction(param)
         comm_dtype = self.get_param_comm_dtype(param)
         bucket = self.ipg_buckets[comm_dtype]


### PR DESCRIPTION
## Summary
- skip zero-sized parameters before ZeRO-1/2 gradient reduction
- add regression coverage for stages 1 and 2

## Testing
- `pytest -q tests/unit/runtime/zero/test_zero_empty_param.py -s`
- original #8279 reproducer on A6000 with PyTorch 2.13.0+cu126 for ZeRO-1 and ZeRO-2
- `pre-commit run --files deepspeed/runtime/zero/stage_1_and_2.py tests/unit/runtime/zero/test_zero_empty_param.py`

Fixes #8279