### PR TITLE
Run tests/unit/model_parallelism in the modal GPU workflow

### DIFF
--- a/ci/test_torch_latest.py
+++ b/ci/test_torch_latest.py
@@ -37,6 +37,9 @@ def _selection_file(content: str) -> tuple[Path, Path]:
     return root, path
 
 
+_ALL_MODE_SELECTION = "tests/unit/v1\ntests/unit/model_parallelism\n"
+
+
 def _valid_env(path: Path, **overrides: str) -> dict[str, str]:
     values = {
         "GITHUB_EVENT_NAME": "pull_request_target",
@@ -188,9 +191,11 @@ def test_transformers_ref_validation():
 
 def test_selection_modes_and_path_validation():
     cases = [
-        ("all", "tests/unit/v1\n", ("tests/unit/v1", )),
-        ("subset", "tests/unit/v1/test_one.py\ntests/unit/v1/sub/test_two.py\n", ("tests/unit/v1/test_one.py",
-                                                                                  "tests/unit/v1/sub/test_two.py")),
+        ("all", _ALL_MODE_SELECTION, ("tests/unit/v1", "tests/unit/model_parallelism")),
+        ("subset",
+         "tests/unit/v1/test_one.py\ntests/unit/v1/sub/test_two.py\ntests/unit/model_parallelism/test_autotp.py\n",
+         ("tests/unit/v1/test_one.py", "tests/unit/v1/sub/test_two.py",
+          "tests/unit/model_parallelism/test_autotp.py")),
         ("none", "", ()),
     ]
     for mode, content, expected in cases:
@@ -202,6 +207,7 @@ def test_selection_modes_and_path_validation():
 
     invalid = [
         ("all", ""),
+        ("all", "tests/unit/v1\n"),
         ("all", "tests/unit/v1/test_one.py\n"),
         ("subset", ""),
         ("subset", "tests/unit/v1/../test_bad.py\n"),
@@ -209,6 +215,7 @@ def test_selection_modes_and_path_validation():
         ("subset", "tests\\unit\\v1\\test_bad.py\n"),
         ("subset", "--collect-only\n"),
         ("subset", "tests/unit/v1/helper.py\n"),
+        ("subset", "tests/unit/other/test_bad.py\n"),
         ("none", "tests/unit/v1\n"),
         ("bogus", ""),
     ]
@@ -347,7 +354,7 @@ def test_git_environment_is_positive_allowlist():
 
 
 def test_controller_inputs_and_push_manual_fallback():
-    root, path = _selection_file("tests/unit/v1\n")
+    root, path = _selection_file(_ALL_MODE_SELECTION)
     try:
         explicit = torch_latest.resolve_controller_inputs(_valid_env(path))
         assert explicit.repository == "example/DeepSpeed"
@@ -420,7 +427,7 @@ def test_sandbox_kwargs_are_fixed_and_secret_free():
 
 
 def test_controller_creates_one_sandbox_without_forwarding_secrets_and_cleans_up():
-    root, path = _selection_file("tests/unit/v1\n")
+    root, path = _selection_file(_ALL_MODE_SELECTION)
     try:
         env = _valid_env(
             path,
@@ -445,7 +452,7 @@ def test_controller_creates_one_sandbox_without_forwarding_secrets_and_cleans_up
 
 
 def test_controller_propagates_command_and_cleanup_failures():
-    root, path = _selection_file("tests/unit/v1\n")
+    root, path = _selection_file(_ALL_MODE_SELECTION)
     try:
         env = _valid_env(path)
         fake, _, sandbox = _fake_modal("a" * 40, fail_label="pytest")
@@ -515,7 +522,7 @@ def test_remote_output_is_prefixed_escaped_capped_and_drained():
 
 
 def test_validate_selection_cli_needs_no_modal_install():
-    root, path = _selection_file("tests/unit/v1\n")
+    root, path = _selection_file(_ALL_MODE_SELECTION)
     try:
         script = Path(torch_latest.__file__).resolve()
         env = {
@@ -531,7 +538,7 @@ def test_validate_selection_cli_needs_no_modal_install():
             env=env,
         )
         assert result.returncode == 0, result.stderr
-        assert result.stdout.strip() == "Validated selection mode=all count=1"
+        assert result.stdout.strip() == f"Validated selection mode=all count={len(torch_latest._MODAL_TEST_SCOPES)}"
     finally:
         shutil.rmtree(root, ignore_errors=True)
 

--- a/ci/tests_fetcher.py
+++ b/ci/tests_fetcher.py
@@ -90,7 +90,7 @@ WORKFLOWS: dict[str, WorkflowConfig] = {
     "modal-torch-latest":
     WorkflowConfig(
         name="modal-torch-latest",
-        test_scopes=("tests/unit/v1", ),
+        test_scopes=("tests/unit/v1", "tests/unit/model_parallelism"),
         extra_run_all_globs=(".github/workflows/modal*.yml", ),
     ),
 }

--- a/ci/torch_latest.py
+++ b/ci/torch_latest.py
@@ -26,6 +26,12 @@ from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Sequence
 
+# The controller validates exactly what ci/tests_fetcher.py selects, so share its
+# scopes instead of re-declaring them here and letting the two drift apart.
+from tests_fetcher import WORKFLOWS
+
+_MODAL_TEST_SCOPES = WORKFLOWS["modal-torch-latest"].test_scopes
+
 DEFAULT_MODAL_TORCH_PRESET = "2.10.0-cuda12.8"
 DEFAULT_MODAL_TRANSFORMERS_SOURCE = "git"
 MODAL_TORCH_PRESETS = {
@@ -79,7 +85,8 @@ GDS_TEST_TARGET = "tests/unit/v1/nvme/test_gds.py"
 _REPOSITORY_COMPONENT = r"[A-Za-z0-9][A-Za-z0-9._-]{0,99}"
 _REPOSITORY_RE = re.compile(rf"{_REPOSITORY_COMPONENT}/{_REPOSITORY_COMPONENT}\Z")
 _SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
-_TEST_FILE_RE = re.compile(r"tests/unit/v1/(?:[^/\x00-\x1f\x7f]+/)*test_[^/\x00-\x1f\x7f]+\.py\Z")
+_TEST_FILE_RE = re.compile("(?:" + "|".join(rf"{re.escape(scope)}/(?:[^/\x00-\x1f\x7f]+/)*test_[^/\x00-\x1f\x7f]+\.py"
+                                            for scope in _MODAL_TEST_SCOPES) + r")\Z")
 
 
 def exclude_unsupported_gds_targets(targets: Sequence[str]) -> tuple[str, ...]:
@@ -153,7 +160,7 @@ def _validate_target(value: str) -> str:
     if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
         raise ValueError(f"invalid pytest target: {value!r}")
     if not _TEST_FILE_RE.fullmatch(value):
-        raise ValueError(f"pytest target is outside tests/unit/v1 or is not a test file: {value!r}")
+        raise ValueError(f"pytest target is outside the workflow test scopes or is not a test file: {value!r}")
     return value
 
 
@@ -182,8 +189,8 @@ def load_test_selection(path: Path, mode: str) -> tuple[str, ...]:
     if len(lines) != len(set(lines)):
         raise ValueError("test selection contains duplicate targets")
     if mode == "all":
-        if lines != ["tests/unit/v1"]:
-            raise ValueError("all mode requires exactly tests/unit/v1")
+        if sorted(lines) != sorted(_MODAL_TEST_SCOPES):
+            raise ValueError(f"all mode requires exactly the workflow test scopes: {', '.join(_MODAL_TEST_SCOPES)}")
         return tuple(lines)
     if mode == "none":
         if lines:


### PR DESCRIPTION
## What this does

`tests/unit/model_parallelism` was never executed in PR CI:

- **cpu-torch-latest** collects it but skips every test: the whole directory is multi-rank `DistributedTest` (world_size 2/4), and `DistributedExec._launch_procs` (`tests/unit/common.py`) skips them because a CPU runner reports `device_count() == 1`.
- **modal-torch-latest** (2xL40S GPU) has the devices to run them, but its diff-driven selector only considered `tests/unit/v1`.

This came to light in #8241, whose regression test for #8231 (`TestAutoTPMultipleModels`) is in that directory and therefore ran nowhere in CI.

## Changes

- `ci/tests_fetcher.py`: add `tests/unit/model_parallelism` to the modal workflow `test_scopes`.
- `ci/torch_latest.py`: derive `_TEST_FILE_RE` and the all-mode selection check from the workflow's `test_scopes` (imported from `tests_fetcher`) instead of hardcoding `tests/unit/v1`, so the selector and the validator share one source of truth.
- `ci/test_torch_latest.py`: update the self-tests for the two-scope reality (all-mode selection content, a model_parallelism subset target, new invalid cases, `count=` assertion).

## Validation

- `python3 ci/test_tests_fetcher.py` — 16/16 passed
- `python3 ci/test_torch_latest.py` — 20/20 passed
- End-to-end locally: with a scratch commit touching `deepspeed/module_inject/tp_shard.py`, `ci/tests_fetcher.py --workflow modal-torch-latest` selects all 6 `model_parallelism` test files (mode=subset, 45 targets), and `ci/torch_latest.py validate-selection --mode subset` accepts the list.

## Notes

- The collect-tests job checks out the **base** revision of the CI scripts (`pull_request_target`), so this only takes effect for other PRs once it lands on master; this PR's own run validates the selection plumbing but will still select v1-only tests for its own diff.
- `tp_size=4` tests will still be skipped on the 2-GPU modal sandbox via the existing device-count gate; world_size=2 tests (including `TestAutoTPMultipleModels`) will run for real.