### PR TITLE
Fix ZeroDivisionError in compute_elastic_config return_microbatch on non-0.2 elasticity

### DIFF
--- a/deepspeed/elasticity/elasticity.py
+++ b/deepspeed/elasticity/elasticity.py
@@ -370,6 +370,24 @@ def compute_elastic_config(ds_config: dict, target_deepspeed_version: str, world
         if float(elastic_config.version) == 0.2:
             return final_batch_size, valid_gpus, candidate_microbatch_size
         else:
+            # Only an unset world_size reaches here, since the block above returns
+            # for every positive value. Resolve it the same way version 0.2 does.
+            if world_size <= 0:
+                env_world_size = os.getenv('WORLD_SIZE')
+                if env_world_size is not None and env_world_size.isnumeric():
+                    world_size = int(env_world_size)
+                else:
+                    raise ElasticityConfigError(
+                        f'Elasticity V {elastic_config.version} needs WORLD_SIZE '\
+                        'to compute a micro batch size. '\
+                        'Either give it as argument to function compute_elastic_config '\
+                        'or set it as an environment variable. '\
+                        f'Value of WORLD_SIZE as environment variable is {env_world_size}')
+
+            if world_size not in valid_gpus:
+                raise ElasticityIncompatibleWorldSize(f"World size ({world_size}) is not valid " \
+                                                      f"with the current list of valid GPU counts: {valid_gpus}")
+
             micro_batch_size = None
             for mbsz in sorted(list(set(elastic_config.micro_batches)), reverse=True):
                 if final_batch_size // world_size % mbsz == 0:

--- a/tests/unit/elasticity/test_elastic.py
+++ b/tests/unit/elasticity/test_elastic.py
@@ -75,6 +75,30 @@ def test_invalid_world_size(ds_config):
             ds_config=ds_config, target_deepspeed_version=ds_version, world_size=128)
 
 
+def test_return_microbatch_without_world_size(ds_config, monkeypatch):
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    with pytest.raises(deepspeed.elasticity.config.ElasticityConfigError):
+        deepspeed.elasticity.compute_elastic_config(ds_config=ds_config,
+                                                    target_deepspeed_version=ds_version,
+                                                    return_microbatch=True)
+
+
+def test_return_microbatch_world_size_from_env(ds_config, monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "64")
+    final_batch_size, valid_gpus, mbsize = deepspeed.elasticity.compute_elastic_config(
+        ds_config=ds_config, target_deepspeed_version=ds_version, return_microbatch=True)
+    assert final_batch_size == 9792
+    assert mbsize == 17
+
+
+def test_return_microbatch_invalid_world_size_from_env(ds_config, monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "128")
+    with pytest.raises(deepspeed.elasticity.config.ElasticityIncompatibleWorldSize):
+        deepspeed.elasticity.compute_elastic_config(ds_config=ds_config,
+                                                    target_deepspeed_version=ds_version,
+                                                    return_microbatch=True)
+
+
 def test_future_elastic_version(ds_config):
     ds_config['elasticity']['version'] = '0.3'
     with pytest.raises(deepspeed.elasticity.config.ElasticityError):


### PR DESCRIPTION
## Root cause

With `return_microbatch=True`, `compute_elastic_config` takes the `else` at `elasticity.py:372` for any elasticity version other than `0.2`, and that branch divides `final_batch_size` by `world_size`. In practice that means version `0.1`: `0.3` is rejected at line 301 and any other value raises `NotImplementedError` at line 348, both before this point. The branch is only reachable when `world_size` is unset, because the `if world_size > 0:` block above it returns for every positive value. So on master the division is always by zero and the caller gets a bare `ZeroDivisionError` at line 375 rather than a configuration error.

Version `0.2` avoids this by resolving `world_size` from the `WORLD_SIZE` environment variable at lines 321-334, and raising `ElasticityConfigError` naming that variable when it cannot. Version `0.1` never reads the environment, so a caller who follows the `0.2` message's own advice, "set it as an environment variable", still crashes:

| config | `WORLD_SIZE` in env | master |
|---|---|---|
| 0.2 | yes | returns `(9792, [...], 17)` |
| 0.2 | no | `ElasticityConfigError` naming `WORLD_SIZE` |
| 0.1 | yes | `ZeroDivisionError` |
| 0.1 | no | `ZeroDivisionError` |

## Fix

Resolve `world_size` from `WORLD_SIZE` in the non-`0.2` branch the way `0.2` already does, and raise `ElasticityConfigError` with the same guidance when it cannot be resolved. Then check the resolved value against `valid_gpus` before dividing, matching the sibling block at lines 352-355; without that check an out-of-range `WORLD_SIZE` would reach the loop and fail on the `micro_batch_size is not None` assertion instead of `ElasticityIncompatibleWorldSize`.

Both divisions by `world_size` in this function now run only on a value that is positive and a member of `valid_gpus`. Nothing that works today changes: on master this branch raised `ZeroDivisionError` for every input, and the `0.2` path is untouched.

## Verification

- Three new tests in `tests/unit/elasticity/test_elastic.py` cover the unset case, resolution from `WORLD_SIZE`, and an out-of-range `WORLD_SIZE`. All three fail on master with `ZeroDivisionError` at `elasticity.py:375` and pass here.
- `pytest unit/elasticity/` gives 23 passed, 3 skipped, on Python 3.12 with `torch==2.10.0+cpu` to match the `cpu-torch-latest` leg. The 3 skips are the `DistributedTest` classes that need `FusedLambBuilder`, and they skip on master too.
- `pre-commit run --files` passes on both changed files, yapf, flake8, codespell and `check-torchdist` included.
- Not checked: the GPU legs, and the `0.2` `return_microbatch` return at line 371, which no test in the repo reaches either before or after this change.

#8162 proposed the same resolution in July, and its author closed it unmerged on 2026-08-12 without a review.

Fixes #8156
