### PR TITLE
docs: note async cpu_checkpointing perf and expandable_segments

### DIFF
--- a/docs/_pages/config-json.md
+++ b/docs/_pages/config-json.md
@@ -1338,6 +1338,8 @@ Use a built-in preset but override specific naming/weight fields for a fine-tune
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | Offloads activation checkpoint inputs to CPU. With `partition_activations` it offloads the partitioned activations; otherwise it uses an asynchronous pinned side-stream copy that overlaps the CPU transfer with compute. | `false` |
 
+The asynchronous side-stream copy matches the peak-memory reduction of a blocking copy at a fraction of the step-time cost. On a single H200 with Qwen3-8B full-parameter SFT (`use_reentrant=False`), it lowers the GPU activation peak by up to ~14% at 32K sequence length while staying within ~2% of the no-offload step time, whereas a blocking offload is 1.4–1.9x slower. For very long sequences, set `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` to avoid allocator fragmentation from the offload/restore cycle.
+
 
 <i>**contiguous_memory_optimization**</i>: [boolean]
 


### PR DESCRIPTION
## Summary

Follow-up to #8282. The docs note for `cpu_checkpointing` landed after that PR was merged, so this cherry-picks it onto `master`.

Adds a short note under the `cpu_checkpointing` config entry covering:
- The Qwen3-8B single-H200 result: async side-stream copy matches a blocking offload's peak reduction (up to ~14% at 32K) while staying within ~2% of no-offload step time.
- Recommending `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for very long sequences to avoid allocator fragmentation from the offload/restore cycle.

## Test plan

- [x] `pre-commit run --files docs/_pages/config-json.md`
- [ ] Docs preview of the Activation Checkpointing `cpu_checkpointing` section

Made with [Cursor](https://cursor.com)