### PR TITLE
Enable DeepSpeed support on Apple Silicon (MPS) with ZeRO Stage 1-3

### DIFF
--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -174,6 +174,10 @@ class DeepSpeedAccelerator(ABC):
     def is_fp16_supported(self):
         ...
 
+    # Not abstract: nearly every accelerator supports fp64, so only those that do not need to override.
+    def is_fp64_supported(self):
+        return True
+
     @abc.abstractmethod
     def supported_dtypes(self):
         ...

--- a/accelerator/mps_accelerator.py
+++ b/accelerator/mps_accelerator.py
@@ -19,11 +19,14 @@ class MPS_Accelerator(DeepSpeedAccelerator):
 
     def __init__(self):
         self._name = "mps"
-        self._communication_backend_name = None
+        # MPS has no native collective backend; gloo is the only torch backend available on macOS.
+        self._communication_backend_name = "gloo"
         self._compile_backend = "inductor"
 
     def is_synchronized_device(self):
-        return False
+        # MPS runs everything on a single in-order command queue and exposes no user-visible
+        # streams, so DeepSpeed never needs to synchronize between streams on this device.
+        return True
 
     def use_host_timers(self):
         # Event timers are not supported on MPS
@@ -90,7 +93,8 @@ class MPS_Accelerator(DeepSpeedAccelerator):
         return None
 
     def stream(self, stream):
-        return None
+        from deepspeed.runtime.utils import noop_context
+        return noop_context()
 
     def current_stream(self, device_index=None):
         return None
@@ -100,7 +104,7 @@ class MPS_Accelerator(DeepSpeedAccelerator):
 
     @property
     def Event(self):
-        return None
+        return torch.mps.Event
 
     # Memory management
     def empty_cache(self):
@@ -119,41 +123,53 @@ class MPS_Accelerator(DeepSpeedAccelerator):
         return
 
     def memory_cached(self, device_index=None):
-        return
+        return torch.mps.driver_allocated_memory()
 
     def max_memory_cached(self, device_index=None):
-        return
+        return torch.mps.driver_allocated_memory()
 
     def reset_max_memory_cached(self, device_index=None):
         return
 
     def memory_stats(self, device_index=None):
-        return
+        # torch.mps has no caching-allocator stats; expose what it does report under the CUDA key names.
+        return {
+            'allocated_bytes.all.current': torch.mps.current_allocated_memory(),
+            'reserved_bytes.all.current': torch.mps.driver_allocated_memory(),
+        }
 
     def reset_peak_memory_stats(self, device_index=None):
         return
 
     def memory_reserved(self, device_index=None):
-        return
+        return torch.mps.driver_allocated_memory()
 
     def max_memory_reserved(self, device_index=None):
-        return
+        return torch.mps.driver_allocated_memory()
 
     def total_memory(self, device_index=None):
-        return
+        # Unified memory: the driver-recommended working set is the usable budget for the GPU.
+        return torch.mps.recommended_max_memory()
 
     def available_memory(self, device_index=None):
-        return
+        return self.total_memory() - torch.mps.driver_allocated_memory()
 
     # Data types
     def is_bf16_supported(self):
-        return False
+        # bf16 on MPS requires macOS 14 (Sonoma) or newer.
+        return torch.backends.mps.is_macos_or_newer(14, 0)
 
     def is_fp16_supported(self):
+        return True
+
+    def is_fp64_supported(self):
         return False
 
     def supported_dtypes(self):
-        return [torch.float]
+        supported_dtypes = [torch.float, torch.half]
+        if self.is_bf16_supported():
+            supported_dtypes.append(torch.bfloat16)
+        return supported_dtypes
 
     # Misc
     def is_available(self):
@@ -188,31 +204,39 @@ class MPS_Accelerator(DeepSpeedAccelerator):
     # Tensor operations
     @property
     def BFloat16Tensor(self):
-        return
+        return torch.BFloat16Tensor
 
     @property
     def ByteTensor(self):
-        return
+        return torch.ByteTensor
 
     @property
     def DoubleTensor(self):
-        return
+        return torch.DoubleTensor
 
     @property
     def FloatTensor(self):
-        return
+        return torch.FloatTensor
 
     @property
     def HalfTensor(self):
-        return
+        return torch.HalfTensor
 
     @property
     def IntTensor(self):
-        return
+        return torch.IntTensor
 
     @property
     def LongTensor(self):
-        return
+        return torch.LongTensor
+
+    # Apple Silicon has unified memory, so host tensors are already directly accessible to the GPU
+    # and there is nothing to pin. torch's pin_memory() also raises for the MPS backend.
+    def _torch_pin_memory(self, tensor):
+        return tensor
+
+    def _torch_is_pinned(self, tensor):
+        return tensor.device.type == 'cpu'
 
     def on_accelerator(self, tensor):
         device_str = str(tensor.device)
@@ -227,9 +251,9 @@ class MPS_Accelerator(DeepSpeedAccelerator):
             # if successful this also means we're doing a local install and not JIT compile path
             from op_builder import __deepspeed__  # noqa: F401 # type: ignore
 
-            return "op_builder"
+            return "op_builder.mps"
         except ImportError:
-            return "deepspeed.ops.op_builder"
+            return "deepspeed.ops.op_builder.mps"
 
     # create an instance of op builder, specified by class_name
     def create_op_builder(self, op_name):
@@ -240,9 +264,18 @@ class MPS_Accelerator(DeepSpeedAccelerator):
 
     # return an op builder class, specified by class_name
     def get_op_builder(self, class_name):
-        from deepspeed.ops.op_builder.cpu import NotImplementedBuilder
+        try:
+            # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
+            # if successful this also means we're doing a local install and not JIT compile path
+            from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+            from op_builder.mps import FusedAdamBuilder, NotImplementedBuilder
+        except ImportError:
+            from deepspeed.ops.op_builder.mps import FusedAdamBuilder, NotImplementedBuilder
 
-        return NotImplementedBuilder
+        if class_name == "FusedAdamBuilder":
+            return FusedAdamBuilder
+        else:
+            return NotImplementedBuilder
 
     def build_extension(self):
         from torch.utils.cpp_extension import BuildExtension

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -95,6 +95,62 @@ class Noop:
         return None
 
 
+class StagedWork:
+    """Completes a staged collective by copying the CPU results back to the original device tensors."""
+
+    def __init__(self, work, copy_back):
+        self.work = work
+        self.copy_back = copy_back
+
+    def wait(self):
+        if self.work is not None:
+            self.work.wait()
+        self.copy_back()
+        return None
+
+
+def _needs_cpu_staging(tensor):
+    # gloo (the only torch backend on macOS) cannot operate on MPS tensors.
+    return isinstance(tensor, torch.Tensor) and tensor.device.type == 'mps'
+
+
+def stage_on_cpu(func):
+    """Runs a collective on CPU copies of any MPS tensor arguments, then copies the results back.
+
+    This is what lets DeepSpeed use the gloo backend on Apple Silicon, where device tensors are
+    not supported by any torch.distributed backend. Unified memory keeps the copies cheap.
+    """
+
+    def _stage(arg, pairs):
+        if _needs_cpu_staging(arg):
+            cpu_tensor = arg.to('cpu')
+            pairs.append((arg, cpu_tensor))
+            return cpu_tensor
+        if isinstance(arg, list) and any(_needs_cpu_staging(t) for t in arg):
+            return [_stage(t, pairs) for t in arg]
+        return arg
+
+    def wrapper(self, *args, **kwargs):
+        pairs = []
+        args = [_stage(arg, pairs) for arg in args]
+        kwargs = {key: _stage(arg, pairs) for key, arg in kwargs.items()}
+        if not pairs:
+            return func(self, *args, **kwargs)
+
+        work = func(self, *args, **kwargs)
+
+        def copy_back():
+            for device_tensor, cpu_tensor in pairs:
+                device_tensor.copy_(cpu_tensor)
+
+        if kwargs.get('async_op', False):
+            return StagedWork(work, copy_back)
+        copy_back()
+        return work
+
+    return wrapper
+
+
 class TorchBackend(Backend):
     """
         A light-weight wrapper class for torch.distributed API.
@@ -179,6 +235,7 @@ class TorchBackend(Backend):
         self.using_mpi = torch.distributed.get_backend() == 'mpi'
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_reduce(self, tensor, op=torch.distributed.ReduceOp.SUM, group=None, async_op=False):
         op = self._reduce_op(op)
         return torch.distributed.all_reduce(tensor=tensor, op=op, group=group, async_op=async_op)
@@ -195,6 +252,7 @@ class TorchBackend(Backend):
             return torch.ops.deepspeed.inference_all_reduce_(tensor)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_reduce_coalesced(self, tensors, op=torch.distributed.ReduceOp.SUM, group=None, async_op=False):
         """ proxy func to torch.distributed.all_reduce_coalesced,
         which is included in PyTorch 1.13 and above
@@ -206,6 +264,7 @@ class TorchBackend(Backend):
         return torch.distributed.all_reduce_coalesced(tensors=tensors, op=op, group=group, async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def reduce(self, tensor, dst, op=ReduceOp.SUM, group=None, async_op=False):
         if DS_COMM_REDUCE_OFF:
             if int(os.getenv('RANK', '0')) == 0:
@@ -214,6 +273,7 @@ class TorchBackend(Backend):
         return torch.distributed.reduce(tensor=tensor, dst=dst, op=self._reduce_op(op), group=group, async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def reduce_scatter(self, output, input_list, op=ReduceOp.SUM, group=None, async_op=False):
         if DS_COMM_REDUCE_SCATTER_OFF:
             if int(os.getenv('RANK', '0')) == 0:
@@ -227,6 +287,7 @@ class TorchBackend(Backend):
                                                     async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def broadcast(self, tensor, src, group=None, async_op=False):
         if DS_COMM_BROADCAST_OFF:
             if int(os.getenv('RANK', '0')) == 0:
@@ -240,6 +301,7 @@ class TorchBackend(Backend):
         return torch.distributed.broadcast_object_list(object_list=object_list, src=src, group=group, device=device)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_gather(self, tensor_list, tensor, group=None, async_op=False):
         if DS_COMM_ALL_GATHER_OFF:
             if int(os.getenv('RANK', '0')) == 0:
@@ -249,6 +311,7 @@ class TorchBackend(Backend):
             return torch.distributed.all_gather(tensor_list=tensor_list, tensor=tensor, group=group, async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_gather_into_tensor(self, output_tensor, input_tensor, group=None, async_op=False):
         # Transparent SDMA fast-path on AMD/ROCm: when the mori backend is
         # available and the call is on the WORLD process group, route
@@ -266,6 +329,7 @@ class TorchBackend(Backend):
                                             async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_gather_base(self, output_tensor, input_tensor, group=None, async_op=False):
         if DS_COMM_ALL_GATHER_OFF:
             if int(os.getenv('RANK', '0')) == 0:
@@ -284,6 +348,7 @@ class TorchBackend(Backend):
                 pass
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_gather_coalesced(self, output_tensors, input_tensors, group=None, async_op=False):
         """"""
         assert len(output_tensors) == len(input_tensors), ""
@@ -312,6 +377,7 @@ class TorchBackend(Backend):
         return torch.distributed.all_gather_object(object_list=object_list, obj=obj, group=group)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def reduce_scatter_tensor(self, output_tensor, input_tensor, op=ReduceOp.SUM, group=None, async_op=False):
         if self.has_reduce_scatter_tensor():
             return self.reduce_scatter_function(output_tensor,
@@ -326,6 +392,7 @@ class TorchBackend(Backend):
             pass
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_to_all_single(self,
                           output,
                           input,
@@ -341,26 +408,32 @@ class TorchBackend(Backend):
                                                    async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def all_to_all(self, output_tensor_list, input_tensor_list, group=None, async_op=False):
         return torch.distributed.all_to_all(output_tensor_list, input_tensor_list, group=group, async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def send(self, tensor, dst, group=None, tag=0):
         return torch.distributed.send(tensor=tensor, dst=dst, group=group, tag=tag)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def recv(self, tensor, src=None, group=None, tag=0):
         return torch.distributed.recv(tensor=tensor, src=src, group=group, tag=tag)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def isend(self, tensor, dst, group=None, tag=0):
         return torch.distributed.isend(tensor=tensor, dst=dst, group=group, tag=tag)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def irecv(self, tensor, src=None, group=None, tag=0):
         return torch.distributed.irecv(tensor=tensor, src=src, group=group, tag=tag)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def gather(self, tensor, gather_list=None, dst=0, group=None, async_op=False):
         return torch.distributed.gather(tensor=tensor,
                                         gather_list=gather_list,
@@ -369,6 +442,7 @@ class TorchBackend(Backend):
                                         async_op=async_op)
 
     @disable_compiler_collective
+    @stage_on_cpu
     def scatter(self, tensor, scatter_list=None, src=0, group=None, async_op=False):
         return torch.distributed.scatter(tensor=tensor,
                                          scatter_list=scatter_list,

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -130,6 +130,8 @@ def stage_on_cpu(func):
             return [_stage(t, pairs) for t in arg]
         return arg
 
+    signature = inspect.signature(func)
+
     def wrapper(self, *args, **kwargs):
         pairs = []
         args = [_stage(arg, pairs) for arg in args]
@@ -143,7 +145,9 @@ def stage_on_cpu(func):
             for device_tensor, cpu_tensor in pairs:
                 device_tensor.copy_(cpu_tensor)
 
-        if kwargs.get('async_op', False):
+        # async_op is usually forwarded positionally, so resolve it against the real signature.
+        bound_args = signature.bind(self, *args, **kwargs)
+        if bound_args.arguments.get('async_op', False):
             return StagedWork(work, copy_back)
         copy_back()
         return work

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -28,7 +28,7 @@ from deepspeed.runtime.zero.config import ZeroStageEnum
 from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum, OffloadStateTypeEnum
 from deepspeed.runtime.zero.parameter_offload import DeepSpeedZeRoOffload
 import deepspeed.runtime.zenflow.engine_stage3 as zf_engine_stage3
-from deepspeed.runtime.zero.utils import get_mapping_to_flat_buffer, defragment
+from deepspeed.runtime.zero.utils import get_mapping_to_flat_buffer, defragment, get_norm_dtype
 from deepspeed.runtime.zero.offload_states import offload_adam_states, reload_adam_states
 from deepspeed.ops.adam import DeepSpeedCPUAdam
 from deepspeed.runtime.swap_tensor.partitioned_param_swapper import PartitionedParamStatus
@@ -1843,9 +1843,9 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
         norm = None
         for part in input.view(-1).split(buffer_size):
             if norm is None:
-                norm = part.data.double().norm(2)**2.0
+                norm = part.data.to(get_norm_dtype()).norm(2)**2.0
             else:
-                norm += part.data.double().norm(2)**2.0
+                norm += part.data.to(get_norm_dtype()).norm(2)**2.0
         return norm**0.5
 
     def set_norm_for_param_grad_in_gpu(self, param):
@@ -2282,13 +2282,14 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             grad_norms = []
             for g, p in zip(gradients, params):
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
-                    grad_norms.append(g.to(get_accelerator().device_name(), non_blocking=True).double().norm(2))
+                    grad_norms.append(
+                        g.to(get_accelerator().device_name(), non_blocking=True).to(get_norm_dtype()).norm(2))
 
             # Sum across all model parallel GPUs.
             if len(grad_norms) == 0:
                 # FIX https://github.com/deepspeedai/DeepSpeed/issues/3564
-                total_norm_cuda = torch.tensor(0,
-                                               dtype=gradients[0].dtype).to(get_accelerator().device_name()).double()
+                total_norm_cuda = torch.tensor(0, dtype=gradients[0].dtype).to(get_accelerator().device_name()).to(
+                    get_norm_dtype())
             else:
                 total_norm_cuda = torch.sum(torch.pow(torch.stack(grad_norms), 2))
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -24,6 +24,7 @@ from deepspeed.runtime.utils import (empty_cache, see_memory_usage, inf, is_mode
                                      align_dense_tensors, all_gather_dp_groups, mask_nan_or_inf_with_val_inplace,
                                      count_used_parameters_in_backward)
 from deepspeed.runtime.zero.config import ZeroStageEnum
+from deepspeed.runtime.zero.utils import get_norm_dtype
 from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum, OffloadStateTypeEnum
 from deepspeed.ops.adam import DeepSpeedCPUAdam
 from deepspeed.utils import logger
@@ -1570,7 +1571,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         start = source_offset
         accumulated_grad = accumulated_grad.view(-1).narrow(0, start, num_elements)
 
-        self.norm_for_param_grads[param_id] = accumulated_grad.data.double().norm(2)
+        self.norm_for_param_grads[param_id] = accumulated_grad.data.to(get_norm_dtype()).norm(2)
 
     def set_norm_for_param_grad_in_gpu(self, param):
         param_id = self.get_param_id(param)
@@ -1585,7 +1586,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         start = source_offset
         accumulated_grad = accumulated_grad.view(-1).narrow(0, start, num_elements)
 
-        self.norm_for_param_grads[param_id] = accumulated_grad.data.double().norm(2)
+        self.norm_for_param_grads[param_id] = accumulated_grad.data.to(get_norm_dtype()).norm(2)
 
     def async_inplace_copy_grad_to_fp32_buffer_from_gpu(self, param):
         param_id = self.get_param_id(param)
@@ -2086,7 +2087,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     continue
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
                     all_norms.append(
-                        torch.linalg.vector_norm(g.data.double().detach(),
+                        torch.linalg.vector_norm(g.data.to(get_norm_dtype()).detach(),
                                                  ord=norm_type).to(get_accelerator().current_device_name()))
             if len(all_norms) > 0:
                 total_norm = torch.stack(all_norms).square().sum().float()

--- a/deepspeed/runtime/zero/utils.py
+++ b/deepspeed/runtime/zero/utils.py
@@ -63,6 +63,13 @@ except ImportError:
     pass
 
 
+def get_norm_dtype():
+    """Gradient norms accumulate in fp64 for accuracy, except on devices without fp64 (e.g. MPS)."""
+    if get_accelerator().is_fp64_supported():
+        return torch.double
+    return torch.float
+
+
 def is_zero_supported_optimizer(optimizer):
     if dist.get_rank() == 0:
         logger.info(f'Checking ZeRO support for optimizer={optimizer.__class__.__name__} type={type(optimizer)}')

--- a/docs/_tutorials/accelerator-setup-guide.md
+++ b/docs/_tutorials/accelerator-setup-guide.md
@@ -10,6 +10,7 @@ tags: getting-started training accelerator
 - [Intel XPU](#intel-xpu)
 - [Huawei Ascend NPU](#huawei-ascend-npu)
 - [Intel Gaudi](#intel-gaudi)
+- [Apple Silicon (MPS)](#apple-silicon-mps)
 
 # Introduction
 DeepSpeed supports different accelerators from different companies.   Setup steps to run DeepSpeed on certain accelerators might be different.  This guide allows user to lookup setup instructions for the accelerator family and hardware they are using.
@@ -276,3 +277,40 @@ PyTorch models can be run on Intel® Gaudi® AI accelerator using DeepSpeed. Ref
 * [DeepSpeed User Guide for Training](https://docs.habana.ai/en/latest/PyTorch/DeepSpeed/DeepSpeed_User_Guide/DeepSpeed_User_Guide.html#deepspeed-user-guide)
 * [Optimizing Large Language Models](https://docs.habana.ai/en/latest/PyTorch/DeepSpeed/Optimizing_LLM.html#llms-opt)
 * [Inference Using DeepSpeed](https://docs.habana.ai/en/latest/PyTorch/DeepSpeed/Inference_Using_DeepSpeed.html#deepspeed-inference-user-guide)
+
+# Apple Silicon (MPS)
+DeepSpeed can train on the GPU of Apple Silicon Macs through PyTorch's MPS backend. This support is new and currently covers single-device training; see the limitations below.
+
+DeepSpeed has been verified on the following hardware:
+* Apple M5 Max (macOS 26)
+
+## Installation steps for Apple Silicon
+1. Install PyTorch (2.4 or newer) with MPS support. The default macOS arm64 wheels include it:
+```
+pip install torch
+```
+
+2. Install DeepSpeed. There are no kernels to compile on MPS, but `setup.py` imports PyTorch, so disable build isolation:
+```
+DS_ACCELERATOR=mps pip install --no-build-isolation deepspeed
+```
+
+3. Verify that the MPS accelerator is detected:
+```
+ds_report
+```
+The accelerator is auto-detected when MPS is available; set `DS_ACCELERATOR=mps` to force it.
+
+## How to use DeepSpeed on Apple Silicon
+Launch a single-process job as usual; no hostfile is needed:
+```
+deepspeed --num_gpus 1 train.py --deepspeed --deepspeed_config ds_config.json
+```
+ZeRO stages 0 through 3 are supported with fp32, fp16, and bf16 (bf16 requires macOS 14 or newer). The fused Adam optimizer runs as a PyTorch implementation on MPS; ZeRO-Offload (`DeepSpeedCPUAdam`) is not yet available on this backend.
+
+## Limitations
+* PyTorch exposes one MPS device per machine, so `device_count()` is 1 and multi-device data parallelism on a single Mac is not possible.
+* There is no native collective backend for MPS. DeepSpeed uses `gloo` and stages tensors through CPU memory for each collective. This is cheap on unified memory, but multi-machine training over gloo is untested.
+* MPS does not support fp64; gradient norms are accumulated in fp32 on this backend.
+* MPS has no user-visible streams, so DeepSpeed treats it as a synchronized device and does not overlap communication with computation.
+* Tests and multiprocessing code must use the `spawn` start method, because MPS cannot be used from a forked child process.

--- a/op_builder/mps/__init__.py
+++ b/op_builder/mps/__init__.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/mps/__init__.py
+++ b/op_builder/mps/__init__.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team
-'''Copyright The Microsoft DeepSpeed Team'''
 
 from .fused_adam import FusedAdamBuilder
 from .no_impl import NotImplementedBuilder

--- a/op_builder/mps/__init__.py
+++ b/op_builder/mps/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+'''Copyright The Microsoft DeepSpeed Team'''
+
+from .fused_adam import FusedAdamBuilder
+from .no_impl import NotImplementedBuilder

--- a/op_builder/mps/builder.py
+++ b/op_builder/mps/builder.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/mps/builder.py
+++ b/op_builder/mps/builder.py
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+try:
+    # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed
+    # if successful this also means we're doing a local install and not JIT compile path
+    from op_builder import __deepspeed__  # noqa: F401 # type: ignore
+    from op_builder.builder import OpBuilder
+except ImportError:
+    from deepspeed.ops.op_builder.builder import OpBuilder
+
+
+class MPSOpBuilder(OpBuilder):
+    """Base class for ops on Apple Silicon.
+
+    Ops here are currently pure PyTorch (torch.mps) implementations, so there is nothing to compile.
+    Metal kernels will plug into the same builder classes later.
+    """
+
+    def sources(self):
+        return []
+
+    def include_paths(self):
+        return []
+
+    def is_compatible(self, verbose=False):
+        import torch
+        return hasattr(torch.backends, "mps") and torch.backends.mps.is_available()

--- a/op_builder/mps/fused_adam.py
+++ b/op_builder/mps/fused_adam.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/mps/fused_adam.py
+++ b/op_builder/mps/fused_adam.py
@@ -18,9 +18,15 @@ class MPSFusedAdam:
     """
 
     @staticmethod
-    @torch.no_grad()
     def multi_tensor_adam(chunk_size, noop_flag_buffer, tensor_lists, lr, beta1, beta2, epsilon, step, adam_w_mode,
                           bias_correction, weight_decay, *args):
+        # The caller passes bf16 params as leaf tensors (not .data), so the in-place update must bypass autograd.
+        with torch.no_grad():
+            MPSFusedAdam._adam_step(tensor_lists, lr, beta1, beta2, epsilon, step, adam_w_mode, bias_correction,
+                                    weight_decay)
+
+    @staticmethod
+    def _adam_step(tensor_lists, lr, beta1, beta2, epsilon, step, adam_w_mode, bias_correction, weight_decay):
         grads, params, exp_avgs, exp_avg_sqs = tensor_lists
 
         bias_correction1 = 1.0

--- a/op_builder/mps/fused_adam.py
+++ b/op_builder/mps/fused_adam.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .builder import MPSOpBuilder
+
+try:
+    import torch
+except ImportError as e:
+    pass
+
+
+class MPSFusedAdam:
+    """Pure-torch replacement for the CUDA multi_tensor_adam kernel, using torch._foreach_* ops on MPS.
+
+    The math mirrors csrc/adam/multi_tensor_adam.cu so checkpoints and numerics stay interchangeable.
+    """
+
+    @staticmethod
+    @torch.no_grad()
+    def multi_tensor_adam(chunk_size, noop_flag_buffer, tensor_lists, lr, beta1, beta2, epsilon, step, adam_w_mode,
+                          bias_correction, weight_decay, *args):
+        grads, params, exp_avgs, exp_avg_sqs = tensor_lists
+
+        bias_correction1 = 1.0
+        bias_correction2 = 1.0
+        if bias_correction:
+            bias_correction1 = 1.0 - beta1**step
+            bias_correction2 = 1.0 - beta2**step
+
+        # L2 mode folds weight decay into the gradient; AdamW mode applies it to the parameter directly.
+        if weight_decay != 0 and not adam_w_mode:
+            grads = torch._foreach_add(grads, params, alpha=weight_decay)
+
+        torch._foreach_mul_(exp_avgs, beta1)
+        torch._foreach_add_(exp_avgs, grads, alpha=1 - beta1)
+        torch._foreach_mul_(exp_avg_sqs, beta2)
+        torch._foreach_addcmul_(exp_avg_sqs, grads, grads, value=1 - beta2)
+
+        denom = torch._foreach_div(exp_avg_sqs, bias_correction2)
+        torch._foreach_sqrt_(denom)
+        torch._foreach_add_(denom, epsilon)
+
+        if weight_decay != 0 and adam_w_mode:
+            torch._foreach_mul_(params, 1 - lr * weight_decay)
+        torch._foreach_addcdiv_(params, exp_avgs, denom, value=-lr / bias_correction1)
+
+
+class FusedAdamBuilder(MPSOpBuilder):
+    BUILD_VAR = "DS_BUILD_FUSED_ADAM"
+    NAME = "fused_adam"
+
+    def __init__(self):
+        super().__init__(name=self.NAME)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.adam.{self.NAME}_op'
+
+    def load(self, verbose=True):
+        return MPSFusedAdam

--- a/op_builder/mps/no_impl.py
+++ b/op_builder/mps/no_impl.py
@@ -1,4 +1,3 @@
-# Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team

--- a/op_builder/mps/no_impl.py
+++ b/op_builder/mps/no_impl.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+from .builder import MPSOpBuilder
+
+
+class NotImplementedBuilder(MPSOpBuilder):
+    BUILD_VAR = "DS_BUILD_NOT_IMPLEMENTED"
+    NAME = "deepspeed_not_implemented"
+
+    def __init__(self, name=None):
+        name = self.NAME if name is None else name
+        super().__init__(name=name)
+
+    def absolute_name(self):
+        return f'deepspeed.ops.comm.{self.NAME}_op'
+
+    def load(self, verbose=True):
+        raise ValueError("This op had not been implemented on MPS backend.")

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -117,6 +117,8 @@ def set_accelerator_visible():
             br_smi = subprocess.check_output(['brsmi', 'gpu', 'list'])
             gpu_ids = filter(lambda s: 'GPU' in s, br_smi.decode('utf-8').strip().split('\n'))
             num_accelerators = len(list(gpu_ids))
+        elif get_accelerator().device_name() == 'mps':
+            num_accelerators = get_accelerator().device_count()
         else:
             assert get_accelerator().device_name() == 'cpu'
             num_accelerators = _get_cpu_socket_count()
@@ -274,7 +276,8 @@ class DistributedExec(ABC):
                 f"Skipping test because not enough GPUs are available: {num_procs} required, {get_accelerator().device_count()} available"
             )
 
-        if get_accelerator().device_name() == 'xpu':
+        # MPS cannot be used from a forked child (Metal's compiler service is lost), so spawn instead.
+        if get_accelerator().device_name() in ['xpu', 'mps']:
             self.non_daemonic_procs = True
             self.reuse_dist_env = False
 

--- a/tests/unit/ops/adam/test_adamw.py
+++ b/tests/unit/ops/adam/test_adamw.py
@@ -9,6 +9,7 @@ import pytest
 
 from deepspeed.ops.adam import FusedAdam
 from deepspeed.ops.adam import DeepSpeedCPUAdam
+from deepspeed.ops.op_builder import FusedAdamBuilder
 from unit.common import DistributedTest
 from unit.simple_model import SimpleModel
 from deepspeed.accelerator import get_accelerator
@@ -77,3 +78,34 @@ class TestAdamConfigs(DistributedTest):
         assert isinstance(ds_optimizer, opt_class)
         if adam_w_mode in [True, False]:
             assert ds_optimizer.adam_w_mode == adam_w_mode
+
+
+@pytest.mark.parametrize('adam_w_mode', [True, False], ids=["adamw", "adam"])
+@pytest.mark.parametrize('dtype', [torch.float, torch.bfloat16], ids=["fp32", "bf16"])
+def test_fused_adam_matches_torch(adam_w_mode, dtype):
+    if dtype not in get_accelerator().supported_dtypes():
+        pytest.skip(f"{dtype} not supported on {get_accelerator().device_name()}")
+    if not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME]:
+        pytest.skip("FusedAdam is not compatible")
+
+    device = get_accelerator().device_name()
+    torch.manual_seed(0)
+    ref_params = [torch.randn(1024, device=device, dtype=dtype, requires_grad=True) for _ in range(3)]
+    ds_params = [torch.nn.Parameter(p.detach().clone()) for p in ref_params]
+    optimizer_kwargs = dict(lr=1e-2, weight_decay=0.1)
+    torch_optimizer = torch.optim.AdamW if adam_w_mode else torch.optim.Adam
+    ref_optimizer = torch_optimizer(ref_params, **optimizer_kwargs)
+    ds_optimizer = FusedAdam(ds_params, adam_w_mode=adam_w_mode, **optimizer_kwargs)
+
+    for _ in range(5):
+        for ref_param, ds_param in zip(ref_params, ds_params):
+            grad = torch.randn_like(ref_param)
+            ref_param.grad = grad.clone()
+            ds_param.grad = grad.clone()
+        ref_optimizer.step()
+        ds_optimizer.step()
+
+    # bf16 storage rounds differently depending on where intermediates are kept, so allow one ulp.
+    atol = 1e-5 if dtype == torch.float else 2e-2
+    for ref_param, ds_param in zip(ref_params, ds_params):
+        torch.testing.assert_close(ds_param.float(), ref_param.float(), atol=atol, rtol=0)


### PR DESCRIPTION
## Summary

This PR is the first step (phase 0) of enabling Apple Silicon support for DeepSpeed: make single-device training work end to end with pure-PyTorch ops. 

[**To-Do in phase 1**] Metal kernels will come later and plug into the `op_builder/mps` classes added here.

The MPS accelerator was a stub: memory queries returned `None`, no communication backend was set, `fp16/bf16` were reported unsupported, and every op builder resolved to `NotImplementedBuilder`. `deepspeed.initialize` + one training step failed for every ZeRO stage on an Apple Silicon machine. This PR aims on enabling capabilities. 

### Changes

- **`accelerator/mps_accelerator.py`** — real `torch.mps` memory stats, fp16/bf16 support (bf16 gated on macOS 14+), `torch.mps.Event`, `gloo` as the comm backend, and `is_synchronized_device() = True` (PyTorch's MPS backend effectively exposes a single in-order execution stream and currently provides no public CUDA-style stream API or `record_stream` mechanism.). Unified memory makes `pin_memory` a no-op (torch's `pin_memory()` also raises under MPS).
- **`deepspeed/comm/torch.py`** — gloo cannot operate on MPS tensors (even at world size 1), so collectives stage MPS tensors through CPU copies via a `stage_on_cpu` decorator; async ops copy back on `wait()`.
- **`accelerator/abstract_accelerator.py` + `runtime/zero`** — MPS has no fp64. Gradient-norm accumulation now picks its dtype via a new concrete `is_fp64_supported()` (default `True`) and `get_norm_dtype()` instead of hard-coded `.double()`.
- **`op_builder/mps/`** — new backend package (`MPSOpBuilder`, `NotImplementedBuilder`, `FusedAdamBuilder`). `FusedAdam` is implemented with `torch._foreach_*` ops and mirrors the math in `csrc/adam/multi_tensor_adam.cu`, following the HPU precedent of Python-backed builders.
- **`tests/unit/common.py`** — MPS must use `spawn` (Metal's compiler service is lost in `forkserver` children, which hangs the harness) and reports its device count via the accelerator.
- **`tests/unit/ops/adam/test_adamw.py`** — `test_fused_adam_matches_torch` checks `FusedAdam` against `torch.optim.Adam/AdamW` on the active accelerator (fp32/bf16 × Adam/AdamW), so it also guards the CUDA kernel.

### Verified on an M5 Max (macOS 26.3, torch 2.13.0)

- ZeRO 1/2/3 × fp32/bf16/fp16 train end to end with `deepspeed.initialize` (single process). Also tested on ZeRO stage 0 which disables ZeRO completely and falling back to standard data parallelism. 
- MPS `FusedAdam` matches `torch.optim` to 2e-7 in fp32.
- `DS_ACCELERATOR=mps pytest unit/runtime/test_ds_config_dict.py unit/runtime/test_ds_initialize.py unit/runtime/half_precision/test_fp16.py unit/runtime/half_precision/test_dynamic_loss_scale.py unit/runtime/zero/test_zero_grad_clip.py unit/runtime/zero/test_zero_context.py unit/checkpoint/test_zero_optimizer.py`: 132 passed, 0 failed, 126 skipped (multi-device tests; `device_count() == 1`).

### Known limitations / follow-ups

- bf16 `FusedAdam` differs from the CUDA kernel by ~1 bf16 ulp (CUDA computes in fp32 and stores bf16; the `_foreach` path rounds in bf16).
- The CPU-staged gloo path is only exercised at world size 1 here; multi-Mac runs are untested.
- Follow-ups: macOS arm64 CI workflow, arm64 build of CPU Adam for ZeRO-Offload, Metal kernels via `torch.mps.compile_shader`, and an Apple Silicon tutorial page.

