### PR TITLE
[AutoTP] Convert HF embedding_rowwise tp_plan entries to SKIP specs

### DIFF
--- a/deepspeed/module_inject/tp_plan_converter.py
+++ b/deepspeed/module_inject/tp_plan_converter.py
@@ -6,8 +6,11 @@
 from typing import List, Dict, Optional
 from .autotp_config import TPLayerSpec, PartitionType
 
-SUPPORTED_STYLES = {"colwise", "colwise_rep", "colwise_gather_output", "rowwise", "replicated_with_grad_allreduce"}
+SUPPORTED_STYLES = {
+    "colwise", "colwise_rep", "colwise_gather_output", "rowwise", "replicated_with_grad_allreduce", "embedding_rowwise"
+}
 # `colwise_rep` was renamed to `colwise_gather_output` in huggingface/transformers#42809.
+# `embedding_rowwise` is injected for every tied-embedding model since huggingface/transformers#47579.
 
 
 class TPPlanConverter:
@@ -50,6 +53,10 @@ class TPPlanConverter:
                 gather_output = partition_style != "colwise"
             elif partition_style == "rowwise":
                 partition_type = PartitionType.ROW
+            elif partition_style == "embedding_rowwise":
+                # Vocabulary-parallel embeddings are not supported yet, so the embedding stays whole and
+                # the gathered-column tie fallback keeps any LM head tied to it replicated as well.
+                partition_type = PartitionType.SKIP
             else:  # replicated_with_grad_allreduce, the only other supported style
                 # The parameter stays whole; only its gradient needs summing across the group.
                 partition_type = PartitionType.SKIP

--- a/deepspeed/module_inject/tp_plan_converter.py
+++ b/deepspeed/module_inject/tp_plan_converter.py
@@ -20,15 +20,21 @@ class TPPlanConverter:
     def convert(hf_tp_plan: Dict[str, str]) -> Optional[List[TPLayerSpec]]:
         """Convert HF tp_plan to DeepSpeed layer specs.
 
-        Entries whose style is not supported are converted to SKIP specs instead of invalidating
-        the whole plan. Discarding the plan used to send models like Llama4 or Qwen3 down the
-        heuristic path, which shards by name patterns alone and has no notion of the modules the
-        plan deliberately excluded — on Llama4 it wraps the MoE router, whose forward returns a
-        tuple, and breaks the model. A SKIP spec keeps such layers untouched on purpose while the
-        supported entries are still applied.
+        A style outside SUPPORTED_STYLES raises ValueError and invalidates the whole plan, so a
+        style newly introduced upstream fails loudly and gets a deliberate decision rather than
+        being dropped on the quiet. Converting only the recognized entries could shard one half
+        of a column/row pair, and silently discarding the plan would send models like Llama4 or
+        Qwen3 down the heuristic path, which shards by name patterns alone and has no notion of
+        the modules the plan deliberately excluded. On Llama4 that path wraps the MoE router,
+        whose forward returns a tuple, and breaks the model.
 
-        Returns None only when no entry is convertible, so the caller can fall back to the
-        existing AutoTP path for models whose plan gives us nothing to work with.
+        Supported styles that must stay whole become SKIP specs, which keeps those layers
+        untouched on purpose while the rest of the plan is still applied: `embedding_rowwise`,
+        because vocabulary-parallel embeddings are not supported yet, and
+        `replicated_with_grad_allreduce`, which additionally sums the gradient across the group.
+
+        Returns None only for an empty plan, so the caller can fall back to the existing AutoTP
+        path for models that give us nothing to work with.
         """
         if not hf_tp_plan:
             return None

--- a/tests/unit/module_inject/test_tp_partition_config_path.py
+++ b/tests/unit/module_inject/test_tp_partition_config_path.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 
 from deepspeed.module_inject.auto_tp import AutoTP, AutoTPConfig, PartitionType, TPLayerSpec
 from deepspeed.module_inject.layers import LinearLayer
+from deepspeed.module_inject.tp_plan_converter import TPPlanConverter
 
 
 class SubAttn(nn.Module):
@@ -170,6 +171,28 @@ def test_gathered_lm_head_falls_back_for_runtime_parameter_tie():
     assert model.lm_head.weight is model.embed_tokens.weight
 
     _build_gathered_lm_head_autotp(model)._replace_module(model)
+
+    assert isinstance(model.embed_tokens, nn.Embedding)
+    assert isinstance(model.lm_head, nn.Linear)
+    assert model.lm_head.weight is model.embed_tokens.weight
+
+
+def test_tied_embedding_plan_leaves_lm_head_and_embedding_replicated():
+    model = OutputModel(tied=True)
+    specs = TPPlanConverter.convert({"embed_tokens": "embedding_rowwise", "lm_head": "colwise_gather_output"})
+
+    autotp = AutoTP(
+        module=model,
+        all_reduce_linears=[],
+        prefix="",
+        state_dict=None,
+        linear_layer_setting=None,
+        orig_layer_impl=None,
+        partition_config=AutoTPConfig(layer_specs=specs),
+    )
+    autotp.set_tensor_parallel_config(1, None)
+    autotp.update_linear_policies()
+    autotp._replace_module(model)
 
     assert isinstance(model.embed_tokens, nn.Embedding)
     assert isinstance(model.lm_head, nn.Linear)

--- a/tests/unit/module_inject/test_tp_plan_converter.py
+++ b/tests/unit/module_inject/test_tp_plan_converter.py
@@ -126,6 +126,28 @@ class TestTPPlanConverter:
         with pytest.raises(ValueError, match="unsupported partition style"):
             TPPlanConverter.convert(hf_plan)
 
+    def test_tied_embedding_style_converts_to_skip(self):
+        """`embedding_rowwise` is injected for every tied-embedding model, so rejecting it would
+        strand those models on the heuristic path. Tied embeddings stay replicated here, and the
+        entry carries no gradient all-reduce because the parameter is never split."""
+        hf_plan = {
+            "layers.*.self_attn.q_proj": "colwise",
+            "layers.*.self_attn.o_proj": "rowwise",
+            "embed_tokens": "embedding_rowwise",
+            "lm_head": "colwise_gather_output",
+        }
+        specs = TPPlanConverter.convert(hf_plan)
+
+        assert len(specs) == 4
+
+        embed_spec = [s for s in specs if "embed_tokens" in s.patterns[0]][0]
+        lm_head_spec = [s for s in specs if "lm_head" in s.patterns[0]][0]
+
+        assert embed_spec.partition_type == PartitionType.SKIP
+        assert not embed_spec.grad_allreduce
+        assert lm_head_spec.partition_type == PartitionType.COLUMN
+        assert lm_head_spec.gather_output
+
     def test_alternate_prefixes(self):
         """Test tp_plan with non-layers prefix"""
         hf_plan = {


### PR DESCRIPTION
## Problem

huggingface/transformers#47579 (on `main` since `861f4c41`, 2026-08-21) makes `PretrainedConfig.__init__` inject `"embed_tokens": "embedding_rowwise"` into `base_model_tp_plan` whenever `tie_word_embeddings` is true. `SUPPORTED_STYLES` is a strict allowlist and `convert()` raises on any style outside it, rejecting the whole plan, so AutoTP plan conversion now fails for every tied-embedding model (Qwen2/Qwen3, Llama, Gemma) built against transformers `main`.

## Fix

Recognize `embedding_rowwise` and convert it to a `SKIP` spec, which is option 2 in #8290: the entry is understood and the embedding is deliberately left replicated.

What follows is the behaviour DeepSpeed already implements rather than a new policy. `lm_head` still converts to a gathered column spec, and `_configure_gathered_column_tie_fallbacks` then sees that `lm_head.weight is embed_tokens.weight` and leaves both modules replicated, logging that coupled vocabulary-parallel embedding is not supported yet. A tied model is therefore left in the shape it has on a transformers release without the injection, with both modules replicated and the tie intact.

The entry maps to `SKIP` with `grad_allreduce` left false, unlike `replicated_with_grad_allreduce`. The parameter is never split, so `register_replicated_grad_hooks` must not register an all-reduce for it.

Styles that are still unknown continue to reject the whole plan. `test_unsupported_style_rejects_whole_plan` is unchanged and still passes.

## Verification

Run on CPU in a container at `edaa7221`, against transformers `main` (5.16.0.dev0) and torch 2.13.0+cpu.

- The two added tests fail on master with the reported `ValueError` and pass with this change.
- `tests/unit/module_inject/` and `tests/unit/runtime/test_tp_plan_extraction.py`: 47 passed, on Python 3.11 and on 3.12.
- `pre-commit run --files` on the three changed files passes yapf, check-torchdist, check-license and codespell; flake8 5.0.4 exits 0 on them under Python 3.11.
- Not verified here: `test_qwen2_tied_lm_head_falls_back_to_replicated`, which needs 2 GPUs. That is the test #8290 reports as failing and the one this change is meant to restore.

## Two things worth deciding separately

Scoping this to `embedding_rowwise` leaves the next transformers-side style to fail the same way, since the injection is unconditional and the allowlist is deny-by-default against a vocabulary DeepSpeed does not own. A general rule for unknown styles looks like a maintainer call rather than something to settle here.

Related to that, the `convert()` docstring says entries with an unsupported style become SKIP specs instead of invalidating the plan, but no code path does that, and none does after this change either: an unsupported style still raises before the loop is reached. The docstring and the raise arrived together in #8204, so I have left both alone. Happy to follow up once you have picked the policy.

Refs #8290. This covers the conversion failure only, and does not implement vocabulary-parallel tied embeddings (option 1 or 3 in that issue), so I have not used a closing keyword.
