### PR TITLE
Fix nonblocking P2P staging on MPS

### DIFF
--- a/deepspeed/comm/comm.py
+++ b/deepspeed/comm/comm.py
@@ -384,13 +384,13 @@ def recv(tensor, src=None, group=None, tag=0, prof=False, log_name='recv', debug
 @timed_op
 def isend(tensor, dst, group=None, tag=0, prof=False, log_name='isend', debug=get_caller_func()):
     global cdb
-    return cdb.send(tensor=tensor, dst=dst, group=group, tag=tag)
+    return cdb.isend(tensor=tensor, dst=dst, group=group, tag=tag)
 
 
 @timed_op
 def irecv(tensor, src=None, group=None, tag=0, prof=False, log_name='irecv', debug=get_caller_func()):
     global cdb
-    return cdb.recv(tensor=tensor, src=src, group=group, tag=tag)
+    return cdb.irecv(tensor=tensor, src=src, group=group, tag=tag)
 
 
 @timed_op

--- a/deepspeed/comm/torch.py
+++ b/deepspeed/comm/torch.py
@@ -7,6 +7,8 @@ import deepspeed
 from deepspeed import utils
 from packaging import version
 import inspect
+from threading import Lock
+import weakref
 
 from .utils import *
 from .backend import *
@@ -96,17 +98,100 @@ class Noop:
 
 
 class StagedWork:
-    """Completes a staged collective by copying the CPU results back to the original device tensors."""
+    """Completes CPU-staged operations after their underlying work finishes."""
 
-    def __init__(self, work, copy_back):
+    def __init__(self, work, complete, staged_pairs=()):
         self.work = work
-        self.copy_back = copy_back
+        self._complete_callback = complete
+        self._complete_lock = Lock()
+        self._staged_tensors = {
+            id(cpu_tensor): (weakref.ref(cpu_tensor), device_tensor)
+            for device_tensor, cpu_tensor in staged_pairs
+        }
 
-    def wait(self):
+    def _complete(self):
+        with self._complete_lock:
+            if self._complete_callback is not None:
+                self._complete_callback()
+                self._complete_callback = None
+
+    def _discard(self):
+        with self._complete_lock:
+            self._complete_callback = None
+            self._staged_tensors.clear()
+
+    def _finish_if_successful(self):
+        if self.work is None:
+            self._complete()
+        elif self.work.is_completed():
+            if self.work.is_success():
+                self._complete()
+            else:
+                self._discard()
+
+    def _restore_staged_tensors(self, value):
+        staged_tensor = self._staged_tensors.get(id(value))
+        if staged_tensor is not None and staged_tensor[0]() is value:
+            return staged_tensor[1]
+        if isinstance(value, list):
+            return [self._restore_staged_tensors(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._restore_staged_tensors(item) for item in value)
+        return value
+
+    def wait(self, *args, **kwargs):
+        result = None
         if self.work is not None:
-            self.work.wait()
-        self.copy_back()
-        return None
+            result = self.work.wait(*args, **kwargs)
+        if result is False:
+            self._discard()
+        else:
+            self._complete()
+        return result
+
+    def is_completed(self):
+        completed = self.work is None or self.work.is_completed()
+        if completed:
+            self._finish_if_successful()
+        return completed
+
+    def synchronize(self):
+        if self.work is not None:
+            self.work.synchronize()
+        self._finish_if_successful()
+
+    def result(self):
+        result = None if self.work is None else self.work.result()
+        result = self._restore_staged_tensors(result)
+        self._finish_if_successful()
+        return result
+
+    def _wrap_future(self, future, restore_tensors, is_success=lambda value: True):
+
+        def complete(future):
+            value = future.value()
+            if not is_success(value):
+                self._discard()
+                return value
+            if restore_tensors:
+                value = self._restore_staged_tensors(value)
+            self._complete()
+            return value
+
+        return future.then(complete)
+
+    def get_future(self):
+        return self._wrap_future(self.work.get_future(), restore_tensors=True)
+
+    def get_future_result(self):
+        return self._wrap_future(self.work.get_future_result(),
+                                 restore_tensors=False,
+                                 is_success=lambda result: getattr(result, 'value', result) == 0)
+
+    def __getattr__(self, name):
+        if self.work is None:
+            raise AttributeError(name)
+        return getattr(self.work, name)
 
 
 def _needs_cpu_staging(tensor):
@@ -114,12 +199,15 @@ def _needs_cpu_staging(tensor):
     return isinstance(tensor, torch.Tensor) and tensor.device.type == 'mps'
 
 
-def stage_on_cpu(func):
-    """Runs a collective on CPU copies of any MPS tensor arguments, then copies the results back.
+def stage_on_cpu(func=None, *, always_async=False, copy_results=True):
+    """Runs a collective on CPU copies of MPS tensors and retains them until completion.
 
     This is what lets DeepSpeed use the gloo backend on Apple Silicon, where device tensors are
-    not supported by any torch.distributed backend. Unified memory keeps the copies cheap.
+    not supported by any torch.distributed backend. Results are copied back unless the operation
+    only reads its staged inputs.
     """
+    if func is None:
+        return lambda wrapped_func: stage_on_cpu(wrapped_func, always_async=always_async, copy_results=copy_results)
 
     def _stage(arg, pairs):
         if _needs_cpu_staging(arg):
@@ -141,15 +229,29 @@ def stage_on_cpu(func):
 
         work = func(self, *args, **kwargs)
 
-        def copy_back():
-            for device_tensor, cpu_tensor in pairs:
-                device_tensor.copy_(cpu_tensor)
+        if copy_results:
+
+            def complete():
+                with torch.no_grad():
+                    for device_tensor, cpu_tensor in pairs:
+                        device_tensor.copy_(cpu_tensor)
+                pairs.clear()
+
+            staged_pairs = pairs
+        else:
+            staged_inputs = [cpu_tensor for _, cpu_tensor in pairs]
+            pairs.clear()
+
+            def complete():
+                staged_inputs.clear()
+
+            staged_pairs = ()
 
         # async_op is usually forwarded positionally, so resolve it against the real signature.
         bound_args = signature.bind(self, *args, **kwargs)
-        if bound_args.arguments.get('async_op', False):
-            return StagedWork(work, copy_back)
-        copy_back()
+        if always_async or bound_args.arguments.get('async_op', False):
+            return StagedWork(work, complete, staged_pairs)
+        complete()
         return work
 
     return wrapper
@@ -427,12 +529,12 @@ class TorchBackend(Backend):
         return torch.distributed.recv(tensor=tensor, src=src, group=group, tag=tag)
 
     @disable_compiler_collective
-    @stage_on_cpu
+    @stage_on_cpu(always_async=True, copy_results=False)
     def isend(self, tensor, dst, group=None, tag=0):
         return torch.distributed.isend(tensor=tensor, dst=dst, group=group, tag=tag)
 
     @disable_compiler_collective
-    @stage_on_cpu
+    @stage_on_cpu(always_async=True)
     def irecv(self, tensor, src=None, group=None, tag=0):
         return torch.distributed.irecv(tensor=tensor, src=src, group=group, tag=tag)
 

--- a/tests/unit/comm/test_p2p.py
+++ b/tests/unit/comm/test_p2p.py
@@ -1,0 +1,351 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import gc
+import importlib
+from datetime import timedelta
+from types import SimpleNamespace
+import weakref
+
+import pytest
+
+ds_comm = importlib.import_module("deepspeed.comm.comm")
+torch_backend = importlib.import_module("deepspeed.comm.torch")
+
+
+class FakeBackend:
+
+    def __init__(self):
+        self.called = None
+        self.work = object()
+
+    def send(self, **kwargs):
+        self.called = "send"
+        return self.work
+
+    def recv(self, **kwargs):
+        self.called = "recv"
+        return self.work
+
+    def isend(self, **kwargs):
+        self.called = "isend"
+        return self.work
+
+    def irecv(self, **kwargs):
+        self.called = "irecv"
+        return self.work
+
+
+class FakeTensor:
+
+    def __init__(self, value, device_type):
+        self.value = value
+        self.device = SimpleNamespace(type=device_type)
+        self.copy_count = 0
+
+    def to(self, device_type):
+        return FakeTensor(self.value, device_type)
+
+    def copy_(self, other):
+        self.value = other.value
+        self.copy_count += 1
+
+
+class FakeWork:
+
+    def __init__(self, tensor=None, wait_result=True, successful=True, work_result=None):
+        self.tensor = tensor
+        self.completed = False
+        self.wait_timeouts = []
+        self.wait_result = wait_result
+        self.successful = successful
+        self.work_result = work_result
+        self.result_error = None
+
+    def wait(self, timeout=None):
+        self.wait_timeouts.append(timeout)
+        self.completed = self.wait_result
+        if self.completed and self.tensor is not None:
+            self.tensor.value = 42
+        return self.wait_result
+
+    def is_completed(self):
+        return self.completed
+
+    def is_success(self):
+        return self.successful
+
+    def source_rank(self):
+        return 1
+
+    def synchronize(self):
+        return None
+
+    def result(self):
+        if self.result_error is not None:
+            raise self.result_error
+        return [self.tensor]
+
+    def get_future(self):
+        future = torch_backend.torch.futures.Future()
+        future.set_result([self.tensor])
+        return future
+
+    def get_future_result(self):
+        future = torch_backend.torch.futures.Future()
+        future.set_result(self.work_result)
+        return future
+
+
+@pytest.mark.parametrize(("operation", "peer_arg"), [("isend", "dst"), ("irecv", "src")])
+def test_nonblocking_p2p_uses_nonblocking_backend(monkeypatch, operation, peer_arg):
+    backend = FakeBackend()
+    monkeypatch.setattr(ds_comm, "cdb", backend)
+    monkeypatch.setattr(ds_comm.comms_logger, "enabled", False)
+
+    work = getattr(ds_comm, operation)(object(), **{peer_arg: 1})
+
+    assert backend.called == operation
+    assert work is backend.work
+
+
+def configure_mps_staging(monkeypatch, operation, fake_operation):
+    monkeypatch.setattr(torch_backend, "_needs_cpu_staging",
+                        lambda tensor: isinstance(tensor, FakeTensor) and tensor.device.type == "mps")
+    torch_dist = getattr(torch_backend.torch, "distributed")
+    monkeypatch.setattr(torch_dist, operation, fake_operation)
+    backend = object.__new__(torch_backend.TorchBackend)
+    return backend, FakeTensor(0, "mps")
+
+
+def test_inherently_async_mps_isend_retains_staging_without_copy_back(monkeypatch):
+    holder = {}
+
+    def fake_isend(tensor, **kwargs):
+        holder["tensor"] = weakref.ref(tensor)
+        holder["work"] = FakeWork()
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "isend", fake_isend)
+
+    work = backend.isend(device_tensor, dst=1)
+
+    assert isinstance(work, torch_backend.StagedWork)
+    assert device_tensor.copy_count == 0
+    device_tensor_ref = weakref.ref(device_tensor)
+    del device_tensor
+    gc.collect()
+    assert device_tensor_ref() is None
+    assert holder["tensor"]() is not None
+
+    timeout = timedelta(seconds=1)
+    assert work.wait(timeout) is True
+
+    assert holder["work"].wait_timeouts == [timeout]
+    gc.collect()
+    assert holder["tensor"]() is None
+
+
+def test_inherently_async_mps_irecv_copies_back_once_after_wait(monkeypatch):
+    holder = {}
+
+    def fake_irecv(tensor, **kwargs):
+        holder["work"] = FakeWork(tensor)
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+
+    work = backend.irecv(device_tensor, src=1)
+
+    assert isinstance(work, torch_backend.StagedWork)
+    assert work.is_completed() is False
+    assert device_tensor.copy_count == 0
+    assert device_tensor.value == 0
+
+    timeout = timedelta(seconds=1)
+    assert work.wait(timeout=timeout) is True
+
+    assert holder["work"].wait_timeouts == [timeout]
+    assert work.is_completed() is True
+    assert work.source_rank() == 1
+    assert device_tensor.copy_count == 1
+    assert device_tensor.value == 42
+    assert work.result() == [device_tensor]
+
+    assert work.wait(timeout) is True
+    assert holder["work"].wait_timeouts == [timeout, timeout]
+    assert device_tensor.copy_count == 1
+    assert device_tensor.value == 42
+
+
+def test_staged_irecv_wait_false_discards_copy_back(monkeypatch):
+    holder = {}
+
+    def fake_irecv(tensor, **kwargs):
+        holder["work"] = FakeWork(tensor, wait_result=False)
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    work = backend.irecv(device_tensor, src=1)
+
+    assert work.wait() is False
+    holder["work"].completed = True
+
+    assert work.is_completed() is True
+    assert device_tensor.copy_count == 0
+
+
+def test_staged_irecv_synchronize_waits_for_completion(monkeypatch):
+    holder = {}
+
+    def fake_irecv(tensor, **kwargs):
+        holder["work"] = FakeWork(tensor)
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    work = backend.irecv(device_tensor, src=1)
+
+    work.synchronize()
+    assert device_tensor.copy_count == 0
+
+    holder["work"].tensor.value = 42
+    holder["work"].completed = True
+    work.synchronize()
+    work.synchronize()
+
+    assert device_tensor.copy_count == 1
+    assert device_tensor.value == 42
+
+
+@pytest.mark.parametrize("completion_api", ["result", "get_future", "get_future_result"])
+def test_staged_irecv_completion_apis_copy_back_once(monkeypatch, completion_api):
+    holder = {}
+    work_result = 0
+
+    def fake_irecv(tensor, **kwargs):
+        tensor.value = 42
+        holder["work"] = FakeWork(tensor, work_result=work_result)
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    work = backend.irecv(device_tensor, src=1)
+    holder["work"].completed = True
+
+    result = getattr(work, completion_api)()
+    if completion_api == "result":
+        assert result == [device_tensor]
+    elif completion_api == "get_future":
+        assert result.wait() == [device_tensor]
+    else:
+        assert result.wait() == work_result
+
+    assert device_tensor.copy_count == 1
+    assert device_tensor.value == 42
+    assert work.wait() is True
+    assert device_tensor.copy_count == 1
+
+
+@pytest.mark.parametrize("work_result", [1, 2, 100])
+def test_staged_irecv_failed_future_result_discards_copy_back(monkeypatch, work_result):
+
+    def fake_irecv(tensor, **kwargs):
+        tensor.value = 42
+        return FakeWork(tensor, successful=False, work_result=work_result)
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    result = backend.irecv(device_tensor, src=1).get_future_result().wait()
+
+    assert result == work_result
+    assert device_tensor.copy_count == 0
+    assert device_tensor.value == 0
+
+
+def test_staged_irecv_copy_back_disables_autograd(monkeypatch):
+
+    class GradTensor(FakeTensor):
+
+        def __init__(self, value, device_type, requires_grad):
+            super().__init__(value, device_type)
+            self.tensor = torch_backend.torch.tensor(value,
+                                                     dtype=torch_backend.torch.float32,
+                                                     requires_grad=requires_grad)
+
+        def to(self, device_type):
+            return GradTensor(self.value, device_type, requires_grad=False)
+
+        def copy_(self, other):
+            self.tensor.copy_(other.tensor)
+            super().copy_(other)
+
+    def fake_irecv(tensor, **kwargs):
+        tensor.tensor.fill_(42)
+        tensor.value = 42
+        return FakeWork(tensor)
+
+    monkeypatch.setattr(torch_backend, "_needs_cpu_staging",
+                        lambda tensor: isinstance(tensor, GradTensor) and tensor.device.type == "mps")
+    torch_dist = getattr(torch_backend.torch, "distributed")
+    monkeypatch.setattr(torch_dist, "irecv", fake_irecv)
+    backend = object.__new__(torch_backend.TorchBackend)
+    device_tensor = GradTensor(0, "mps", requires_grad=True)
+
+    assert backend.irecv(device_tensor, src=1).wait() is True
+    assert device_tensor.tensor.item() == 42
+
+
+def test_staged_work_polling_finishes_copy_back_once(monkeypatch):
+    holder = {}
+
+    def fake_irecv(tensor, **kwargs):
+        holder["work"] = FakeWork(tensor)
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    work = backend.irecv(device_tensor, src=1)
+    holder["work"].tensor.value = 42
+    holder["work"].completed = True
+
+    assert work.is_completed() is True
+    assert work.is_completed() is True
+    assert device_tensor.copy_count == 1
+    assert device_tensor.value == 42
+
+
+def test_staged_work_failed_completion_discards_copy_back(monkeypatch):
+    holder = {}
+
+    def fake_irecv(tensor, **kwargs):
+        holder["work"] = FakeWork(tensor, successful=False)
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    work = backend.irecv(device_tensor, src=1)
+    holder["work"].tensor.value = 42
+    holder["work"].completed = True
+
+    assert work.is_completed() is True
+    work.synchronize()
+
+    assert device_tensor.copy_count == 0
+    assert device_tensor.value == 0
+
+
+def test_staged_work_unsupported_result_preserves_copy_back(monkeypatch):
+    holder = {}
+
+    def fake_irecv(tensor, **kwargs):
+        holder["work"] = FakeWork(tensor)
+        holder["work"].result_error = RuntimeError("result is unsupported")
+        return holder["work"]
+
+    backend, device_tensor = configure_mps_staging(monkeypatch, "irecv", fake_irecv)
+    work = backend.irecv(device_tensor, src=1)
+
+    with pytest.raises(RuntimeError, match="result is unsupported"):
+        work.result()
+
+    assert work.wait() is True
+    assert device_tensor.copy_count == 1
+    assert device_tensor.value == 42


### PR DESCRIPTION
## Summary

- route `deepspeed.comm.isend` and `irecv` through the backend's nonblocking methods
- treat point-to-point MPS staging as inherently asynchronous
- keep staged send buffers alive and copy received data back exactly once when the underlying `Work` completes
- preserve `Work` polling, result, future, and error semantics while restoring original tensor identities

This follows the unresolved MPS review note on #8293: https://github.com/deepspeedai/DeepSpeed/pull/8293#discussion_r3838066086. The existing wrapper only detects collectives with an `async_op` argument, but `isend` and `irecv` are asynchronous by contract and `irecv` has no such parameter. In addition, the public wrappers currently dispatch them to blocking backend methods.

## Validation

- `pytest tests/unit/comm/test_p2p.py` — 16 passed
- `pytest --forked tests/unit/comm/test_p2p.py` — 16 passed
- `pre-commit run --files deepspeed/comm/comm.py deepspeed/comm/torch.py tests/unit/comm/test_p2p.py`

The tests use deterministic fake MPS tensors and work handles to cover wait, polling, result and future completion, failure paths, no-grad copy-back, exactly-once behavior, and staging lifetime.
