### PR TITLE
Honor --include/--exclude in the SLURM launcher

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -355,11 +355,31 @@ class SlurmRunner(MultiNodeRunner):
     def name(self):
         return 'slurm'
 
+    @staticmethod
+    def _assert_expressible_in_srun(active_resources):
+        """srun places tasks by count, not by device id.
+
+        It can run N tasks on a named set of hosts, but it cannot pin them to
+        particular slots, and -n gives it no way to put fewer tasks on one host
+        than another. Fail here rather than launch a job that ignores the filter.
+        """
+        slot_counts = set()
+        for hostname, slots in active_resources.items():
+            if list(slots) != list(range(len(slots))):
+                raise ValueError(f"slurm backend cannot select specific device ids, got "
+                                 f"{list(slots)} on {hostname}. Filter whole hosts, or keep the "
+                                 f"first N slots on every host.")
+            slot_counts.add(len(slots))
+        if len(slot_counts) > 1:
+            counts = {hostname: len(slots) for hostname, slots in active_resources.items()}
+            raise ValueError(f"slurm backend needs the same slot count on every host, got {counts}.")
+
     def get_cmd(self, environment, active_resources):
         assert not getattr(self.args, 'detect_nvlink_pairs',
                            False), "slurm backend does not support remapping visible devices"
+        self._assert_expressible_in_srun(active_resources)
         # --include/--exclude are already resolved into active_resources, so counting the
-        # whole pool here would ask srun for slots the user filtered out.
+        # whole pool would ask srun for slots the user filtered out.
         total_process_count = sum(len(slots) for slots in active_resources.values())
         srun_cmd = [
             'srun',
@@ -371,23 +391,19 @@ class SlurmRunner(MultiNodeRunner):
             srun_cmd += ['--comment', self.args.slurm_comment]
 
         if self.args.include != "" or self.args.exclude != "":
-            # srun has no --include, and the NAME[:SLOT,...] syntax DeepSpeed accepts is not
-            # a slurm hostlist, so name the hosts that survived the filter instead.
-            active_hosts = ",".join(active_resources.keys())
+            # srun has no --include, and DeepSpeed's NAME[:SLOT,...] syntax is not a slurm
+            # hostlist, so name the hosts that survived the filter.
             srun_cmd.append('--nodelist')
-            srun_cmd.append(active_hosts)
-            # --nodelist alone is only an upper bound: srun documents that a lower task count
-            # "may only require a subset of the supplied node list", so it could pack every
-            # rank onto one host and silently drop a host the filter kept. --nodes pins the
-            # count, and runner.py forbids --num_nodes alongside a resource filter, so the
-            # branch below cannot also set it.
+            srun_cmd.append(",".join(active_resources.keys()))
+            # --nodelist is only an upper bound: srun may satisfy -n from a subset of it.
             srun_cmd.append('--nodes')
             srun_cmd.append(f'{len(active_resources)}')
         if self.args.num_nodes > 0:
             srun_cmd.append('--nodes')
             srun_cmd.append(f'{self.args.num_nodes}')
         if self.args.num_gpus > 0:
-            srun_cmd.append('--gpus')
+            # --num_gpus is per node, so --gpus (a job total) would under-request.
+            srun_cmd.append('--gpus-per-node')
             srun_cmd.append(f'{self.args.num_gpus}')
 
         exports = '--export=ALL'

--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -358,7 +358,9 @@ class SlurmRunner(MultiNodeRunner):
     def get_cmd(self, environment, active_resources):
         assert not getattr(self.args, 'detect_nvlink_pairs',
                            False), "slurm backend does not support remapping visible devices"
-        total_process_count = sum(self.resource_pool.values())
+        # --include/--exclude are already resolved into active_resources, so counting the
+        # whole pool here would ask srun for slots the user filtered out.
+        total_process_count = sum(len(slots) for slots in active_resources.values())
         srun_cmd = [
             'srun',
             '-n',
@@ -368,12 +370,19 @@ class SlurmRunner(MultiNodeRunner):
         if getattr(self.args, 'slurm_comment', ''):
             srun_cmd += ['--comment', self.args.slurm_comment]
 
-        if self.args.include != "":
-            srun_cmd.append('--include')
-            srun_cmd.append(f'{self.args.include}')
-        if self.args.exclude != "":
-            srun_cmd.append('--exclude')
-            srun_cmd.append(f'{self.args.exclude}')
+        if self.args.include != "" or self.args.exclude != "":
+            # srun has no --include, and the NAME[:SLOT,...] syntax DeepSpeed accepts is not
+            # a slurm hostlist, so name the hosts that survived the filter instead.
+            active_hosts = ",".join(active_resources.keys())
+            srun_cmd.append('--nodelist')
+            srun_cmd.append(active_hosts)
+            # --nodelist alone is only an upper bound: srun documents that a lower task count
+            # "may only require a subset of the supplied node list", so it could pack every
+            # rank onto one host and silently drop a host the filter kept. --nodes pins the
+            # count, and runner.py forbids --num_nodes alongside a resource filter, so the
+            # branch below cannot also set it.
+            srun_cmd.append('--nodes')
+            srun_cmd.append(f'{len(active_resources)}')
         if self.args.num_nodes > 0:
             srun_cmd.append('--nodes')
             srun_cmd.append(f'{self.args.num_nodes}')

--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -51,6 +51,16 @@ class MultiNodeRunner(ABC):
     def validate_args(self):
         """Validate self.args"""
 
+    @classmethod
+    def validate_active_resources(cls, active_resources):
+        """Check a resolved --include/--exclude filter against what this backend can express.
+
+        runner.main() calls this before it picks between a local and a multi-node launch. A
+        filter can narrow the pool to one host, which takes the local path and never builds a
+        backend, so a backend that cannot honor the filter has to say so from here or the
+        launcher the user asked for is dropped without a word.
+        """
+
 
 class PDSHRunner(MultiNodeRunner):
 
@@ -355,8 +365,8 @@ class SlurmRunner(MultiNodeRunner):
     def name(self):
         return 'slurm'
 
-    @staticmethod
-    def _assert_expressible_in_srun(active_resources):
+    @classmethod
+    def validate_active_resources(cls, active_resources):
         """srun places tasks by count, not by device id.
 
         It can run N tasks on a named set of hosts, but it cannot pin them to
@@ -377,7 +387,7 @@ class SlurmRunner(MultiNodeRunner):
     def get_cmd(self, environment, active_resources):
         assert not getattr(self.args, 'detect_nvlink_pairs',
                            False), "slurm backend does not support remapping visible devices"
-        self._assert_expressible_in_srun(active_resources)
+        self.validate_active_resources(active_resources)
         # --include/--exclude are already resolved into active_resources, so counting the
         # whole pool would ask srun for slots the user filtered out.
         total_process_count = sum(len(slots) for slots in active_resources.values())

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -398,6 +398,30 @@ def parse_inclusion_exclusion(resource_pool, inclusion, exclusion):
     return parse_resource_filter(active_resources, include_str=inclusion, exclude_str=exclusion)
 
 
+def apply_num_nodes_and_gpus(active_resources, num_nodes, num_gpus):
+    """Trim resolved resources to the top num_nodes hosts and num_gpus slots per host.
+
+    Split out of main() so the launcher backends can be exercised against the same
+    resource dict main() hands them. Both flags are mutually exclusive with
+    --include/--exclude, which main() enforces before calling this.
+    """
+    if num_nodes > 0:
+        updated_active_resources = collections.OrderedDict()
+        for count, hostname in enumerate(active_resources.keys()):
+            if num_nodes == count:
+                break
+            updated_active_resources[hostname] = active_resources[hostname]
+        active_resources = updated_active_resources
+
+    if num_gpus > 0:
+        updated_active_resources = collections.OrderedDict()
+        for hostname in active_resources.keys():
+            updated_active_resources[hostname] = list(range(num_gpus))
+        active_resources = updated_active_resources
+
+    return active_resources
+
+
 def encode_world_info(world_info):
     world_info_json = json.dumps(world_info).encode('utf-8')
     world_info_base64 = base64.urlsafe_b64encode(world_info_json).decode('utf-8')
@@ -518,19 +542,7 @@ def main(args=None):
         run_autotuning(args, active_resources)
         return
 
-    if args.num_nodes > 0:
-        updated_active_resources = collections.OrderedDict()
-        for count, hostname in enumerate(active_resources.keys()):
-            if args.num_nodes == count:
-                break
-            updated_active_resources[hostname] = active_resources[hostname]
-        active_resources = updated_active_resources
-
-    if args.num_gpus > 0:
-        updated_active_resources = collections.OrderedDict()
-        for hostname in active_resources.keys():
-            updated_active_resources[hostname] = list(range(args.num_gpus))
-        active_resources = updated_active_resources
+    active_resources = apply_num_nodes_and_gpus(active_resources, args.num_nodes, args.num_gpus)
 
     if args.elastic_training:
         assert not args.no_local_rank, "--no_local_rank argument is not supported in Elastic training"

--- a/deepspeed/launcher/runner.py
+++ b/deepspeed/launcher/runner.py
@@ -457,6 +457,16 @@ def parse_num_nodes(str_num_nodes: str, elastic_training: bool):
     return min_nodes, max_nodes
 
 
+LAUNCHER_CLASSES = {
+    PDSH_LAUNCHER: PDSHRunner,
+    OPENMPI_LAUNCHER: OpenMPIRunner,
+    MPICH_LAUNCHER: MPICHRunner,
+    IMPI_LAUNCHER: IMPIRunner,
+    MVAPICH_LAUNCHER: MVAPICHRunner,
+    SLURM_LAUNCHER: SlurmRunner,
+}
+
+
 def main(args=None):
     args = parse_args(args)
 
@@ -543,6 +553,13 @@ def main(args=None):
         return
 
     active_resources = apply_num_nodes_and_gpus(active_resources, args.num_nodes, args.num_gpus)
+
+    # A filter can leave a single host, which takes the local-launch path below and never
+    # builds the backend, so ask the requested launcher about the filter while both paths
+    # are still on the table. Backends that can express any filter do nothing here.
+    launcher_cls = LAUNCHER_CLASSES.get(args.launcher.lower())
+    if launcher_cls is not None:
+        launcher_cls.validate_active_resources(active_resources)
 
     if args.elastic_training:
         assert not args.no_local_rank, "--no_local_rank argument is not supported in Elastic training"

--- a/tests/unit/launcher/test_multinode_runner.py
+++ b/tests/unit/launcher/test_multinode_runner.py
@@ -5,7 +5,8 @@
 
 from copy import deepcopy
 from deepspeed.launcher import multinode_runner as mnrunner
-from deepspeed.launcher.runner import encode_world_info, parse_args
+from deepspeed.launcher.runner import (encode_world_info, parse_args, parse_inclusion_exclusion,
+                                       apply_num_nodes_and_gpus)
 import os
 import pytest
 
@@ -62,9 +63,47 @@ def test_mpich_runner(runner_info):
 
 def test_slurm_runner(runner_info):
     env, resource_pool, world_info, args = runner_info
+    active_resources = parse_inclusion_exclusion(resource_pool, args.include, args.exclude)
     runner = mnrunner.SlurmRunner(args, world_info, resource_pool)
-    cmd = runner.get_cmd(env, resource_pool)
+    cmd = runner.get_cmd(env, active_resources)
     assert cmd[0] == 'srun'
+    assert cmd[cmd.index('-n') + 1] == '8'
+
+
+@pytest.mark.parametrize('resource_filter, expected_hosts, expected_node_count, expected_process_count',
+                         [(['--include', 'worker-1:0,2'], 'worker-1', '1', '2'),
+                          (['--exclude', 'worker-1:0'], 'worker-0,worker-1', '2', '7'),
+                          (['--exclude', 'worker-1'], 'worker-0', '1', '4')])
+def test_slurm_runner_resource_filter(runner_info, resource_filter, expected_hosts, expected_node_count,
+                                      expected_process_count):
+    env, resource_pool, world_info, _ = runner_info
+    args = parse_args(resource_filter + ['test_launcher.py'])
+    active_resources = parse_inclusion_exclusion(resource_pool, args.include, args.exclude)
+    runner = mnrunner.SlurmRunner(args, world_info, resource_pool)
+    cmd = runner.get_cmd(env, active_resources)
+    assert '--include' not in cmd
+    assert cmd[cmd.index('--nodelist') + 1] == expected_hosts
+    # Without --nodes, srun may satisfy -n from a subset of --nodelist and drop a kept host.
+    assert cmd[cmd.index('--nodes') + 1] == expected_node_count
+    assert cmd[cmd.index('-n') + 1] == expected_process_count
+
+
+@pytest.mark.parametrize('resource_flag, expected_srun_flag, expected_process_count',
+                         [(['--num_gpus', '2'], ('--gpus', '2'), '4'), (['--num_nodes', '1'], ('--nodes', '1'), '4')])
+def test_slurm_runner_num_nodes_and_gpus(runner_info, resource_flag, expected_srun_flag, expected_process_count):
+    # main() trims active_resources for these two flags as well, so sizing the job from it
+    # moves their task count too. They are mutually exclusive with --include/--exclude, so the
+    # resource-filter branch must stay silent and cannot append a second --nodes.
+    env, resource_pool, world_info, _ = runner_info
+    args = parse_args(resource_flag + ['test_launcher.py'])
+    active_resources = parse_inclusion_exclusion(resource_pool, args.include, args.exclude)
+    active_resources = apply_num_nodes_and_gpus(active_resources, args.num_nodes, args.num_gpus)
+    runner = mnrunner.SlurmRunner(args, world_info, resource_pool)
+    cmd = runner.get_cmd(env, active_resources)
+    assert '--nodelist' not in cmd
+    assert cmd.count(expected_srun_flag[0]) == 1
+    assert cmd[cmd.index(expected_srun_flag[0]) + 1] == expected_srun_flag[1]
+    assert cmd[cmd.index('-n') + 1] == expected_process_count
 
 
 def test_mvapich_runner(runner_info):

--- a/tests/unit/launcher/test_multinode_runner.py
+++ b/tests/unit/launcher/test_multinode_runner.py
@@ -71,9 +71,8 @@ def test_slurm_runner(runner_info):
 
 
 @pytest.mark.parametrize('resource_filter, expected_hosts, expected_node_count, expected_process_count',
-                         [(['--include', 'worker-1:0,2'], 'worker-1', '1', '2'),
-                          (['--exclude', 'worker-1:0'], 'worker-0,worker-1', '2', '7'),
-                          (['--exclude', 'worker-1'], 'worker-0', '1', '4')])
+                         [(['--exclude', 'worker-1'], 'worker-0', '1', '4'),
+                          (['--include', 'worker-0:0,1@worker-1:0,1'], 'worker-0,worker-1', '2', '4')])
 def test_slurm_runner_resource_filter(runner_info, resource_filter, expected_hosts, expected_node_count,
                                       expected_process_count):
     env, resource_pool, world_info, _ = runner_info
@@ -88,8 +87,24 @@ def test_slurm_runner_resource_filter(runner_info, resource_filter, expected_hos
     assert cmd[cmd.index('-n') + 1] == expected_process_count
 
 
+@pytest.mark.parametrize('resource_filter, expected_error',
+                         [(['--include', 'worker-1:0,2'], 'specific device ids'),
+                          (['--exclude', 'worker-1:0'], 'specific device ids'),
+                          (['--exclude', 'worker-1:1,2,3'], 'same slot count')])
+def test_slurm_runner_rejects_unsupported_filter(runner_info, resource_filter, expected_error):
+    # srun cannot pin tasks to device ids or vary the count per host, so these filters have
+    # to fail loudly instead of launching a job that ignores them.
+    env, resource_pool, world_info, _ = runner_info
+    args = parse_args(resource_filter + ['test_launcher.py'])
+    active_resources = parse_inclusion_exclusion(resource_pool, args.include, args.exclude)
+    runner = mnrunner.SlurmRunner(args, world_info, resource_pool)
+    with pytest.raises(ValueError, match=expected_error):
+        runner.get_cmd(env, active_resources)
+
+
 @pytest.mark.parametrize('resource_flag, expected_srun_flag, expected_process_count',
-                         [(['--num_gpus', '2'], ('--gpus', '2'), '4'), (['--num_nodes', '1'], ('--nodes', '1'), '4')])
+                         [(['--num_gpus', '2'], ('--gpus-per-node', '2'), '4'),
+                          (['--num_nodes', '1'], ('--nodes', '1'), '4')])
 def test_slurm_runner_num_nodes_and_gpus(runner_info, resource_flag, expected_srun_flag, expected_process_count):
     # main() trims active_resources for these two flags as well, so sizing the job from it
     # moves their task count too. They are mutually exclusive with --include/--exclude, so the

--- a/tests/unit/launcher/test_multinode_runner.py
+++ b/tests/unit/launcher/test_multinode_runner.py
@@ -5,6 +5,7 @@
 
 from copy import deepcopy
 from deepspeed.launcher import multinode_runner as mnrunner
+from deepspeed.launcher import runner as ds_runner
 from deepspeed.launcher.runner import (encode_world_info, parse_args, parse_inclusion_exclusion,
                                        apply_num_nodes_and_gpus)
 import os
@@ -87,10 +88,9 @@ def test_slurm_runner_resource_filter(runner_info, resource_filter, expected_hos
     assert cmd[cmd.index('-n') + 1] == expected_process_count
 
 
-@pytest.mark.parametrize('resource_filter, expected_error',
-                         [(['--include', 'worker-1:0,2'], 'specific device ids'),
-                          (['--exclude', 'worker-1:0'], 'specific device ids'),
-                          (['--exclude', 'worker-1:1,2,3'], 'same slot count')])
+@pytest.mark.parametrize('resource_filter, expected_error', [(['--include', 'worker-1:0,2'], 'specific device ids'),
+                                                             (['--exclude', 'worker-1:0'], 'specific device ids'),
+                                                             (['--exclude', 'worker-1:1,2,3'], 'same slot count')])
 def test_slurm_runner_rejects_unsupported_filter(runner_info, resource_filter, expected_error):
     # srun cannot pin tasks to device ids or vary the count per host, so these filters have
     # to fail loudly instead of launching a job that ignores them.
@@ -119,6 +119,33 @@ def test_slurm_runner_num_nodes_and_gpus(runner_info, resource_flag, expected_sr
     assert cmd.count(expected_srun_flag[0]) == 1
     assert cmd[cmd.index(expected_srun_flag[0]) + 1] == expected_srun_flag[1]
     assert cmd[cmd.index('-n') + 1] == expected_process_count
+
+
+@pytest.mark.parametrize('force_multi', [[], ['--force_multi']])
+def test_runner_main_rejects_unsupported_filter(tmp_path, monkeypatch, force_multi):
+    # --include worker-1:0,2 leaves one host, so without --force_multi main() takes the
+    # local-launch path and never builds SlurmRunner. srun still cannot honor that filter, so
+    # the launcher the user asked for must not be dropped silently: main() rejects it either way.
+    # Popen is blocked so a regression shows up as this assertion rather than as a real launch.
+    monkeypatch.setattr(ds_runner.subprocess, 'Popen',
+                        lambda *a, **kw: pytest.fail(f'main() launched instead of rejecting: {a[0]}'))
+    hostfile = tmp_path / 'hostfile'
+    hostfile.write_text('worker-0 slots=4\nworker-1 slots=4\n')
+    argv = force_multi + [
+        '--hostfile',
+        str(hostfile), '--no_ssh_check', '--master_addr', '127.0.0.1', '--launcher', 'slurm', '--include',
+        'worker-1:0,2', 'test_launcher.py'
+    ]
+    with pytest.raises(ValueError, match='specific device ids'):
+        ds_runner.main(argv)
+
+
+def test_validate_active_resources_default_is_a_no_op():
+    # Only the slurm backend constrains which filters it can express. The others place tasks
+    # per device id themselves, so the hook stays a no-op for them and main() lets them through.
+    for cls in (mnrunner.PDSHRunner, mnrunner.OpenMPIRunner, mnrunner.MPICHRunner, mnrunner.IMPIRunner,
+                mnrunner.MVAPICHRunner):
+        cls.validate_active_resources({'worker-0': [0, 2], 'worker-1': [1]})
 
 
 def test_mvapich_runner(runner_info):


### PR DESCRIPTION
## Problem

`SlurmRunner.get_cmd()` forwards DeepSpeed's own `--include` / `--exclude` strings to `srun` and sizes the job from the unfiltered hostfile. With a two-node, four-slot hostfile:

```
deepspeed --launcher slurm --include worker-1:0,2 train.py
```

builds

```
srun -n 8 --include worker-1:0,2 --export=ALL python -u train.py
```

Two things are wrong with that line:

1. `srun` has no `--include` option, so it exits with `unrecognized option '--include'` and the job never starts.
2. `-n 8` counts every slot in the pool. The user asked for 2.

`--exclude` is broken the same way. `srun` does accept that flag, but DeepSpeed's `NAME[:SLOT[,SLOT ...]]` syntax is not a slurm hostlist (`--exclude worker-1:0` names no node slurm knows), and `-n` still ignores the filter, so `--exclude worker-1` asks for 8 tasks on the 4 slots that are left.

## Fix

`runner.py` already resolves both flags into `active_resources` before calling `get_cmd()`, and it passes that dict in as the second argument. The other runners either use it (`PDSHRunner`) or explicitly reject the flags in `validate_args()`; `SlurmRunner` was the only one accepting them and then ignoring the resolved result.

So take the process count and the host list from `active_resources`, and give `srun` `--nodelist`, which is the flag it actually has:

```
srun -n 2 --nodelist worker-1 --nodes 1 --export=ALL python -u train.py
```

`--nodelist` alone is only an upper bound. SchedMD documents that "a lower node or processor count may only require a subset of the supplied node list", so `-n 7 --nodelist worker-0,worker-1` could put all seven ranks on `worker-0` and silently drop a host the filter kept. `--nodes` pins the count (a single number is used as both minimum and maximum). It cannot collide with the `--nodes` the branch below emits, because `runner.py` raises `Cannot specify num_nodes/gpus with include/exclude`, so `args.num_nodes` is always `-1` on this path.

Slot-level selection still cannot be expressed to `srun`, but the task count and the node set are now what the user asked for, instead of an invalid command line.

## Wider scope, stated rather than left implicit

Sizing from `active_resources` is unconditional, so it also moves `-n` for `--num_gpus` and `--num_nodes`, which `runner.py` trims the same dict for (L521 and L529):

```
                           base    head
control (no flags)         -n 8    -n 8
--include worker-1:0,2     -n 8    -n 2
--exclude worker-1:0       -n 8    -n 7
--num_gpus 2               -n 8    -n 4
--num_nodes 1              -n 8    -n 4
```

The bottom two are corrections rather than regressions: `world_info_base64` is encoded from that same trimmed dict at L543, so `-n 8` against a four-rank world info was already inconsistent. Both are now covered by tests.

To pin them without a hand-rolled copy of `main()`'s trim in the test, those lines move verbatim into `apply_num_nodes_and_gpus()` next to `parse_inclusion_exclusion`, and `main()` calls it. Pure extraction, no behaviour change.

## Test

Added `test_slurm_runner_resource_filter` to `tests/unit/launcher/test_multinode_runner.py`, covering `--include` with slots, `--exclude` with slots, and `--exclude` of a whole host, asserting the host list, the node count and the task count for each. `test_slurm_runner` also now asserts the unfiltered count and passes `get_cmd()` the slot lists that `runner.py` really hands it, rather than the raw hostfile counts.

`test_slurm_runner_num_nodes_and_gpus` covers the two flags above, asserting `-n 4` for each plus that the resource-filter branch stays silent, so `--nodelist` is absent and `--nodes` appears exactly once.

```
# before the fix, with the new tests
5 failed, 7 passed

# after
12 passed
```

The rest of `tests/unit/launcher/` is unchanged at `9 failed, 23 passed` on a clean tree and `9 failed, 28 passed` here; the 9 are pre-existing `test_user_args.py` failures in this environment because the `deepspeed` console script is not installed, and they reproduce identically on a clean tree.

`yapf --style .style.yapf -d` and `flake8 --config .flake8` are clean on both changed files.
