### PR TITLE
Raise the per-tensor norms to norm_type when combining them

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -401,7 +401,10 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
                 param_norm = p.grad.data.detach().float().norm(norm_type)
                 all_norms.append(param_norm)
         if len(all_norms) > 0:
-            total_norm = torch.stack(all_norms).square().sum().float()
+            # The p-norm over every gradient is (sum_i ||g_i||_p ** p) ** (1/p), and the
+            # 1/norm_type root is taken below, so each per-parameter norm has to be raised
+            # to norm_type here. Squaring only matches that for norm_type == 2.
+            total_norm = torch.stack(all_norms).pow(norm_type).sum().float()
         else:
             total_norm = get_accelerator().FloatTensor([0.0])
         total_norm = total_norm.to(get_accelerator().current_device_name())

--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -2283,7 +2283,7 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             for g, p in zip(gradients, params):
                 if is_model_parallel_parameter(p) or (self.model_parallel_rank == 0):
                     grad_norms.append(
-                        g.to(get_accelerator().device_name(), non_blocking=True).to(get_norm_dtype()).norm(2))
+                        g.to(get_accelerator().device_name(), non_blocking=True).to(get_norm_dtype()).norm(norm_type))
 
             # Sum across all model parallel GPUs.
             if len(grad_norms) == 0:
@@ -2291,7 +2291,9 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
                 total_norm_cuda = torch.tensor(0, dtype=gradients[0].dtype).to(get_accelerator().device_name()).to(
                     get_norm_dtype())
             else:
-                total_norm_cuda = torch.sum(torch.pow(torch.stack(grad_norms), 2))
+                # Each entry is ||g||_norm_type and the 1/norm_type root is taken below, so
+                # both the per-tensor norm above and this exponent follow norm_type.
+                total_norm_cuda = torch.sum(torch.pow(torch.stack(grad_norms), norm_type))
 
             dist.all_reduce(total_norm_cuda, op=dist.ReduceOp.SUM, group=process_group)
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2090,7 +2090,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         torch.linalg.vector_norm(g.data.to(get_norm_dtype()).detach(),
                                                  ord=norm_type).to(get_accelerator().current_device_name()))
             if len(all_norms) > 0:
-                total_norm = torch.stack(all_norms).square().sum().float()
+                # vector_norm above already gives each ||g||_norm_type, and the 1/norm_type
+                # root is taken below, so the exponent here has to be norm_type too.
+                total_norm = torch.stack(all_norms).pow(norm_type).sum().float()
             else:
                 total_norm = torch.tensor(0.0, dtype=torch.float32).to(self.device)
             # Sum across all model parallel Device.

--- a/tests/unit/runtime/test_runtime_utils.py
+++ b/tests/unit/runtime/test_runtime_utils.py
@@ -73,6 +73,34 @@ class TestClipGradNorm(DistributedTest):
         assert torch.equal(params_expected[1].grad, params_actual[1].grad)
 
 
+class TestClipGradNormPNorm(DistributedTest):
+    # world_size 1 so this runs wherever the suite runs; the bug is in the per-rank
+    # recombination of the norms, which is independent of the group size.
+    world_size = 1
+
+    @pytest.mark.parametrize("norm_type", [1, 2, 3])
+    def test_matches_torch(self, norm_type):
+        # The p-norm over all gradients is (sum_i ||g_i||_p ** p) ** (1/p). Squaring the
+        # per-parameter norms computes that only for p == 2, which is the control here.
+        def test_params():
+            param1 = torch.nn.Parameter(torch.zeros(2))
+            param1.grad = torch.Tensor([3.0, -4.0])
+            param2 = torch.nn.Parameter(torch.zeros(1))
+            param2.grad = torch.Tensor([2.0])
+            return [param1, param2]
+
+        max_norm = 1.0
+        params_expected = test_params()
+        expected_norm = torch.nn.utils.clip_grad_norm_(params_expected, max_norm, norm_type=norm_type)
+
+        params_actual = test_params()
+        actual_norm = ds_utils.clip_grad_norm_(params_actual, max_norm=max_norm, norm_type=norm_type)
+
+        assert torch.allclose(actual_norm.float().cpu(), expected_norm.float().cpu())
+        for expected, actual in zip(params_expected, params_actual):
+            assert torch.allclose(actual.grad, expected.grad)
+
+
 @pytest.mark.parametrize("check_using_norm", [(False), (True)])
 class TestCheckOverflow(DistributedTest):
     world_size = 2

--- a/tests/unit/runtime/zero/test_zero_grad_clip.py
+++ b/tests/unit/runtime/zero/test_zero_grad_clip.py
@@ -10,6 +10,7 @@ from deepspeed.runtime.zero.stage3 import DeepSpeedZeroOptimizer_Stage3
 from deepspeed.utils import safe_get_local_grad, safe_set_local_grad
 from deepspeed.accelerator import get_accelerator
 from unit.simple_model import SimpleModel
+from unit.common import DistributedTest
 import os
 
 
@@ -46,6 +47,38 @@ def get_config(precision, clip_value, offload_device="cpu"):
         }
 
     return config
+
+
+@pytest.mark.parametrize("zero_stage", [1, 2, 3])
+@pytest.mark.parametrize("norm_type", [1, 2, 3])
+class TestZeroGradNormPNorm(DistributedTest):
+    world_size = 1
+
+    def test_matches_flat_norm(self, zero_stage, norm_type):
+        # get_grad_norm_direct returns the norm of the gradients viewed as a single vector,
+        # so on one rank with no model parallelism it must equal the p-norm of the
+        # concatenation. norm_type 2 is the control: it is right on both sides.
+        config = {
+            "train_batch_size": 1,
+            "optimizer": {
+                "type": "Adam",
+                "params": {
+                    "lr": 1e-4
+                }
+            },
+            "zero_optimization": {
+                "stage": zero_stage
+            },
+        }
+        model = SimpleModel(hidden_dim=4, nlayers=2)
+        engine, optimizer, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+
+        gradients = [torch.Tensor([3.0, -4.0]), torch.Tensor([2.0])]
+        params = list(model.parameters())[:len(gradients)]
+        expected = torch.cat([g.reshape(-1) for g in gradients]).norm(float(norm_type))
+
+        actual = optimizer.get_grad_norm_direct(gradients, params, norm_type=norm_type)
+        assert torch.allclose(torch.as_tensor(actual).float().cpu(), expected.float().cpu())
 
 
 @pytest.mark.parametrize("precision,clip_value,offload_device", [


### PR DESCRIPTION
## Problem

The p-norm over a set of tensors is

```
||g||_p = ( sum_i ||g_i||_p ** p ) ** (1/p)
```

so combining per-tensor norms means raising each one to `norm_type`. Three functions take the `1/norm_type` root but hardcode the exponent at 2, so they are correct only when `norm_type == 2`:

| file | function | how it combines |
|---|---|---|
| `runtime/utils.py` | `clip_grad_norm_` | `torch.stack(all_norms).square().sum()` |
| `runtime/zero/stage_1_and_2.py` | `get_grad_norm_direct` | `torch.stack(all_norms).square().sum()` |
| `runtime/zero/stage3.py` | `get_grad_norm_direct` | `.norm(2)` per tensor, then `torch.pow(..., 2)` |

`stage3` is wrong twice over: it takes an **L2** norm per tensor whatever `norm_type` says, sums the squares, and then takes the `1/norm_type` root, so it never computes a p-norm at all.

`norm_type` is a documented argument on all three (*"type of the used p-norm"*). Measured against the p-norm of the concatenated gradients, on grads `[3, -4]` and `[2]`:

| | p=1 | p=2 | p=3 |
|---|---|---|---|
| ground truth | 9.000 | 5.385 | 4.626 |
| `clip_grad_norm_` | 53.000 | 5.385 | 2.894 |
| ZeRO 1/2 | 53.000 | 5.385 | 2.894 |
| ZeRO 3 | 29.000 | 5.385 | 3.072 |

At p=1 `clip_grad_norm_` reports `7**2 + 2**2 = 53` where the answer is `7 + 2 = 9`; at p=3 all three under-clip. The returned norm is wrong and so are the resulting gradients, not just the reported number.

**Scope, stated up front rather than buried.** No DeepSpeed config reaches this. `norm_type` is not a config key (absent from `runtime/config.py`, `constants.py` and `config_utils.py`), and every in-tree call site passes the default 2: `engine.py` L3326 and L3339 for `clip_grad_norm_`, `stage_1_and_2.py` L2245 and `stage3.py` L2395 for `get_grad_norm_direct`. Both fp16 optimizers pin `self.norm_type = 2`, and `BF16_Optimizer`'s `norm_type` default is not overridden; where a threaded `self.norm_type` does reach a norm helper it lands on `get_global_norm_of_tensors` and `get_norm_with_moe_layers`, which are already correct.

So p=2 is the only column a DeepSpeed run reaches today, and there `pow(2.0)` and `.square()` agree exactly. What this fixes is the documented `norm_type` argument for direct callers of `runtime/utils.clip_grad_norm_` and the two `get_grad_norm_direct` methods, including code outside this repo, and it removes a defect that would become live the moment anything threads a non-default `norm_type` through.

## Where it came from

`clip_grad_norm_` is a regression from #4915, which vectorized the accumulation. Before that commit the loop read

```python
param_norm = p.grad.data.float().norm(norm_type)
total_norm += param_norm.item()**norm_type
```

and the rewrite replaced the `**norm_type` with `.square()` while keeping `.pow(1. / norm_type)` below. The norm-combining sites that commit did **not** touch all still raise to `norm_type`, which is what makes the intended rule unambiguous rather than a matter of taste: `get_flattened_grad_norm` (L483), `get_weight_norm` (L579), `get_global_norm_of_tensors` (L927) and `get_norm_with_moe_layers` (L1144). `scaled_global_norm` in `stage_1_and_2.py` takes the other honest route and asserts `norm_type == 2` outright.

## Fix

Follow `norm_type` at each of the three sites. In `stage3` that means the per-tensor `.norm()` as well as the exponent.

`norm_type` is `float()`-ed in all three functions, so the default becomes `pow(2.0)`, which is bit-identical to `square()` on float32; checked over 20000 random vectors spanning a wide dynamic range, zero differing elements. Combined with the call-site audit above, the default path is provably unchanged.

Deliberately not touched: `complete_grad_norm_calculation_for_cpu_offload` in both ZeRO files takes the same `1/norm_type` root over squares, but it accepts no `norm_type` argument and sets `norm_type = 2.0` as a local, so it is self-consistent L2 and correct as written. A repo-wide sweep finds nine sites taking a `1/norm_type` root: four already correct, those two self-consistent, and the three fixed here.

## Test

- `TestClipGradNormPNorm::test_matches_torch` in `tests/unit/runtime/test_runtime_utils.py`, parametrized over `norm_type` in `1, 2, 3` against `torch.nn.utils.clip_grad_norm_`, asserting both the returned norm and the resulting gradients.
- `TestZeroGradNormPNorm::test_matches_flat_norm` in `tests/unit/runtime/zero/test_zero_grad_clip.py`, parametrized over `zero_stage` in `1, 2, 3` and `norm_type` in `1, 2, 3`, asserting `get_grad_norm_direct` equals the p-norm of the concatenated gradients on a single rank.

`norm_type=2` is the control throughout: it passes on both sides.

```
# new tests against the unpatched sources
8 failed, 8 passed, 6 skipped     (2 from clip_grad_norm_, 6 from ZeRO: p in {1,3} x stage in {1,2,3})

# after the fix
16 passed, 6 skipped

# clean tree, same two files, without the new tests
4 passed, 6 skipped
```

4 + 12 new = 16, so the net difference is exactly the twelve new cases and nothing else moved. The 6 skips are pre-existing and identical throughout.

Both new classes use `world_size = 1` so they run wherever the suite runs; the defect is in the per-rank recombination and is independent of group size.

`yapf --style .style.yapf -d` and `flake8 --config .flake8` are clean on all five files, with nothing reported on the clean-tree copies either.
