### PR TITLE
Count each module object once when aggregating flops profiler totals

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -1178,22 +1178,14 @@ def duration_to_string(duration, units=None, precision=DEFAULT_PRECISION):
     return f"{number_to_string(duration, units=units, precision=precision)}s"
 
 
-    # can not iterate over all submodules using self.model.modules()
-    # since modules() returns duplicate modules only once
 def get_module_flops(module):
-    sum = module.__flops__
-    # iterate over immediate children modules
-    for child in module.children():
-        sum += get_module_flops(child)
-    return sum
+    # Each module object owns a single __flops__ accumulator that every forward call adds
+    # into, so visiting an aliased module once already counts all of its calls.
+    return sum(m.__flops__ for m in module.modules())
 
 
 def get_module_macs(module):
-    sum = module.__macs__
-    # iterate over immediate children modules
-    for child in module.children():
-        sum += get_module_macs(child)
-    return sum
+    return sum(m.__macs__ for m in module.modules())
 
 
 def get_module_duration(module):

--- a/tests/unit/profiling/flops_profiler/test_flops_profiler.py
+++ b/tests/unit/profiling/flops_profiler/test_flops_profiler.py
@@ -180,3 +180,44 @@ def test_print_model_profile_with_none_dp_world_size(capsys):
     assert match is not None
     # The sequence-data-parallel world size is reported in place of the None dp_world_size.
     assert match.group(1) == "4"
+
+
+class Block(torch.nn.Module):
+
+    def __init__(self, linear):
+        super().__init__()
+        self.linear = linear
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class SplitLinears(torch.nn.Module):
+    # Three blocks over three 100-wide slices of the input; with shared=True one Linear object
+    # is held by all three. The blocks are load bearing: named_children() already skips a
+    # repeat among immediate siblings, so a shared module must sit under distinct parents.
+    def __init__(self, shared):
+        super().__init__()
+        shared_linear = torch.nn.Linear(100, 100, bias=False)
+        self.blocks = torch.nn.ModuleList(
+            [Block(shared_linear if shared else torch.nn.Linear(100, 100, bias=False)) for _ in range(3)])
+
+    def forward(self, x):
+        return tuple(block(part) for block, part in zip(self.blocks, torch.split(x, 100, dim=1)))
+
+
+@pytest.mark.sequential
+@pytest.mark.parametrize("shared", [True, False])
+def test_flops_profiler_counts_shared_module_once(shared):
+    # Regression test for https://github.com/deepspeedai/DeepSpeed/issues/7256
+    # Sharing a submodule changes how many tree positions reach it, not how much work runs, so
+    # both models report the same totals: three Linear(100, 100) calls, 100 * 100 MACs each.
+    flops, macs, params = get_model_profile(model=SplitLinears(shared).eval(),
+                                            input_shape=(1, 300),
+                                            print_profile=False,
+                                            detailed=False,
+                                            warm_up=1,
+                                            as_string=False)
+    assert flops == 60000
+    assert macs == 30000
+    assert params == (10000 if shared else 30000)


### PR DESCRIPTION
`get_module_flops` and `get_module_macs` aggregate by walking `children()` and adding each child's subtree into a running total. A submodule object that is aliased at several positions in the tree is reached once per position, so its flops are added that many times. The issue's model shares one `Linear(100, 100)` across three parents and reports 180 KFLOPs where the work done is 60 KFLOPs.

The per-module counters are already correct. Each module object owns one `__flops__` accumulator and the forward hook adds into it on every call, so the shared `Linear` there ends up holding 60000, the flops of all three calls. Visiting that object once is what counts every call; the extra visits re-add the same number.

The comment above `get_module_flops` ruled out `modules()` because it "returns duplicate modules only once". That is accurate about `modules()`, and given a per-object accumulator it is the behaviour the aggregation wants, so this replaces the walk with a sum over `modules()` instead of leaving the comment standing next to code that no longer follows it.

Note that `named_children()` already skips a repeat among immediate siblings, so this only ever showed up when the shared module sat under distinct parents, as it does in the report.

### Verification

- On the issue's own script the total goes from 180 KFLOPs / 90 KMACs to 60 KFLOPs / 30 KMACs, which is what `torch.profiler` reports for the same model on both the shared and unshared variants.
- Added `test_flops_profiler_counts_shared_module_once`, which fails on master at `assert 180000 == 60000` and passes here for both `shared=True` and `shared=False`. It is marked `sequential`, so it runs in the second `cpu-torch-latest` pytest leg, where the file is 4 passed.
- `pre-commit run --files` passes on both changed files under Python 3.10, the formatting job's environment.
- Not checked: the RNN flop hooks write the same accumulator but no RNN module was exercised. `get_module_duration` and the per-depth table in `print_model_profile` still aggregate per tree position rather than per object; whether they should change too is a separate question I have not measured.

Fixes #7256
