### PR TITLE
XPU: register native pinned host memory with the SYCL runtime

### DIFF
--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+import ctypes
 import torch
 from deepspeed.accelerator.abstract_accelerator import DeepSpeedAccelerator
 import functools
@@ -14,6 +15,29 @@ try:
     oneccl_imported_p = True
 except ImportError as e:
     oneccl_imported_p = False
+
+# Mangled names of ``sycl::ext::oneapi::experimental::prepare_for_device_copy(const void*, size_t, const queue&)``
+# and ``release_from_device_copy(const void*, const queue&)``. These are the SYCL
+# equivalent of ``cudaHostRegister``/``cudaHostUnregister``. Neither SYCL nor torch
+# exposes a C entry point for them, so the C++ symbols are resolved directly.
+SYCL_PREPARE_FOR_DEVICE_COPY = "_ZN4sycl3_V13ext6oneapi12experimental23prepare_for_device_copyEPKvmRKNS0_5queueE"
+SYCL_RELEASE_FROM_DEVICE_COPY = "_ZN4sycl3_V13ext6oneapi12experimental24release_from_device_copyEPKvRKNS0_5queueE"
+
+
+@functools.lru_cache(maxsize=None)
+def _sycl_host_copy_funcs():
+    """Resolve the SYCL host-registration functions, or return None when unavailable."""
+    try:
+        libsycl = ctypes.CDLL("libsycl.so", mode=ctypes.RTLD_GLOBAL)
+        prepare = getattr(libsycl, SYCL_PREPARE_FOR_DEVICE_COPY)
+        release = getattr(libsycl, SYCL_RELEASE_FROM_DEVICE_COPY)
+    except (OSError, AttributeError):
+        return None
+    prepare.restype = None
+    prepare.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p]
+    release.restype = None
+    release.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    return prepare, release
 
 
 class XPU_Accelerator(DeepSpeedAccelerator):
@@ -233,6 +257,31 @@ class XPU_Accelerator(DeepSpeedAccelerator):
 
     def _torch_is_pinned(self, tensor):
         return tensor.is_pinned(device=self.current_device_name())
+
+    def register_host_memory(self, address, num_bytes):
+        funcs = _sycl_host_copy_funcs()
+        if funcs is None:
+            from deepspeed.utils import logger
+            logger.warning_once(
+                "SYCL host-memory registration is unavailable (prepare_for_device_copy not found in libsycl.so); "
+                "native pinned memory stays mlock-only.")
+            return False
+        prepare, _ = funcs
+        prepare(address, num_bytes, self._sycl_queue())
+        return True
+
+    def unregister_host_memory(self, address):
+        funcs = _sycl_host_copy_funcs()
+        if funcs is None:
+            return None
+        _, release = funcs
+        release(address, self._sycl_queue())
+
+    def _sycl_queue(self):
+        # prepare_for_device_copy registers with the queue's SYCL context, so any
+        # queue on the current device gives the same registration.
+        torch.xpu.init()
+        return torch.xpu.current_stream().sycl_queue
 
     def op_builder_dir(self):
         try:

--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -19,23 +19,44 @@ except ImportError as e:
 # Mangled names of ``sycl::ext::oneapi::experimental::prepare_for_device_copy(const void*, size_t, const queue&)``
 # and ``release_from_device_copy(const void*, const queue&)``. These are the SYCL
 # equivalent of ``cudaHostRegister``/``cudaHostUnregister``. Neither SYCL nor torch
-# exposes a C entry point for them, so the C++ symbols are resolved directly.
+# exposes a C entry point for them, so the C++ symbols are resolved directly. The
+# names live in SYCL's ``_V1`` inline ABI namespace and are stable across the
+# libsycl.so.8 (oneAPI 2025.x) and libsycl.so.9 (oneAPI 2026.x) runtimes.
 SYCL_PREPARE_FOR_DEVICE_COPY = "_ZN4sycl3_V13ext6oneapi12experimental23prepare_for_device_copyEPKvmRKNS0_5queueE"
 SYCL_RELEASE_FROM_DEVICE_COPY = "_ZN4sycl3_V13ext6oneapi12experimental24release_from_device_copyEPKvRKNS0_5queueE"
 
-# The soname (not the ``libsycl.so`` development symlink) of the runtime torch
-# links against. Loaded with RTLD_NOLOAD so we only ever bind to the instance
-# torch already initialized; opening a second SYCL runtime leaves both with
-# their own driver state and aborts at interpreter shutdown.
-SYCL_RUNTIME_SONAME = "libsycl.so.8"
+# Only ever bind to the SYCL runtime torch already initialized. Opening a second
+# one (e.g. via the ``libsycl.so`` development symlink, which may resolve to a
+# different oneAPI install) leaves both with their own driver state and aborts at
+# interpreter shutdown with UR_RESULT_ERROR_UNINITIALIZED.
 RTLD_NOLOAD = 0x00004
 
 
-@functools.lru_cache(maxsize=None)
+def _mapped_sycl_runtime_path():
+    """Path of the libsycl the current process already mapped, or None.
+
+    Read from /proc/self/maps rather than hardcoding a soname: the soname is
+    version-dependent (oneAPI 2025.x ships libsycl.so.8, 2026.x ships .so.9) and
+    the path also disambiguates between several oneAPI installs on one machine.
+    """
+    try:
+        with open("/proc/self/maps") as maps:
+            for line in maps:
+                path = line.rstrip("\n").rpartition(" ")[2]
+                if "/libsycl.so" in path:
+                    return path
+    except OSError:
+        return None
+    return None
+
+
 def _sycl_host_copy_funcs():
     """Resolve the SYCL host-registration functions, or return None when unavailable."""
+    runtime_path = _mapped_sycl_runtime_path()
+    if runtime_path is None:
+        return None
     try:
-        libsycl = ctypes.CDLL(SYCL_RUNTIME_SONAME, mode=RTLD_NOLOAD)
+        libsycl = ctypes.CDLL(runtime_path, mode=RTLD_NOLOAD)
         prepare = getattr(libsycl, SYCL_PREPARE_FOR_DEVICE_COPY)
         release = getattr(libsycl, SYCL_RELEASE_FROM_DEVICE_COPY)
     except (OSError, AttributeError):
@@ -273,7 +294,7 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         if funcs is None:
             from deepspeed.utils import logger
             logger.warning_once("SYCL host-memory registration is unavailable (prepare_for_device_copy not found in "
-                                f"{SYCL_RUNTIME_SONAME}); native pinned memory stays mlock-only.")
+                                "the loaded SYCL runtime); native pinned memory stays mlock-only.")
             return False
         prepare, _ = funcs
         prepare(address, num_bytes, sycl_queue)

--- a/accelerator/xpu_accelerator.py
+++ b/accelerator/xpu_accelerator.py
@@ -23,12 +23,19 @@ except ImportError as e:
 SYCL_PREPARE_FOR_DEVICE_COPY = "_ZN4sycl3_V13ext6oneapi12experimental23prepare_for_device_copyEPKvmRKNS0_5queueE"
 SYCL_RELEASE_FROM_DEVICE_COPY = "_ZN4sycl3_V13ext6oneapi12experimental24release_from_device_copyEPKvRKNS0_5queueE"
 
+# The soname (not the ``libsycl.so`` development symlink) of the runtime torch
+# links against. Loaded with RTLD_NOLOAD so we only ever bind to the instance
+# torch already initialized; opening a second SYCL runtime leaves both with
+# their own driver state and aborts at interpreter shutdown.
+SYCL_RUNTIME_SONAME = "libsycl.so.8"
+RTLD_NOLOAD = 0x00004
+
 
 @functools.lru_cache(maxsize=None)
 def _sycl_host_copy_funcs():
     """Resolve the SYCL host-registration functions, or return None when unavailable."""
     try:
-        libsycl = ctypes.CDLL("libsycl.so", mode=ctypes.RTLD_GLOBAL)
+        libsycl = ctypes.CDLL(SYCL_RUNTIME_SONAME, mode=RTLD_NOLOAD)
         prepare = getattr(libsycl, SYCL_PREPARE_FOR_DEVICE_COPY)
         release = getattr(libsycl, SYCL_RELEASE_FROM_DEVICE_COPY)
     except (OSError, AttributeError):
@@ -259,27 +266,30 @@ class XPU_Accelerator(DeepSpeedAccelerator):
         return tensor.is_pinned(device=self.current_device_name())
 
     def register_host_memory(self, address, num_bytes):
+        # Resolve the queue first: it initializes torch's XPU runtime, which is
+        # what loads libsycl.so.8 and makes the RTLD_NOLOAD lookup below succeed.
+        sycl_queue = self._sycl_queue()
         funcs = _sycl_host_copy_funcs()
         if funcs is None:
             from deepspeed.utils import logger
-            logger.warning_once(
-                "SYCL host-memory registration is unavailable (prepare_for_device_copy not found in libsycl.so); "
-                "native pinned memory stays mlock-only.")
+            logger.warning_once("SYCL host-memory registration is unavailable (prepare_for_device_copy not found in "
+                                f"{SYCL_RUNTIME_SONAME}); native pinned memory stays mlock-only.")
             return False
         prepare, _ = funcs
-        prepare(address, num_bytes, self._sycl_queue())
+        prepare(address, num_bytes, sycl_queue)
         return True
 
     def unregister_host_memory(self, address):
+        sycl_queue = self._sycl_queue()
         funcs = _sycl_host_copy_funcs()
         if funcs is None:
             return None
         _, release = funcs
-        release(address, self._sycl_queue())
+        release(address, sycl_queue)
 
     def _sycl_queue(self):
         # prepare_for_device_copy registers with the queue's SYCL context, so any
-        # queue on the current device gives the same registration.
+        # queue on the current device yields the same registration.
         torch.xpu.init()
         return torch.xpu.current_stream().sycl_queue
 

--- a/benchmarks/pin_memory/h2d_d2h_bench.py
+++ b/benchmarks/pin_memory/h2d_d2h_bench.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # DeepSpeed Team
-"""Compare torch and native pinned-memory H2D/D2H bandwidth on one CUDA GPU."""
+"""Compare torch and native pinned-memory H2D/D2H bandwidth on one accelerator device."""
 
 import argparse
 import json
@@ -55,7 +55,9 @@ def _time_copy(accelerator, copy_fn, stream, warmup, iters):
 
 def _allocate_host(accelerator, numel, arm):
     if arm == "torch":
-        return torch.empty(numel, dtype=torch.float32, pin_memory=True)
+        # Go through the accelerator so non-CUDA backends pin against their own
+        # device rather than torch's CUDA-only ``pin_memory=True`` fast path.
+        return accelerator._torch_pin_memory(torch.empty(numel, dtype=torch.float32))
 
     return accelerator.pin_memory(torch.empty(numel, dtype=torch.float32), make_copy=False)
 
@@ -65,8 +67,8 @@ def _run_arm(args):
         os.environ[key] = value
 
     accelerator = get_accelerator()
-    if accelerator.device_name() != "cuda" or not accelerator.is_available():
-        raise RuntimeError("CUDA GPU is required")
+    if not accelerator.is_available():
+        raise RuntimeError(f"No {accelerator.device_name()} device is available")
     accelerator.set_device(0)
     stream = accelerator.Stream()
 
@@ -86,7 +88,7 @@ def _run_arm(args):
             "size_mib": size_mib,
             "h2d_gbps": num_bytes / h2d_seconds / 1e9,
             "d2h_gbps": num_bytes / d2h_seconds / 1e9,
-            "torch_is_pinned": host.is_pinned(),
+            "torch_is_pinned": accelerator._torch_is_pinned(host),
             "accelerator_is_pinned": accelerator.is_pinned(host),
         }
         print(f"RESULT={json.dumps(result, sort_keys=True)}", flush=True)

--- a/tests/unit/v1/pin_memory/test_pin_memory.py
+++ b/tests/unit/v1/pin_memory/test_pin_memory.py
@@ -222,21 +222,35 @@ def test_xpu_device_registration_calls_sycl(monkeypatch):
 
 
 def test_xpu_sycl_lookup_reuses_torch_runtime(monkeypatch):
-    """Opening a second SYCL runtime aborts at shutdown, so only RTLD_NOLOAD on the soname is allowed."""
+    """Only the already-mapped runtime may be opened, and only with RTLD_NOLOAD.
+
+    Opening a second SYCL runtime (or a hardcoded soname that may resolve to a
+    different oneAPI install) aborts at interpreter shutdown.
+    """
     calls = []
+    mapped = "/some/env/lib/libsycl.so.9"
 
     def fake_cdll(name, mode=0):
         calls.append((name, mode))
         raise OSError("not loaded")
 
+    monkeypatch.setattr(xpu_accelerator, "_mapped_sycl_runtime_path", lambda: mapped)
     monkeypatch.setattr(xpu_accelerator.ctypes, "CDLL", fake_cdll)
-    xpu_accelerator._sycl_host_copy_funcs.cache_clear()
-    try:
-        assert xpu_accelerator._sycl_host_copy_funcs() is None
-    finally:
-        xpu_accelerator._sycl_host_copy_funcs.cache_clear()
 
-    assert calls == [(xpu_accelerator.SYCL_RUNTIME_SONAME, xpu_accelerator.RTLD_NOLOAD)]
+    assert xpu_accelerator._sycl_host_copy_funcs() is None
+    assert calls == [(mapped, xpu_accelerator.RTLD_NOLOAD)]
+
+
+def test_xpu_sycl_lookup_without_mapped_runtime(monkeypatch):
+    """No libsycl mapped means XPU was never initialized; must not try to load one."""
+
+    def fail_cdll(name, mode=0):
+        raise AssertionError("must not dlopen a SYCL runtime that is not already mapped")
+
+    monkeypatch.setattr(xpu_accelerator, "_mapped_sycl_runtime_path", lambda: None)
+    monkeypatch.setattr(xpu_accelerator.ctypes, "CDLL", fail_cdll)
+
+    assert xpu_accelerator._sycl_host_copy_funcs() is None
 
 
 def test_xpu_device_registration_without_sycl_symbols(monkeypatch):

--- a/tests/unit/v1/pin_memory/test_pin_memory.py
+++ b/tests/unit/v1/pin_memory/test_pin_memory.py
@@ -7,6 +7,8 @@ import torch
 
 from deepspeed.accelerator.cpu_accelerator import CPU_Accelerator
 from deepspeed.accelerator.cuda_accelerator import CUDA_Accelerator
+from deepspeed.accelerator import xpu_accelerator
+from deepspeed.accelerator.xpu_accelerator import XPU_Accelerator
 from deepspeed.utils.pin_memory import NativePinnedMemory
 
 
@@ -195,6 +197,37 @@ def test_cuda_device_registration_calls_cudart(monkeypatch):
     assert cudart.registered == [(1234, 4096, 0)]
     assert cudart.unregistered == [1234]
     assert errors == [0, 0]
+
+
+def test_xpu_device_registration_calls_sycl(monkeypatch):
+
+    prepared = []
+    released = []
+    queue = 0xFEED
+
+    def prepare(address, num_bytes, sycl_queue):
+        prepared.append((address, num_bytes, sycl_queue))
+
+    def release(address, sycl_queue):
+        released.append((address, sycl_queue))
+
+    monkeypatch.setattr(xpu_accelerator, "_sycl_host_copy_funcs", lambda: (prepare, release))
+    accelerator = XPU_Accelerator.__new__(XPU_Accelerator)
+    monkeypatch.setattr(accelerator, "_sycl_queue", lambda: queue)
+
+    assert accelerator.register_host_memory(1234, 4096) is True
+    accelerator.unregister_host_memory(1234)
+    assert prepared == [(1234, 4096, queue)]
+    assert released == [(1234, queue)]
+
+
+def test_xpu_device_registration_without_sycl_symbols(monkeypatch):
+    """Missing prepare_for_device_copy must degrade to mlock-only, not raise."""
+    monkeypatch.setattr(xpu_accelerator, "_sycl_host_copy_funcs", lambda: None)
+    accelerator = XPU_Accelerator.__new__(XPU_Accelerator)
+
+    assert accelerator.register_host_memory(1234, 4096) is False
+    assert accelerator.unregister_host_memory(1234) is None
 
 
 def test_cpu_native_pin_with_register_env_on(monkeypatch, native_pins):

--- a/tests/unit/v1/pin_memory/test_pin_memory.py
+++ b/tests/unit/v1/pin_memory/test_pin_memory.py
@@ -221,6 +221,24 @@ def test_xpu_device_registration_calls_sycl(monkeypatch):
     assert released == [(1234, queue)]
 
 
+def test_xpu_sycl_lookup_reuses_torch_runtime(monkeypatch):
+    """Opening a second SYCL runtime aborts at shutdown, so only RTLD_NOLOAD on the soname is allowed."""
+    calls = []
+
+    def fake_cdll(name, mode=0):
+        calls.append((name, mode))
+        raise OSError("not loaded")
+
+    monkeypatch.setattr(xpu_accelerator.ctypes, "CDLL", fake_cdll)
+    xpu_accelerator._sycl_host_copy_funcs.cache_clear()
+    try:
+        assert xpu_accelerator._sycl_host_copy_funcs() is None
+    finally:
+        xpu_accelerator._sycl_host_copy_funcs.cache_clear()
+
+    assert calls == [(xpu_accelerator.SYCL_RUNTIME_SONAME, xpu_accelerator.RTLD_NOLOAD)]
+
+
 def test_xpu_device_registration_without_sycl_symbols(monkeypatch):
     """Missing prepare_for_device_copy must degrade to mlock-only, not raise."""
     monkeypatch.setattr(xpu_accelerator, "_sycl_host_copy_funcs", lambda: None)


### PR DESCRIPTION
Fixes #8315.

## Summary

- Implement `register_host_memory` / `unregister_host_memory` in `XPU_Accelerator` via SYCL's `prepare_for_device_copy` / `release_from_device_copy` (the SYCL analogue of `cudaHostRegister`/`cudaHostUnregister`). Previously XPU inherited the base-class no-ops, so `DS_PIN_MEMORY_BACKEND=native` buffers stayed mlock-only on Intel GPUs.
- Honors the existing `DS_PIN_MEMORY_REGISTER_DEVICE` opt-out and falls back to "log once and continue with mlock" when the symbols cannot be resolved.
- Make `benchmarks/pin_memory/h2d_d2h_bench.py` accelerator-agnostic (it hardcoded a CUDA check and torch's CUDA-only `pin_memory=True` path) so the arms can be measured on XPU.

## Implementation note: resolving the SYCL entry points

Neither SYCL nor torch exposes a C entry point for these functions, so the mangled C++ symbols are resolved with `ctypes`. Two constraints, both found the hard way on an Arc Pro B60:

**Which library.** Opening the `libsycl.so` development symlink `dlopen`s a *second* SYCL runtime alongside the one torch already loaded. Both end up with their own driver state and the process aborts at interpreter shutdown with `UR_RESULT_ERROR_UNINITIALIZED`. We therefore only ever bind, with `RTLD_NOLOAD`, to the runtime already mapped into the process.

**Not by soname.** The soname is version-dependent -- oneAPI 2025.x ships `libsycl.so.8`, 2026.x ships `libsycl.so.9` (both are present on the test machine). Hardcoding `.so.8` would silently disable registration after a oneAPI upgrade. The path is instead read from `/proc/self/maps`, which tracks the version and also disambiguates between multiple oneAPI installs.

The mangled names themselves are stable: they live in SYCL's `_V1` inline ABI namespace and are byte-identical in `libsycl.so.8` and `libsycl.so.9`, verified with `nm` on both. Symbols disappearing is handled as the mlock-only fallback rather than an error.

Two tests pin this down (`test_xpu_sycl_lookup_reuses_torch_runtime`, `test_xpu_sycl_lookup_without_mapped_runtime`) so the lookup cannot regress to loading a second runtime or a hardcoded soname.

The `sycl_queue` attribute torch exposes as an `int` is a `sycl::queue*` -- confirmed against torch's own AOTI runtime, which dereferences it as `*queue_ptr` -- and pointer/reference share an ABI, so passing it to a `const sycl::queue&` parameter is sound.

## Testing

Intel Arc Pro B60 (4 cards, `ZE_AFFINITY_MASK=3`), torch 2.10.0+xpu, oneAPI 2025.3 + 2026.0 both installed:

- `pytest tests/unit/v1/pin_memory/test_pin_memory.py` -- 21 passed.
- `benchmarks/pin_memory/h2d_d2h_bench.py` runs all three arms to completion and exits 0 (it aborted at shutdown before the `RTLD_NOLOAD` fix).

Bandwidth on this particular machine is **not** a useful signal: the host is a VM whose PCIe path tops out around 1.8 GB/s, and all arms -- including plain pageable -- already sit at that ceiling, so registration has no headroom to show a gain:

```
arm,size_mib,h2d_gbps,d2h_gbps
torch,256,1.82,1.81
native-unregistered,256,1.80,1.78
native-registered,256,1.61,1.81
```

The path is nevertheless exercised: a standalone probe against non-mlocked `malloc` memory (which is not at the mlock-assisted ceiling) moved D2H from 1.53 to 1.78 GB/s after `prepare_for_device_copy`, matching torch-pinned. Confirming the intended H2D/D2H win would need a bare-metal Intel GPU host with a full-bandwidth PCIe link.

## Known limitation

SYCL reports registration failures by throwing `sycl::exception`, which cannot cross the `ctypes` boundary -- a bad address returns normally rather than raising. So unlike the CUDA path (which checks the `cudaError_t`), a failed registration here degrades silently to mlock-only speed instead of being reported. Making this observable would need a small C++ shim that catches the exception and returns a status code; I left it out to keep the change dependency-free, but am happy to add it if reviewers prefer.