### PR TITLE
Fix flops profiler counts for transposed convolutions

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -637,7 +637,10 @@ def _conv_trans_flops_compute(
     paddings = padding if type(padding) is tuple else (padding, ) * length
     strides = stride if type(stride) is tuple else (stride, ) * length
     dilations = dilation if type(dilation) is tuple else (dilation, ) * length
-    output_paddings = output_padding if type(output_padding) is tuple else (output_padding, ) * length
+    # `nn.ConvTransposeNd.forward(x, output_size=...)` computes the per-dimension
+    # output_padding as a list, so a tuple check alone would wrap it and the shape
+    # arithmetic below would add a list to an int.
+    output_paddings = output_padding if isinstance(output_padding, (tuple, list)) else (output_padding, ) * length
 
     output_dims = []
     for idx, input_dim in enumerate(input_dims):

--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -623,7 +623,12 @@ def _conv_trans_flops_compute(
 ):
     batch_size = input.shape[0]
     in_channels = input.shape[1]
-    out_channels = weight.shape[1]
+    # A transposed-convolution weight is [in_channels, out_channels // groups, *kernel],
+    # so dim 1 already holds the per-group filter count and must not be divided by groups
+    # a second time. Doing so reports zero macs for a depthwise transposed convolution,
+    # where out_channels // groups is 1.
+    filters_per_channel = weight.shape[1]
+    out_channels = filters_per_channel * groups
     kernel_dims = list(weight.shape[2:])
     input_dims = list(input.shape[2:])
 
@@ -632,19 +637,16 @@ def _conv_trans_flops_compute(
     paddings = padding if type(padding) is tuple else (padding, ) * length
     strides = stride if type(stride) is tuple else (stride, ) * length
     dilations = dilation if type(dilation) is tuple else (dilation, ) * length
+    output_paddings = output_padding if type(output_padding) is tuple else (output_padding, ) * length
 
     output_dims = []
     for idx, input_dim in enumerate(input_dims):
-
-        output_dim = (input_dim + 2 * paddings[idx] - (dilations[idx] *
-                                                       (kernel_dims[idx] - 1) + 1)) // strides[idx] + 1
+        # A transposed convolution inverts the forward shape formula, so the output grows
+        # with the stride rather than shrinking by it.
+        output_dim = ((input_dim - 1) * strides[idx] - 2 * paddings[idx] + dilations[idx] * (kernel_dims[idx] - 1) +
+                      output_paddings[idx] + 1)
         output_dims.append(output_dim)
 
-    paddings = padding if type(padding) is tuple else (padding, padding)
-    strides = stride if type(stride) is tuple else (stride, stride)
-    dilations = dilation if type(dilation) is tuple else (dilation, dilation)
-
-    filters_per_channel = out_channels // groups
     conv_per_position_macs = int(_prod(kernel_dims)) * in_channels * filters_per_channel
     active_elements_count = batch_size * int(_prod(input_dims))
     overall_conv_macs = conv_per_position_macs * active_elements_count

--- a/tests/unit/profiling/flops_profiler/test_flops_profiler.py
+++ b/tests/unit/profiling/flops_profiler/test_flops_profiler.py
@@ -85,6 +85,30 @@ def test_conv_transpose_flops(groups, stride, padding, output_padding):
     assert flops == 2 * expected_macs + expected_bias_flops
 
 
+@pytest.mark.sequential
+def test_conv_transpose_flops_with_output_size():
+    """`output_size=` makes torch compute the per-dimension output_padding itself, and it
+    hands it over as a list rather than a tuple."""
+    in_channels, out_channels, kernel_size = 4, 8, 3
+    model = torch.nn.ConvTranspose2d(in_channels, out_channels, kernel_size, stride=2, padding=1)
+    inputs = torch.randn(2, in_channels, 8, 8)
+
+    prof = FlopsProfiler(model)
+    prof.start_profile()
+    outputs = model(inputs, output_size=(2, out_channels, 16, 16))
+    prof.stop_profile()
+    flops, macs = prof.get_total_flops(), prof.get_total_macs()
+    prof.end_profile()
+
+    input_elements = inputs.shape[0] * inputs[0, 0].numel()
+    output_elements = outputs.shape[0] * outputs[0, 0].numel()
+    expected_macs = input_elements * in_channels * out_channels * kernel_size * kernel_size
+    expected_bias_flops = out_channels * output_elements
+
+    assert macs == expected_macs
+    assert flops == 2 * expected_macs + expected_bias_flops
+
+
 class LeNet5(torch.nn.Module):
 
     def __init__(self, n_classes):

--- a/tests/unit/profiling/flops_profiler/test_flops_profiler.py
+++ b/tests/unit/profiling/flops_profiler/test_flops_profiler.py
@@ -53,6 +53,38 @@ def test_repeated_profile_restores_operations():
     assert profiles == [(65536, 32768)] * 3
 
 
+@pytest.mark.sequential
+@pytest.mark.parametrize("groups", [1, 2, 4])
+@pytest.mark.parametrize("stride, padding, output_padding", [(1, 0, 0), (2, 1, 1)])
+def test_conv_transpose_flops(groups, stride, padding, output_padding):
+    """A transposed convolution scatters every input element across the kernel and adds the
+    bias once per output element, so the two counts follow different shapes."""
+    in_channels, out_channels, kernel_size = 4, 8, 3
+    model = torch.nn.ConvTranspose2d(in_channels,
+                                     out_channels,
+                                     kernel_size,
+                                     stride=stride,
+                                     padding=padding,
+                                     output_padding=output_padding,
+                                     groups=groups)
+    inputs = torch.randn(2, in_channels, 8, 8)
+
+    prof = FlopsProfiler(model)
+    prof.start_profile()
+    outputs = model(inputs)
+    prof.stop_profile()
+    flops, macs = prof.get_total_flops(), prof.get_total_macs()
+    prof.end_profile()
+
+    input_elements = inputs.shape[0] * inputs[0, 0].numel()
+    output_elements = outputs.shape[0] * outputs[0, 0].numel()
+    expected_macs = input_elements * in_channels * (out_channels // groups) * kernel_size * kernel_size
+    expected_bias_flops = out_channels * output_elements
+
+    assert macs == expected_macs
+    assert flops == 2 * expected_macs + expected_bias_flops
+
+
 class LeNet5(torch.nn.Module):
 
     def __init__(self, n_classes):


### PR DESCRIPTION
## Symptom

The flops profiler reports **zero macs for a depthwise transposed convolution**, and under-counts every other grouped one. Bias flops are wrong for every strided transposed convolution.

```python
import torch
from deepspeed.profiling.flops_profiler import FlopsProfiler

for m in [torch.nn.ConvTranspose2d(4, 6, 4, stride=2, padding=1),
          torch.nn.ConvTranspose2d(4, 4, 3, stride=2, padding=1, output_padding=1, groups=4),
          torch.nn.ConvTranspose2d(6, 6, 2, stride=2, groups=3)]:
    x = torch.randn(2, m.in_channels, 8, 8)
    p = FlopsProfiler(m); p.start_profile(); y = m(x); p.stop_profile()
    print(m.groups, p.get_total_macs(), p.get_total_flops()); p.end_profile()
```

| layer | macs reported | macs | flops reported | flops |
| --- | --- | --- | --- | --- |
| `ConvTranspose2d(4, 6, 4, stride=2, padding=1)` | 49152 | 49152 | 98496 | 101376 |
| `ConvTranspose2d(4, 4, 3, stride=2, padding=1, output_padding=1, groups=4)` | **0** | 4608 | 32 | 11264 |
| `ConvTranspose2d(6, 6, 2, stride=2, groups=3)` | **0** | 6144 | 64 | 15360 |

## Root cause

Two independent problems in `_conv_trans_flops_compute`.

**1. The per-group filter count is divided by `groups` twice.** A transposed-convolution weight is `[in_channels, out_channels // groups, *kernel]`, not `[out_channels, in_channels // groups, *kernel]` as for a forward convolution. So `weight.shape[1]` is already `out_channels // groups`, and

```python
out_channels = weight.shape[1]
...
filters_per_channel = out_channels // groups
```

yields `out_channels // groups ** 2`. For a depthwise layer that is `1 // groups`, which floors to `0`, so `conv_per_position_macs` and the whole layer collapse to zero.

**2. The output shape uses the forward-convolution formula.** A transposed convolution inverts it, and `output_padding` was accepted by the signature but never read:

```python
output_dim = (input_dim + 2 * paddings[idx] - (dilations[idx] * (kernel_dims[idx] - 1) + 1)) // strides[idx] + 1
```

The bias is added once per output element, so `bias_flops = out_channels * batch_size * prod(output_dims)` inherits the error. For a stride-2 layer the formula returns roughly `input_dim / stride` where the real output is `input_dim * stride`, so the bias term comes out about 16x too small in 2D.

The three lines that recomputed `paddings`/`strides`/`dilations` as 2-tuples immediately after the loop were dead, and hardcoded 2D for a helper that also serves `conv_transpose1d` and `conv_transpose3d`, so they go with the fix.

## Fix

Read `filters_per_channel` straight off `weight.shape[1]` and recover `out_channels` by multiplying it back up, and compute the output shape with the transposed-convolution formula, including `output_padding`.

The mac convention is unchanged: a transposed convolution scatters every input element across the kernel, so `active_elements_count` stays based on `input_dims`.

## Test

`tests/unit/profiling/flops_profiler/test_flops_profiler.py::test_conv_transpose_flops`, parametrized over `groups` in 1/2/4 and `(stride, padding, output_padding)` in (1, 0, 0)/(2, 1, 1). It checks both counts against the shapes torch itself produced, so the expected values are not a copy of the implementation.

Against master: **6 failed, 2 passed** (`assert 0 == 9216` for the depthwise cases). With the fix: **8 passed**.

```
$ pytest unit/profiling/flops_profiler/test_flops_profiler.py -m sequential
8 passed, 2 deselected
$ pytest unit/profiling/flops_profiler/test_flops_profiler.py
2 passed, 8 deselected
```

Manually checked beyond what the test parametrizes, all matching torch: `ConvTranspose1d`, `ConvTranspose3d`, `dilation=2`, and `bias=False`.
