### PR TITLE
Synchronize ZeRO destroy before unpinning offload buffers

### DIFF
--- a/deepspeed/runtime/zero/stage3.py
+++ b/deepspeed/runtime/zero/stage3.py
@@ -532,6 +532,8 @@ class DeepSpeedZeroOptimizer_Stage3(ZeROOptimizer):
             hook.remove()
         print_rank_0("Removed grad acc hooks", force=False)
         self.ipg_buckets.clear()
+        if get_accelerator().is_available():
+            get_accelerator().synchronize()
         self._unpin_offload_buffers()
 
     def _unpin_offload_buffers(self):

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -686,6 +686,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         for hook in self._grad_acc_hooks:
             hook.remove()
         self.print_rank_0("Removed grad acc hooks")
+        if get_accelerator().is_available():
+            get_accelerator().synchronize()
         self._unpin_offload_buffers()
 
     def _unpin_offload_buffers(self):

--- a/tests/unit/v1/pin_memory/test_destroy_unpin.py
+++ b/tests/unit/v1/pin_memory/test_destroy_unpin.py
@@ -13,6 +13,7 @@ import os
 import pytest
 import torch
 import deepspeed
+from deepspeed.accelerator import get_accelerator
 from deepspeed.utils.pin_memory import get_active_native_pinned_memory
 
 from unit.common import DistributedTest, preferred_dtype
@@ -152,6 +153,55 @@ class TestDestroyUnpinsNativeBuffers(DistributedTest):
             engine.destroy()
             assert len(native._ranges) <= ranges_before, (f"offload_states pins not released on destroy: "
                                                           f"offloaded={ranges_offloaded} after={len(native._ranges)}")
+        finally:
+            _restore_pin_backend(prev)
+
+    @pytest.mark.parametrize("stage", [1, 2, 3])
+    def test_native_async_offload_destroy_synchronizes_before_unpin(self, stage, monkeypatch):
+        prev = os.environ.get("DS_PIN_MEMORY_BACKEND")
+        try:
+            native = _require_native()
+            config, dtype = _config(stage, pin_memory=True, offload_optimizer=False)
+            hidden_dim = 16
+            model = SimpleModel(hidden_dim, nlayers=2)
+            engine, _, _, _ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+            _run_one_step(engine, hidden_dim, dtype)
+
+            accelerator = get_accelerator()
+            original_synchronize = accelerator.synchronize
+            original_unpin = accelerator.unpin_memory
+            events = []
+            safety_sync_done = False
+
+            def record_synchronize():
+                events.append("synchronize")
+                return original_synchronize()
+
+            def safely_record_unpin(tensor):
+                nonlocal safety_sync_done
+                if "synchronize" not in events and not safety_sync_done:
+                    original_synchronize()
+                    safety_sync_done = True
+                events.append("unpin")
+                return original_unpin(tensor)
+
+            monkeypatch.setattr(accelerator, "synchronize", record_synchronize)
+            monkeypatch.setattr(accelerator, "unpin_memory", safely_record_unpin)
+
+            ranges_before = len(native._ranges)
+            engine.offload_states(pin_memory=True, non_blocking=True)
+            assert len(native._ranges) > ranges_before, "expected offload_states to pin host buffers"
+            engine.destroy()
+
+            assert events and events[0] == "synchronize", f"destroy reached native unpin before completion: {events}"
+            assert "unpin" in events
+
+            # DeepSpeedEngine.__del__ calls destroy() again after an explicit
+            # destroy, so the optimizer cleanup path must remain repeatable.
+            events.clear()
+            engine.destroy()
+            assert events and events[0] == "synchronize", f"repeated destroy unpinned before sync: {events}"
+            assert "unpin" in events
         finally:
             _restore_pin_backend(prev)
 


### PR DESCRIPTION
## Problem

`offload_states(pin_memory=True, non_blocking=True)` can queue device-to-host copies into native pinned buffers. The ZeRO destroy paths unpinned those buffers without first ensuring the queued copies had completed, allowing native storage to be released while still in use.

## Approach

Synchronize the accelerator in the shared ZeRO-1/2 destroy path and the ZeRO-3 destroy path immediately before unpinning optimizer-owned offload buffers. Teardown remains state-free because destroy is terminal. The regression covers ZeRO stages 1, 2, and 3 and repeats destroy to exercise destructor-style cleanup.

## Testing

- `pre-commit run --all-files`
- On one node with 2 NVIDIA H100 80GB GPUs, all 3 destroy-ordering cases passed with no skips, and all 15 broader native pin-memory and ZeRO offload cases passed with no skips.
