### PR TITLE
Keep the elasticity batch overrides out of the caller's config dict

### DIFF
--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -727,6 +727,7 @@ class DeepSpeedConfig(object):
             self.world_size = 1
         logger.info(f"Config mesh_device {mesh_device} world_size = {self.world_size}")
         # If elastic-mode enabled, update compute + update _param_dict
+        elastic_batch_params = {}
         self.elasticity_enabled = elasticity_enabled(self._param_dict)
         if self.elasticity_enabled:
             logger.info("DeepSpeed elasticity support enabled")
@@ -784,12 +785,18 @@ class DeepSpeedConfig(object):
 
             logger.info(f"[Elasticity] valid GPU counts: {valid_gpus}")
 
-            self._param_dict[TRAIN_BATCH_SIZE] = final_batch_size
-            self._param_dict[TRAIN_MICRO_BATCH_SIZE_PER_GPU] = micro_batch_size
-            self._param_dict[GRADIENT_ACCUMULATION_STEPS] = gradient_accu_steps
+            elastic_batch_params = {
+                TRAIN_BATCH_SIZE: final_batch_size,
+                TRAIN_MICRO_BATCH_SIZE_PER_GPU: micro_batch_size,
+                GRADIENT_ACCUMULATION_STEPS: gradient_accu_steps,
+            }
 
-        # Pass a copy so that user json is unmodified, e.g. for logging
-        self._initialize_params(copy.copy(self._param_dict))
+        # Pass a copy so that user json is unmodified, e.g. for logging. The elasticity
+        # overrides go into that copy for the same reason -- all three are top-level
+        # keys, so the shallow copy keeps them off the caller's dict.
+        param_dict = copy.copy(self._param_dict)
+        param_dict.update(elastic_batch_params)
+        self._initialize_params(param_dict)
         self._configure_train_batch_size()
         self._do_sanity_check()
 

--- a/tests/unit/runtime/test_ds_config_dict.py
+++ b/tests/unit/runtime/test_ds_config_dict.py
@@ -271,6 +271,10 @@ def test_max_grad_norm_leaves_caller_config_untouched():
 def test_elasticity_leaves_caller_config_untouched():
     # Same contract as above on the elasticity path: the resolved batch sizes belong in
     # the copy handed to _initialize_params, not in the caller's dict.
+    #
+    # ignore_non_elastic_batch_info is deliberately left out. With it on, the batch-key
+    # guard is skipped and the second parse below cannot fail, so the test would pass
+    # whether or not the write-back is there.
     config_dict = {
         "elasticity": {
             "enabled": True,
@@ -280,7 +284,6 @@ def test_elasticity_leaves_caller_config_untouched():
             "max_gpus": 4,
             "min_time": 0,
             "version": 0.1,
-            "ignore_non_elastic_batch_info": True,
         }
     }
     keys_before = set(config_dict)
@@ -292,6 +295,15 @@ def test_elasticity_leaves_caller_config_untouched():
     assert ds_config.train_batch_size == 4
     assert ds_config.train_micro_batch_size_per_gpu == 2
     assert ds_config.gradient_accumulation_steps == 2
+
+    # The write-back made the same dict unparseable a second time: the injected keys
+    # trip the guard that rejects batch parameters under elasticity, and its message
+    # names three keys the caller never wrote.
+    second = DeepSpeedConfig(config_dict)
+
+    assert second.train_batch_size == ds_config.train_batch_size
+    assert second.train_micro_batch_size_per_gpu == ds_config.train_micro_batch_size_per_gpu
+    assert second.gradient_accumulation_steps == ds_config.gradient_accumulation_steps
 
 
 class TestConfigLoad(DistributedTest):

--- a/tests/unit/runtime/test_ds_config_dict.py
+++ b/tests/unit/runtime/test_ds_config_dict.py
@@ -268,6 +268,32 @@ def test_max_grad_norm_leaves_caller_config_untouched():
     assert config_dict["optimizer"]["params"]["max_grad_norm"] == 1.0
 
 
+def test_elasticity_leaves_caller_config_untouched():
+    # Same contract as above on the elasticity path: the resolved batch sizes belong in
+    # the copy handed to _initialize_params, not in the caller's dict.
+    config_dict = {
+        "elasticity": {
+            "enabled": True,
+            "max_train_batch_size": 4,
+            "micro_batch_sizes": [1, 2],
+            "min_gpus": 1,
+            "max_gpus": 4,
+            "min_time": 0,
+            "version": 0.1,
+            "ignore_non_elastic_batch_info": True,
+        }
+    }
+    keys_before = set(config_dict)
+
+    ds_config = DeepSpeedConfig(config_dict)
+
+    assert set(config_dict) == keys_before
+    # The resolved values still reach the parsed config.
+    assert ds_config.train_batch_size == 4
+    assert ds_config.train_micro_batch_size_per_gpu == 2
+    assert ds_config.gradient_accumulation_steps == 2
+
+
 class TestConfigLoad(DistributedTest):
     world_size = 1
 

--- a/tests/unit/runtime/test_ds_config_dict.py
+++ b/tests/unit/runtime/test_ds_config_dict.py
@@ -296,7 +296,7 @@ def test_elasticity_leaves_caller_config_untouched():
     assert ds_config.train_micro_batch_size_per_gpu == 2
     assert ds_config.gradient_accumulation_steps == 2
 
-    # The write-back made the same dict unparseable a second time: the injected keys
+    # The write-back made the same dict unparsable a second time: the injected keys
     # trip the guard that rejects batch parameters under elasticity, and its message
     # names three keys the caller never wrote.
     second = DeepSpeedConfig(config_dict)


### PR DESCRIPTION
`DeepSpeedConfig` keeps the dict it is handed by reference:

```python
if isinstance(config, dict):
    self._param_dict = config
```

#8289 established that parsing must not write back into it — the caller owns that dict and may reuse it after initialization.

The elasticity branch still does, two lines above the comment that says otherwise:

```python
        self._param_dict[TRAIN_BATCH_SIZE] = final_batch_size
        self._param_dict[TRAIN_MICRO_BATCH_SIZE_PER_GPU] = micro_batch_size
        self._param_dict[GRADIENT_ACCUMULATION_STEPS] = gradient_accu_steps

    # Pass a copy so that user json is unmodified, e.g. for logging
    self._initialize_params(copy.copy(self._param_dict))
```

A caller that enables elasticity gets three keys back that it never set. `print_user_config()` dumps `self._param_dict`, so it then reports them as though the user had written them.

**It also makes the dict unparseable a second time.** The elasticity path rejects those keys in the input unless `ignore_non_elastic_batch_info` is set:

```
One or more batch related parameters were found in your ds_config (...).
These parameters *will not be used* since elastic training is enabled ...
```

The first parse succeeds and injects them; the second parse of the same dict trips that guard, and its message asks the user to remove three keys they never wrote.

### The fix

Collect the overrides and apply them to the copy. All three are top-level keys, so the existing shallow copy keeps them off the caller's dict.

### Test

`DeepSpeedConfig(config_dict)` twice on an elasticity config, with `ignore_non_elastic_batch_info` left out so the guard is live:

before
```
parse 1 OK, caller dict gained: ['gradient_accumulation_steps', 'train_batch_size', 'train_micro_batch_size_per_gpu']
parse 2 FAILED: ElasticityConfigError One or more batch related parameters were found in your ds_config ...
```

after
```
parse 1 OK, caller dict gained: nothing
parse 2 OK
```

Parsed values are unchanged either way (`train_batch_size=4  micro=2  gas=2`), so this only removes the write-back.

`test_elasticity_leaves_caller_config_untouched` sits next to #8289's `test_max_grad_norm_leaves_caller_config_untouched` and covers both symptoms. On master it fails at

```
AssertionError: assert {'elasticity', 'train_batch_size', 'train_micro_batch_size_per_gpu',
                        'gradient_accumulation_steps'} == {'elasticity'}
```

```
tests/unit/runtime/test_ds_config_dict.py   27 passed, 5 skipped
tests/unit/elasticity/test_elastic.py       23 passed, 3 skipped
yapf --diff / flake8                        clean
```
