### PR TITLE
Add pin_empty helper for empty scratch destinations

### DIFF
--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -286,19 +286,39 @@ class DeepSpeedAccelerator(ABC):
         """Unregister host memory previously registered with the device runtime."""
         return None
 
-    def pin_memory(self, tensor, make_copy=True, match_shape=True):
+    @staticmethod
+    def _shape_numel(shape):
+        numel = 1
+        for dim in shape:
+            numel *= int(dim)
+        return numel
+
+    def _active_native_pins(self, nbytes):
         from deepspeed.utils.pin_memory_tracker import track_pinned_memory
-        track_pinned_memory(tensor.nbytes)
+        track_pinned_memory(nbytes)
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory
-        pins = get_active_native_pinned_memory()
+        return get_active_native_pinned_memory()
+
+    def pin_memory(self, tensor, make_copy=True, match_shape=True, alloc_shape=None):
+        # ``alloc_shape`` is the size/dtype-only path used by pin_empty: ``tensor``
+        # is just a dtype template and must not dictate the allocation numel.
+        if alloc_shape is None:
+            nbytes = tensor.nbytes
+            out_shape = tensor.shape if match_shape else (tensor.numel(), )
+        else:
+            numel = self._shape_numel(alloc_shape)
+            nbytes = numel * tensor.element_size()
+            out_shape = tuple(alloc_shape) if match_shape else (numel, )
+        pins = self._active_native_pins(nbytes)
         if pins is not None:
+            if alloc_shape is not None:
+                return pins.pin_empty(tensor, out_shape)
             return pins.pin(tensor, make_copy=make_copy, match_shape=match_shape)
-        if make_copy:
+        if make_copy and alloc_shape is None:
             return self._torch_pin_memory(tensor)
         # ``tensor`` is only a shape/dtype template here, so page-lock a fresh
         # buffer instead of faulting it in and copying it into a second one.
-        shape = tensor.shape if match_shape else (tensor.numel(), )
-        return self._torch_empty_pinned(tensor, shape)
+        return self._torch_empty_pinned(tensor, out_shape)
 
     def pin_empty(self, *size, dtype=None, device='cpu'):
         # Scratch destinations: shape/dtype only, no pageable template of ``size``.
@@ -308,24 +328,12 @@ class DeepSpeedAccelerator(ABC):
         else:
             shape = tuple(size)
         template = torch.empty(0, dtype=dtype, device=device)
-        return self._pin_uninitialized(template, shape)
+        return self.pin_memory(template, make_copy=False, alloc_shape=shape)
 
     def pin_empty_like(self, tensor, device='cpu', dtype=None):
         import torch
         template = torch.empty(0, dtype=tensor.dtype if dtype is None else dtype, device=device)
-        return self._pin_uninitialized(template, tuple(tensor.shape))
-
-    def _pin_uninitialized(self, template, shape):
-        numel = 1
-        for dim in shape:
-            numel *= int(dim)
-        from deepspeed.utils.pin_memory_tracker import track_pinned_memory
-        track_pinned_memory(numel * template.element_size())
-        from deepspeed.utils.pin_memory import get_active_native_pinned_memory
-        pins = get_active_native_pinned_memory()
-        if pins is not None:
-            return pins.pin_empty(template, shape)
-        return self._torch_empty_pinned(template, shape)
+        return self.pin_memory(template, make_copy=False, alloc_shape=tuple(tensor.shape))
 
     def is_pinned(self, tensor):
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory

--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -300,6 +300,33 @@ class DeepSpeedAccelerator(ABC):
         shape = tensor.shape if match_shape else (tensor.numel(), )
         return self._torch_empty_pinned(tensor, shape)
 
+    def pin_empty(self, *size, dtype=None, device='cpu'):
+        # Scratch destinations: shape/dtype only, no pageable template of ``size``.
+        import torch
+        if len(size) == 1 and not isinstance(size[0], int):
+            shape = tuple(size[0])
+        else:
+            shape = tuple(size)
+        template = torch.empty(0, dtype=dtype, device=device)
+        return self._pin_uninitialized(template, shape)
+
+    def pin_empty_like(self, tensor, device='cpu', dtype=None):
+        import torch
+        template = torch.empty(0, dtype=tensor.dtype if dtype is None else dtype, device=device)
+        return self._pin_uninitialized(template, tuple(tensor.shape))
+
+    def _pin_uninitialized(self, template, shape):
+        numel = 1
+        for dim in shape:
+            numel *= int(dim)
+        from deepspeed.utils.pin_memory_tracker import track_pinned_memory
+        track_pinned_memory(numel * template.element_size())
+        from deepspeed.utils.pin_memory import get_active_native_pinned_memory
+        pins = get_active_native_pinned_memory()
+        if pins is not None:
+            return pins.pin_empty(template, shape)
+        return self._torch_empty_pinned(template, shape)
+
     def is_pinned(self, tensor):
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory
         pins = get_active_native_pinned_memory()

--- a/accelerator/abstract_accelerator.py
+++ b/accelerator/abstract_accelerator.py
@@ -286,6 +286,10 @@ class DeepSpeedAccelerator(ABC):
         """Unregister host memory previously registered with the device runtime."""
         return None
 
+    # CPU torch pinning is a historical no-op; subclasses that really page-lock
+    # keep the default True so tracker accounting matches the docs.
+    _torch_pins_host_memory = True
+
     @staticmethod
     def _shape_numel(shape):
         numel = 1
@@ -293,47 +297,60 @@ class DeepSpeedAccelerator(ABC):
             numel *= int(dim)
         return numel
 
-    def _active_native_pins(self, nbytes):
-        from deepspeed.utils.pin_memory_tracker import track_pinned_memory
-        track_pinned_memory(nbytes)
-        from deepspeed.utils.pin_memory import get_active_native_pinned_memory
-        return get_active_native_pinned_memory()
+    @staticmethod
+    def _require_host_device(device):
+        import torch
+        try:
+            dev = torch.device(device)
+        except RuntimeError as err:
+            raise ValueError(f"pin_empty allocates host memory; device must be cpu, got {device!r}") from err
+        if dev.type != "cpu":
+            raise ValueError(f"pin_empty allocates host memory; device must be cpu, got {device!r}")
 
-    def pin_memory(self, tensor, make_copy=True, match_shape=True, alloc_shape=None):
-        # ``alloc_shape`` is the size/dtype-only path used by pin_empty: ``tensor``
-        # is just a dtype template and must not dictate the allocation numel.
-        if alloc_shape is None:
-            nbytes = tensor.nbytes
-            out_shape = tensor.shape if match_shape else (tensor.numel(), )
-        else:
-            numel = self._shape_numel(alloc_shape)
-            nbytes = numel * tensor.element_size()
-            out_shape = tuple(alloc_shape) if match_shape else (numel, )
-        pins = self._active_native_pins(nbytes)
+    def _pin_fresh(self, template, shape):
+        # Shared scratch path for pin_empty and pin_memory(make_copy=False).
+        from deepspeed.utils.pin_memory import get_active_native_pinned_memory
+        pins = get_active_native_pinned_memory()
+        if pins is not None or self._torch_pins_host_memory:
+            from deepspeed.utils.pin_memory_tracker import track_pinned_memory
+            track_pinned_memory(self._shape_numel(shape) * template.element_size())
         if pins is not None:
-            if alloc_shape is not None:
-                return pins.pin_empty(tensor, out_shape)
+            return pins.pin_empty(template, shape)
+        return self._torch_empty_pinned(template, shape)
+
+    def pin_memory(self, tensor, make_copy=True, match_shape=True):
+        from deepspeed.utils.pin_memory import get_active_native_pinned_memory
+        pins = get_active_native_pinned_memory()
+        if pins is not None:
+            from deepspeed.utils.pin_memory_tracker import track_pinned_memory
+            track_pinned_memory(tensor.nbytes)
             return pins.pin(tensor, make_copy=make_copy, match_shape=match_shape)
-        if make_copy and alloc_shape is None:
+        if make_copy:
+            if self._torch_pins_host_memory:
+                from deepspeed.utils.pin_memory_tracker import track_pinned_memory
+                track_pinned_memory(tensor.nbytes)
             return self._torch_pin_memory(tensor)
         # ``tensor`` is only a shape/dtype template here, so page-lock a fresh
         # buffer instead of faulting it in and copying it into a second one.
-        return self._torch_empty_pinned(tensor, out_shape)
+        shape = tensor.shape if match_shape else (tensor.numel(), )
+        return self._pin_fresh(tensor, shape)
 
-    def pin_empty(self, *size, dtype=None, device='cpu'):
+    def pin_empty(self, *size, dtype, device="cpu"):
         # Scratch destinations: shape/dtype only, no pageable template of ``size``.
         import torch
-        if len(size) == 1 and not isinstance(size[0], int):
+        self._require_host_device(device)
+        if len(size) == 1 and isinstance(size[0], (tuple, list, torch.Size)):
             shape = tuple(size[0])
         else:
             shape = tuple(size)
         template = torch.empty(0, dtype=dtype, device=device)
-        return self.pin_memory(template, make_copy=False, alloc_shape=shape)
+        return self._pin_fresh(template, shape)
 
-    def pin_empty_like(self, tensor, device='cpu', dtype=None):
-        import torch
-        template = torch.empty(0, dtype=tensor.dtype if dtype is None else dtype, device=device)
-        return self.pin_memory(template, make_copy=False, alloc_shape=tuple(tensor.shape))
+    def pin_empty_like(self, tensor, device="cpu", dtype=None):
+        self._require_host_device(device)
+        dtype = tensor.dtype if dtype is None else dtype
+        template = tensor.new_empty((0, ), dtype=dtype, device=device)
+        return self._pin_fresh(template, tuple(tensor.shape))
 
     def is_pinned(self, tensor):
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -278,19 +278,13 @@ class CPU_Accelerator(DeepSpeedAccelerator):
     def LongTensor(self):
         return torch.LongTensor
 
-    def pin_memory(self, tensor, make_copy=True, match_shape=True, alloc_shape=None):
+    _torch_pins_host_memory = False
+
+    def pin_memory(self, tensor, make_copy=True, match_shape=True):
         # Torch cannot pin CPU tensors to a device; keep the historical no-op and
         # bypass ABC pinned-memory accounting (nothing is page-locked in that path).
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory
         pins = get_active_native_pinned_memory()
-        if alloc_shape is not None:
-            numel = self._shape_numel(alloc_shape)
-            out_shape = tuple(alloc_shape) if match_shape else (numel, )
-            if pins is not None:
-                from deepspeed.utils.pin_memory_tracker import track_pinned_memory
-                track_pinned_memory(numel * tensor.element_size())
-                return pins.pin_empty(tensor, out_shape)
-            return tensor.new_empty(out_shape)
         if pins is not None:
             from deepspeed.utils.pin_memory_tracker import track_pinned_memory
             track_pinned_memory(tensor.nbytes)

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -293,6 +293,10 @@ class CPU_Accelerator(DeepSpeedAccelerator):
         # torch cannot pin CPU tensors to a device; keep the historical no-op.
         return tensor
 
+    def _torch_empty_pinned(self, tensor, shape):
+        # Same no-op as pin_memory: allocate host storage without page-locking.
+        return tensor.new_empty(shape)
+
     def op_builder_dir(self):
         try:
             # is op_builder from deepspeed or a 3p version? this should only succeed if it's deepspeed

--- a/accelerator/cpu_accelerator.py
+++ b/accelerator/cpu_accelerator.py
@@ -278,11 +278,19 @@ class CPU_Accelerator(DeepSpeedAccelerator):
     def LongTensor(self):
         return torch.LongTensor
 
-    def pin_memory(self, tensor, make_copy=True, match_shape=True):
+    def pin_memory(self, tensor, make_copy=True, match_shape=True, alloc_shape=None):
         # Torch cannot pin CPU tensors to a device; keep the historical no-op and
         # bypass ABC pinned-memory accounting (nothing is page-locked in that path).
         from deepspeed.utils.pin_memory import get_active_native_pinned_memory
         pins = get_active_native_pinned_memory()
+        if alloc_shape is not None:
+            numel = self._shape_numel(alloc_shape)
+            out_shape = tuple(alloc_shape) if match_shape else (numel, )
+            if pins is not None:
+                from deepspeed.utils.pin_memory_tracker import track_pinned_memory
+                track_pinned_memory(numel * tensor.element_size())
+                return pins.pin_empty(tensor, out_shape)
+            return tensor.new_empty(out_shape)
         if pins is not None:
             from deepspeed.utils.pin_memory_tracker import track_pinned_memory
             track_pinned_memory(tensor.nbytes)

--- a/deepspeed/runtime/superoffload/superoffload_utils.py
+++ b/deepspeed/runtime/superoffload/superoffload_utils.py
@@ -40,10 +40,9 @@ def _allocate_worker_grad_buffer(max_grad_numel: int, pin_memory: bool) -> torch
     # Scratch destination for the GPU->CPU grad copy. Pinning is optional: it
     # speeds DMA but is not required for correctness, so honor
     # offload_optimizer.pin_memory rather than always page-locking.
-    buffer = torch.empty(max_grad_numel, dtype=torch.float32, device='cpu')
     if pin_memory:
-        buffer = get_accelerator().pin_memory(buffer, make_copy=False)
-    return buffer
+        return get_accelerator().pin_empty(max_grad_numel, dtype=torch.float32, device='cpu')
+    return torch.empty(max_grad_numel, dtype=torch.float32, device='cpu')
 
 
 def superoffload_optimizer_worker(param_queue: mp.SimpleQueue,

--- a/deepspeed/runtime/zero/offload_states.py
+++ b/deepspeed/runtime/zero/offload_states.py
@@ -19,7 +19,7 @@ def offload_optimizer_states(optimizer, device, pin_memory=False, non_blocking=F
         for k, v in state.items():
             if torch.is_tensor(v):
                 if pin_memory and v.device.type != 'cpu':
-                    pinned_buffer = get_accelerator().pin_memory(torch.empty_like(v, device='cpu'), make_copy=False)
+                    pinned_buffer = get_accelerator().pin_empty_like(v, device='cpu')
                     pinned_buffer.copy_(v, non_blocking=non_blocking)
                     state[k] = pinned_buffer
                 else:

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2949,7 +2949,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if pin_memory:
                 if not hasattr(self, "hp_params_pin_buffers"):
                     self.hp_params_pin_buffers = [
-                        get_accelerator().pin_memory(torch.empty_like(t, device=device), make_copy=False)
+                        get_accelerator().pin_empty_like(t, device=device)
                         for t in self.single_partition_of_fp32_groups
                     ]
                 for src_tensor, dest_buf in zip(self.single_partition_of_fp32_groups, self.hp_params_pin_buffers):
@@ -2973,8 +2973,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if pin_memory:
                 if not hasattr(self, "lp_params_pin_buffers"):
                     self.lp_params_pin_buffers = [
-                        get_accelerator().pin_memory(torch.empty_like(t, device=device), make_copy=False)
-                        for t in self.bit16_groups_flat
+                        get_accelerator().pin_empty_like(t, device=device) for t in self.bit16_groups_flat
                     ]
                 for src_tensor, dest_buf in zip(self.bit16_groups_flat, self.lp_params_pin_buffers):
                     dest_buf.copy_(src_tensor, non_blocking=non_blocking)

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2949,8 +2949,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if pin_memory:
                 if not hasattr(self, "hp_params_pin_buffers"):
                     self.hp_params_pin_buffers = [
-                        get_accelerator().pin_empty_like(t, device=device)
-                        for t in self.single_partition_of_fp32_groups
+                        get_accelerator().pin_empty_like(t, device='cpu') for t in self.single_partition_of_fp32_groups
                     ]
                 for src_tensor, dest_buf in zip(self.single_partition_of_fp32_groups, self.hp_params_pin_buffers):
                     dest_buf.copy_(src_tensor, non_blocking=non_blocking)
@@ -2973,7 +2972,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             if pin_memory:
                 if not hasattr(self, "lp_params_pin_buffers"):
                     self.lp_params_pin_buffers = [
-                        get_accelerator().pin_empty_like(t, device=device) for t in self.bit16_groups_flat
+                        get_accelerator().pin_empty_like(t, device='cpu') for t in self.bit16_groups_flat
                     ]
                 for src_tensor, dest_buf in zip(self.bit16_groups_flat, self.lp_params_pin_buffers):
                     dest_buf.copy_(src_tensor, non_blocking=non_blocking)

--- a/deepspeed/utils/pin_memory.py
+++ b/deepspeed/utils/pin_memory.py
@@ -74,6 +74,30 @@ class NativePinnedMemory(object):
                                                    self._finalizers, self._device_registered)
         return locked
 
+    def pin_empty(self, example, shape):
+        # ``example`` is dtype-only (typically 0-element); size comes from ``shape``.
+        numel = 1
+        for dim in shape:
+            numel *= int(dim)
+        base = self._handle.new_cpu_locked_tensor(numel, example)
+        begin = base.data_ptr()
+        locked = base[:numel]
+        if base.nbytes and self._device_registration_enabled():
+            from deepspeed.accelerator import get_accelerator
+            try:
+                if get_accelerator().register_host_memory(begin, base.nbytes):
+                    self._device_registered.add(begin)
+            except Exception as e:
+                logger.warning_once(
+                    f"Native pinned-memory device registration failed; continuing with mlock only: {e}")
+        locked = locked.view(shape)
+        self._ranges[begin] = begin + numel * example.element_size()
+        locked.ds_pinned = True
+        locked.ds_pin_base = begin
+        self._finalizers[begin] = weakref.finalize(base, self._release, self._handle, begin, self._ranges,
+                                                   self._finalizers, self._device_registered)
+        return locked
+
     def is_pinned(self, tensor):
         if getattr(tensor, "ds_pinned", False):
             return True

--- a/deepspeed/utils/pin_memory.py
+++ b/deepspeed/utils/pin_memory.py
@@ -39,9 +39,8 @@ class NativePinnedMemory(object):
                 "DS_PIN_MEMORY_BACKEND=native requires the pin_memory op, which failed to build/load.") from e
 
     def pin(self, tensor, make_copy=True, match_shape=True):
-        numel = tensor.numel()
-        out_shape = tensor.shape if match_shape else (numel, )
-        locked = self._new_locked(tensor, numel, out_shape)
+        out_shape = tensor.shape if match_shape else (tensor.numel(), )
+        locked = self._new_locked(tensor, out_shape)
         if make_copy:
             locked.copy_(tensor.reshape(out_shape))
         return locked
@@ -49,12 +48,12 @@ class NativePinnedMemory(object):
     def pin_empty(self, example, shape):
         # ``example`` is dtype-only. ``pin()`` sizes the allocation from
         # ``example.numel()``, so a 0-element template cannot be passed through.
-        numel = 1
-        for dim in shape:
-            numel *= int(dim)
-        return self._new_locked(example, numel, shape)
+        return self._new_locked(example, shape)
 
-    def _new_locked(self, example, numel, out_shape):
+    def _new_locked(self, example, out_shape):
+        numel = 1
+        for dim in out_shape:
+            numel *= int(dim)
         # ``base`` is the allocation root and the view root for everything derived
         # from it. Every slice/view of the returned tensor keeps ``base`` alive via
         # ``._base``, so the allocation is freed only after the returned tensor and

--- a/deepspeed/utils/pin_memory.py
+++ b/deepspeed/utils/pin_memory.py
@@ -40,45 +40,25 @@ class NativePinnedMemory(object):
 
     def pin(self, tensor, make_copy=True, match_shape=True):
         numel = tensor.numel()
+        out_shape = tensor.shape if match_shape else (numel, )
+        locked = self._new_locked(tensor, numel, out_shape)
+        if make_copy:
+            locked.copy_(tensor.reshape(out_shape))
+        return locked
+
+    def pin_empty(self, example, shape):
+        # ``example`` is dtype-only. ``pin()`` sizes the allocation from
+        # ``example.numel()``, so a 0-element template cannot be passed through.
+        numel = 1
+        for dim in shape:
+            numel *= int(dim)
+        return self._new_locked(example, numel, shape)
+
+    def _new_locked(self, example, numel, out_shape):
         # ``base`` is the allocation root and the view root for everything derived
         # from it. Every slice/view of the returned tensor keeps ``base`` alive via
         # ``._base``, so the allocation is freed only after the returned tensor and
         # all of its aliases are gone (a live view can never outlive the free).
-        base = self._handle.new_cpu_locked_tensor(numel, tensor)
-        begin = base.data_ptr()
-        locked = base[:numel]
-        if base.nbytes and self._device_registration_enabled():
-            from deepspeed.accelerator import get_accelerator
-            try:
-                if get_accelerator().register_host_memory(begin, base.nbytes):
-                    self._device_registered.add(begin)
-            except Exception as e:
-                logger.warning_once(
-                    f"Native pinned-memory device registration failed; continuing with mlock only: {e}")
-        if make_copy:
-            locked.copy_(tensor.reshape(-1))
-        if match_shape:
-            locked = locked.view(tensor.shape)
-        self._ranges[begin] = begin + numel * tensor.element_size()
-        locked.ds_pinned = True
-        # Remember the owning allocation address so an explicit unpin() frees the
-        # original region even if the tensor's ``.data`` is later redirected (e.g.
-        # ZeRO offload/reload rebinds ``.data`` to a different buffer).
-        locked.ds_pin_base = begin
-        # Match torch.pin_memory lifetime semantics: free the page-locked allocation
-        # once its root is garbage-collected, so call sites that never call unpin()
-        # do not accumulate mlocked host memory. The finalizer is tied to ``base``
-        # (not the returned view) and frees by address; ``base`` must not be passed
-        # as a finalize argument or it would be kept alive forever.
-        self._finalizers[begin] = weakref.finalize(base, self._release, self._handle, begin, self._ranges,
-                                                   self._finalizers, self._device_registered)
-        return locked
-
-    def pin_empty(self, example, shape):
-        # ``example`` is dtype-only (typically 0-element); size comes from ``shape``.
-        numel = 1
-        for dim in shape:
-            numel *= int(dim)
         base = self._handle.new_cpu_locked_tensor(numel, example)
         begin = base.data_ptr()
         locked = base[:numel]
@@ -90,10 +70,18 @@ class NativePinnedMemory(object):
             except Exception as e:
                 logger.warning_once(
                     f"Native pinned-memory device registration failed; continuing with mlock only: {e}")
-        locked = locked.view(shape)
+        locked = locked.view(out_shape)
         self._ranges[begin] = begin + numel * example.element_size()
         locked.ds_pinned = True
+        # Remember the owning allocation address so an explicit unpin() frees the
+        # original region even if the tensor's ``.data`` is later redirected (e.g.
+        # ZeRO offload/reload rebinds ``.data`` to a different buffer).
         locked.ds_pin_base = begin
+        # Match torch.pin_memory lifetime semantics: free the page-locked allocation
+        # once its root is garbage-collected, so call sites that never call unpin()
+        # do not accumulate mlocked host memory. The finalizer is tied to ``base``
+        # (not the returned view) and frees by address; ``base`` must not be passed
+        # as a finalize argument or it would be kept alive forever.
         self._finalizers[begin] = weakref.finalize(base, self._release, self._handle, begin, self._ranges,
                                                    self._finalizers, self._device_registered)
         return locked

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -316,6 +316,15 @@ shape/dtype template: both backends page-lock a fresh buffer and never read
 ``tensor``, so scratch destinations do not pay for a second full-size
 allocation and a copy.
 
+Empty scratch buffers should use ``pin_empty`` / ``pin_empty_like`` instead of
+``pin_memory(torch.empty(...), make_copy=False)``. Those helpers take a shape
+and dtype only, so neither backend allocates a full-size pageable template.
+
+.. code-block:: python
+
+    scratch = get_accelerator().pin_empty_like(src, device='cpu')
+    scratch = get_accelerator().pin_empty(1024, dtype=torch.float32, device='cpu')
+
 Pin on/off vs backend
 =====================
 

--- a/docs/code-docs/source/memory.rst
+++ b/docs/code-docs/source/memory.rst
@@ -385,6 +385,9 @@ counted by ``track_pinned_memory`` when pages are actually locked. Differences:
    * - ``pin_memory`` extras
      - Honors ``make_copy`` and ``match_shape`` (both default ``True``)
      - Honors ``make_copy`` and ``match_shape`` (both default ``True``)
+   * - ``pin_empty`` / ``pin_empty_like``
+     - Host scratch allocation (cpu ``device``, required ``dtype``); no pageable template
+     - Same helper; native ``mlock`` via ``pin_empty``
    * - Pin recognition (``is_pinned``)
      - Torch pinned status (``tensor.is_pinned()``)
      - ``.ds_pinned`` and process-wide pointer ranges (slices/views included)

--- a/tests/unit/v1/accelerator/test_accelerator.py
+++ b/tests/unit/v1/accelerator/test_accelerator.py
@@ -102,7 +102,9 @@ def test_pin_memory_torch_backend_make_copy_false_allocates_pinned(monkeypatch):
     class _StubAccelerator:
         # Exercise the shared dispatch without needing a real pinning device.
         pin_memory = DeepSpeedAccelerator.pin_memory
-        _active_native_pins = DeepSpeedAccelerator._active_native_pins
+        _pin_fresh = DeepSpeedAccelerator._pin_fresh
+        _shape_numel = staticmethod(DeepSpeedAccelerator._shape_numel)
+        _torch_pins_host_memory = True
 
         def _torch_pin_memory(self, tensor):
             calls.append(("pin_copy", tuple(tensor.shape)))
@@ -129,9 +131,10 @@ def test_pin_empty_torch_backend_uses_zero_element_template(monkeypatch):
     class _StubAccelerator:
         pin_empty = DeepSpeedAccelerator.pin_empty
         pin_empty_like = DeepSpeedAccelerator.pin_empty_like
-        pin_memory = DeepSpeedAccelerator.pin_memory
+        _pin_fresh = DeepSpeedAccelerator._pin_fresh
+        _require_host_device = staticmethod(DeepSpeedAccelerator._require_host_device)
         _shape_numel = staticmethod(DeepSpeedAccelerator._shape_numel)
-        _active_native_pins = DeepSpeedAccelerator._active_native_pins
+        _torch_pins_host_memory = True
 
         def _torch_empty_pinned(self, tensor, shape):
             calls.append((tuple(tensor.shape), tuple(shape), tensor.dtype, tensor.numel()))
@@ -144,6 +147,29 @@ def test_pin_empty_torch_backend_uses_zero_element_template(monkeypatch):
     like = accel.pin_empty_like(src, device="cpu")
     assert tuple(like.shape) == (2, 3)
     assert calls == [((0, ), (4, 8), torch.float32, 0), ((0, ), (2, 3), torch.float16, 0)]
+
+
+def test_pin_empty_requires_dtype_and_host_device(monkeypatch):
+    monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)
+    accel = get_accelerator()
+    with pytest.raises(TypeError):
+        accel.pin_empty(4, device="cpu")
+    with pytest.raises(ValueError, match="cpu"):
+        accel.pin_empty(4, dtype=torch.float32, device="cuda")
+
+
+def test_pin_empty_cpu_torch_skips_accounting(monkeypatch):
+    """CPU torch pinning is a no-op and must not inflate the pinned-byte total."""
+    monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)
+    from deepspeed.accelerator.cpu_accelerator import CPU_Accelerator
+    from deepspeed.utils import pin_memory_tracker
+
+    accel = CPU_Accelerator()
+    before = pin_memory_tracker._tracker._bytes
+    buffer = accel.pin_empty(8, dtype=torch.float32, device="cpu")
+    assert tuple(buffer.shape) == (8, )
+    assert accel.is_pinned(buffer) is False
+    assert pin_memory_tracker._tracker._bytes == before
 
 
 def test_pin_empty_torch_backend_is_pinned(monkeypatch):

--- a/tests/unit/v1/accelerator/test_accelerator.py
+++ b/tests/unit/v1/accelerator/test_accelerator.py
@@ -120,6 +120,59 @@ def test_pin_memory_torch_backend_make_copy_false_allocates_pinned(monkeypatch):
     assert calls == [("pin_copy", (4, 8)), ("empty_pinned", (4, 8)), ("empty_pinned", (32, ))]
 
 
+def test_pin_empty_torch_backend_uses_zero_element_template(monkeypatch):
+    """pin_empty must not build a full-size pageable tensor for the torch path."""
+    monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)
+    calls = []
+
+    class _StubAccelerator:
+        pin_empty = DeepSpeedAccelerator.pin_empty
+        pin_empty_like = DeepSpeedAccelerator.pin_empty_like
+        _pin_uninitialized = DeepSpeedAccelerator._pin_uninitialized
+
+        def _torch_empty_pinned(self, tensor, shape):
+            calls.append((tuple(tensor.shape), tuple(shape), tensor.dtype, tensor.numel()))
+            return tensor.new_empty(shape)
+
+    accel = _StubAccelerator()
+    buffer = accel.pin_empty(4, 8, dtype=torch.float32, device="cpu")
+    assert tuple(buffer.shape) == (4, 8)
+    src = torch.randn(2, 3, dtype=torch.float16)
+    like = accel.pin_empty_like(src, device="cpu")
+    assert tuple(like.shape) == (2, 3)
+    assert calls == [((0, ), (4, 8), torch.float32, 0), ((0, ), (2, 3), torch.float16, 0)]
+
+
+def test_pin_empty_torch_backend_is_pinned(monkeypatch):
+    """pin_empty page-locks a host buffer on accelerators that can pin."""
+    monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)
+    accel = get_accelerator()
+    if accel.device_name() == "cpu":
+        pytest.skip("torch cannot pin CPU tensors on the CPU accelerator")
+
+    buffer = accel.pin_empty(4, 8, dtype=torch.float32, device="cpu")
+    assert buffer.is_pinned()
+    assert tuple(buffer.shape) == (4, 8)
+    src = torch.randn(2, 3)
+    like = accel.pin_empty_like(src, device="cpu")
+    assert like.is_pinned()
+    assert tuple(like.shape) == (2, 3)
+
+
+def test_pin_empty_native_backend(monkeypatch):
+    _require_native(monkeypatch)
+    accel = get_accelerator()
+    buffer = accel.pin_empty(4, 8, dtype=torch.float32, device="cpu")
+    assert tuple(buffer.shape) == (4, 8)
+    assert accel.is_pinned(buffer)
+    src = torch.randn(2, 3)
+    like = accel.pin_empty_like(src, device="cpu")
+    assert tuple(like.shape) == (2, 3)
+    assert accel.is_pinned(like)
+    assert accel.unpin_memory(buffer) is True
+    assert accel.unpin_memory(like) is True
+
+
 def test_pin_memory_torch_backend_no_copy_is_pinned(monkeypatch):
     """The buffer returned for make_copy=False is really page-locked."""
     monkeypatch.delenv("DS_PIN_MEMORY_BACKEND", raising=False)

--- a/tests/unit/v1/accelerator/test_accelerator.py
+++ b/tests/unit/v1/accelerator/test_accelerator.py
@@ -102,6 +102,7 @@ def test_pin_memory_torch_backend_make_copy_false_allocates_pinned(monkeypatch):
     class _StubAccelerator:
         # Exercise the shared dispatch without needing a real pinning device.
         pin_memory = DeepSpeedAccelerator.pin_memory
+        _active_native_pins = DeepSpeedAccelerator._active_native_pins
 
         def _torch_pin_memory(self, tensor):
             calls.append(("pin_copy", tuple(tensor.shape)))
@@ -128,7 +129,9 @@ def test_pin_empty_torch_backend_uses_zero_element_template(monkeypatch):
     class _StubAccelerator:
         pin_empty = DeepSpeedAccelerator.pin_empty
         pin_empty_like = DeepSpeedAccelerator.pin_empty_like
-        _pin_uninitialized = DeepSpeedAccelerator._pin_uninitialized
+        pin_memory = DeepSpeedAccelerator.pin_memory
+        _shape_numel = staticmethod(DeepSpeedAccelerator._shape_numel)
+        _active_native_pins = DeepSpeedAccelerator._active_native_pins
 
         def _torch_empty_pinned(self, tensor, shape):
             calls.append((tuple(tensor.shape), tuple(shape), tensor.dtype, tensor.numel()))

--- a/tests/unit/v1/pin_memory/test_offload_route.py
+++ b/tests/unit/v1/pin_memory/test_offload_route.py
@@ -39,7 +39,7 @@ def test_offload_helper_pin_pattern_native(monkeypatch):
     accel = get_accelerator()
     # Mirrors offload_optimizer_states: allocate empty host buffer, then copy.
     src = torch.randn(32)
-    pinned_buffer = accel.pin_memory(torch.empty_like(src, device="cpu"), make_copy=False)
+    pinned_buffer = accel.pin_empty_like(src, device="cpu")
     pinned_buffer.copy_(src)
     assert accel.is_pinned(pinned_buffer) is True
     assert accel.unpin_memory(pinned_buffer) is True
@@ -97,7 +97,7 @@ def test_reload_states_holds_pin_buffers_until_sync(monkeypatch):
     device = accel.current_device_name()
 
     hp_param = torch.randn(1024, device=device)
-    pinned = accel.pin_memory(torch.empty_like(hp_param, device="cpu"), make_copy=False)
+    pinned = accel.pin_empty_like(hp_param, device="cpu")
     pinned.copy_(hp_param)
     # Mirrors offload_states(): the hp param now points at the pinned host buffer.
     hp_param.data = pinned

--- a/tests/unit/v1/pin_memory/test_pin_memory.py
+++ b/tests/unit/v1/pin_memory/test_pin_memory.py
@@ -47,6 +47,15 @@ def test_pin_flags(native_pins):
     assert tuple(flat.shape) == (tensor.numel(), )
 
 
+def test_pin_empty_uses_example_dtype_only(native_pins):
+    example = torch.empty(0, dtype=torch.float16)
+    pinned = native_pins.pin_empty(example, (4, 8))
+    assert tuple(pinned.shape) == (4, 8)
+    assert pinned.dtype == torch.float16
+    assert native_pins.is_pinned(pinned)
+    assert native_pins.unpin(pinned) is True
+
+
 def test_unpin_frees_range(native_pins):
     tensor = torch.arange(32, dtype=torch.float32).reshape(4, 8)
     pinned = native_pins.pin(tensor)


### PR DESCRIPTION
## Summary
* Add `get_accelerator().pin_empty()` / `pin_empty_like()` so the repeating `pin_memory(torch.empty(...), make_copy=False)` idiom from #8256 lives in one place ([review note](https://github.com/deepspeedai/DeepSpeed/pull/8256#issuecomment-5358233616)).
* Helpers take a shape and dtype only (zero-element template), so neither backend allocates a full-size pageable buffer before page-locking.
* Route ZeRO-1/2 `offload_states` hp/lp pins, `offload_optimizer_states`, and the SuperOffload worker grad buffer through the helper.

## Test plan
* `pre-commit run --files` on touched paths
* `pytest tests/unit/v1/accelerator/test_accelerator.py tests/unit/v1/pin_memory/test_offload_route.py tests/unit/v1/pin_memory/test_pin_memory.py` — **37 passed**, 5 skipped (CPU host; GPU-only offload-route cases skipped)


Made with [Cursor](https://cursor.com)