### PR TITLE
Replace cuda_graph assertion with explicit ValueError; fix custom_op type annotations

### DIFF
--- a/deepspeed/compile/custom_ops/tp_collectives.py
+++ b/deepspeed/compile/custom_ops/tp_collectives.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+from typing import List
+
 import torch
 import deepspeed.comm as dist
 from deepspeed.utils import groups
@@ -47,7 +49,7 @@ def reduce_from_tp_region_fake(input: torch.Tensor):
 
 
 @torch.library.custom_op("autotp::gather_from_tp_region", mutates_args=())
-def gather_from_tp_region(input: torch.Tensor, partition_sizes: list[int]) -> torch.Tensor:
+def gather_from_tp_region(input: torch.Tensor, partition_sizes: List[int]) -> torch.Tensor:
     """All-gather the last dimension using the frozen shard widths.
 
     Inserted after a column-parallel matmul whose layer asks for gather_output, so that
@@ -85,7 +87,7 @@ def gather_from_tp_region(input: torch.Tensor, partition_sizes: list[int]) -> to
 
 
 @torch.library.register_fake("autotp::gather_from_tp_region")
-def gather_from_tp_region_fake(input: torch.Tensor, partition_sizes: list[int]):
+def gather_from_tp_region_fake(input: torch.Tensor, partition_sizes: List[int]):
     return input.new_empty((*input.shape[:-1], sum(partition_sizes)))
 
 

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -215,9 +215,10 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
 
     def replace_with_policy(child, policy_cls, triangular_masking, inference=False, layer_id=0):
         policy = policy_cls(child, inference=inference)
-        if not policy.cuda_graph_supported:
+        if not policy.cuda_graph_supported and config.enable_cuda_graph:
             # policy says cuda graph is not supported raise an error if set
-            assert not config.enable_cuda_graph, "cuda graph is not supported with this model, please disable"
+            raise ValueError("enable_cuda_graph is not supported with replace_with_kernel_inject for this model. "
+                             "Please set enable_cuda_graph=False or replace_with_kernel_inject=False.")
 
         from deepspeed.moe.layer import MoE
         moe = False

--- a/tests/unit/inference/test_inference_config.py
+++ b/tests/unit/inference/test_inference_config.py
@@ -27,7 +27,7 @@ class TestInferenceCudaGraphConfig:
             intermediate_size=64,
             torch_dtype=torch.bfloat16,
         )
-        model = LlamaForCausalLM(model_config).to("cuda")
+        model = LlamaForCausalLM(model_config).to(get_accelerator().device_name())
 
         with pytest.raises(ValueError, match="enable_cuda_graph is not supported"):
             deepspeed.init_inference(

--- a/tests/unit/inference/test_inference_config.py
+++ b/tests/unit/inference/test_inference_config.py
@@ -6,8 +6,38 @@
 import pytest
 import torch
 import deepspeed
+from deepspeed.accelerator import get_accelerator
 from unit.common import DistributedTest
 from unit.simple_model import create_config_from_dict
+
+
+@pytest.mark.inference
+@pytest.mark.skipif(not get_accelerator().is_available(), reason="requires accelerator")
+class TestInferenceCudaGraphConfig:
+
+    def test_cuda_graph_with_kernel_inject_raises(self):
+        # Regression test for https://github.com/deepspeedai/DeepSpeed/issues/8330
+        from transformers import LlamaConfig, LlamaForCausalLM
+
+        model_config = LlamaConfig(
+            vocab_size=100,
+            hidden_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=64,
+            torch_dtype=torch.bfloat16,
+        )
+        model = LlamaForCausalLM(model_config).to("cuda")
+
+        with pytest.raises(ValueError, match="enable_cuda_graph is not supported"):
+            deepspeed.init_inference(
+                model,
+                config={
+                    "return_tuple": False,
+                    "enable_cuda_graph": True,
+                    "replace_with_kernel_inject": True,
+                },
+            )
 
 
 @pytest.mark.inference


### PR DESCRIPTION
This PR addresses #8330 by replacing the internal assertion in `replace_with_policy` with a clear `ValueError` when both `replace_with_kernel_inject=True` and `enable_cuda_graph=True` are requested for a model whose policy does not support CUDA graphs.

Changes:
- `deepspeed/module_inject/replace_module.py`: raise an actionable `ValueError` instead of asserting.
- `tests/unit/inference/test_inference_config.py`: add a regression test using a tiny Llama model that verifies the new error message.
- `deepspeed/compile/custom_ops/tp_collectives.py`: replace `list[int]` annotations with `typing.List[int]` so `import deepspeed` works on PyTorch 2.6+ (the new regression test needs this to import cleanly).

The regression test was verified on a single H100 with:
```
PYTHONPATH=tests/unit pytest tests/unit/inference/test_inference_config.py::TestInferenceCudaGraphConfig::test_cuda_graph_with_kernel_inject_raises -m inference -v
```
