### PR TITLE
fix(nvme): run main() from the perf script __main__ blocks

### DIFF
--- a/deepspeed/nvme/perf_generate_param.py
+++ b/deepspeed/nvme/perf_generate_param.py
@@ -98,4 +98,4 @@ def main():
 
 
 if __name__ == "__main__":
-    generate_main()
+    main()

--- a/deepspeed/nvme/perf_run_sweep.py
+++ b/deepspeed/nvme/perf_run_sweep.py
@@ -316,4 +316,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sweep_main()
+    main()


### PR DESCRIPTION
### Problem

`deepspeed/nvme/perf_generate_param.py` and `deepspeed/nvme/perf_run_sweep.py` each define a `main()` that parses arguments and hands them to the worker function, and a `__main__` block that skips `main()` and calls the worker directly with no arguments:

```python
def generate_main(log_dir):
    ...

def main():
    args = parse_arguments()
    if not validate_args(args):
        quit()
    print(f'Generate DeepNVMe configuration from {args.log_dir} logs')
    generate_main(args.log_dir)      # <-- correct

if __name__ == "__main__":
    generate_main()                  # <-- no arguments
```

```python
def sweep_main(args):
    ...

def main():
    args = parse_sweep_arguments()
    print(f"Running DeepNVMe performance sweep on {args.nvme_dir}")
    sweep_main(args)                 # <-- correct

if __name__ == "__main__":
    sweep_main()                     # <-- no arguments
```

So running either module directly fails immediately:

```
$ python -m deepspeed.nvme.perf_generate_param
TypeError: generate_main() missing 1 required positional argument: 'log_dir'

$ python -m deepspeed.nvme.perf_run_sweep
TypeError: sweep_main() missing 1 required positional argument: 'args'
```

and both `main()` functions — the ones that actually do the argument parsing and validation — are referenced nowhere else in the tree, so they are dead code today.

### Sibling baseline

`deepspeed/nvme/parse_nvme_stats.py`, in this same package, already does it the right way:

```python
if __name__ == "__main__":
    main()
```

| module | `__main__` calls | runs? |
|---|---|---|
| `parse_nvme_stats.py` | `main()` | ✅ |
| `perf_generate_param.py` | `generate_main()` | ❌ — this PR |
| `perf_run_sweep.py` | `sweep_main()` | ❌ — this PR |

### Scope

`bin/ds_nvme_tune` is **not** affected and is not touched: it does its own parsing and already passes the arguments through (`sweep_main(args)` / `generate_main(args.log_dir)`). The public `deepspeed.nvme` exports (`sweep_main`, `generate_main`, `parse_sweep_arguments`, `ds_io_main`) are unchanged — this only fixes direct module invocation.

### Verification

I replayed the argument binding straight out of the AST rather than hand-copying a repro, so it cannot drift from the source: each worker's parameter list and every call site's shape are read from the files themselves, a signature-identical stub is generated, and the binding is replayed.

```
perf_generate_param.py: generate_main(log_dir)
   line 97   1 arg(s) -> BINDS OK          # inside main()
   line 101  0 arg(s) -> TypeError: generate_main() missing 1 required
                         positional argument: 'log_dir'    # the __main__ block

perf_run_sweep.py: sweep_main(args)
   line 315  1 arg(s) -> BINDS OK          # inside main()
   line 319  0 arg(s) -> TypeError: sweep_main() missing 1 required
                         positional argument: 'args'       # the __main__ block
```

After the change both `__main__` blocks route through `main()`, which is the call site that already binds correctly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
