### PR TITLE
fix(fp16): mark LossScaler._has_inf_or_nan as a staticmethod

### DIFF
--- a/deepspeed/runtime/fp16/loss_scaler.py
+++ b/deepspeed/runtime/fp16/loss_scaler.py
@@ -181,6 +181,7 @@ class LossScaler(LossScalerBase):
         return False
 
     # `x` is a torch.Tensor
+    @staticmethod
     def _has_inf_or_nan(x):
         return False
 
@@ -241,6 +242,7 @@ class DynamicLossScaler(LossScalerBase):
         return False
 
     # `x` is a torch.Tensor
+    @staticmethod
     def _has_inf_or_nan(x):
         return has_inf_or_nan(x)
 


### PR DESCRIPTION
## Problem

Both `_has_inf_or_nan` implementations in `deepspeed/runtime/fp16/loss_scaler.py` are written as plain `def` inside a class body, with no `@staticmethod`:

```python
class DynamicLossScaler(LossScalerBase):
    # `params` is a list / generator of torch.Variable
    def has_overflow_serial(self, params):
        for p in params:
            if p.grad is not None and self._has_inf_or_nan(p.grad.data):
                return True
        return False

    # `x` is a torch.Tensor
    def _has_inf_or_nan(x):          # <-- x receives self
        return has_inf_or_nan(x)
```

Because it is an ordinary method, `x` binds to `self` and the real tensor is passed into a second positional slot that does not exist:

```
TypeError: DynamicLossScaler._has_inf_or_nan() takes 1 positional argument but 2 were given
```

So `DynamicLossScaler.has_overflow_serial()` raises as soon as it reaches a parameter that has a gradient. `LossScaler._has_inf_or_nan` (same file, line 184) has the identical defect.

## Why `@staticmethod` is the intended form

The same helper is implemented three other places in the tree, and all three are written the intended way — including the identical `# \`x\` is a torch.Tensor` comment directly above:

| file | class | decorated? |
|---|---|---|
| `deepspeed/runtime/utils.py` | `CheckOverflow` | ✅ `@staticmethod` |
| `deepspeed/runtime/zero/stage3.py` | ZeRO-3 optimizer | ✅ `@staticmethod` |
| `deepspeed/runtime/zero/stage_1_and_2.py` | ZeRO-1/2 optimizer | ✅ `@staticmethod` |
| `deepspeed/runtime/fp16/loss_scaler.py` | `LossScaler` | ❌ missing |
| `deepspeed/runtime/fp16/loss_scaler.py` | `DynamicLossScaler` | ❌ missing |

`CheckOverflow` calls it exactly the same way (`self._has_inf_or_nan(p.grad.data, i)`) and works, because the decorator is present. Only the two in `loss_scaler.py` were missed.

## Fix

Add `@staticmethod` to both. That is the whole change — **+2 lines, no logic touched.**

## Scope

`DynamicLossScaler.has_overflow_serial()` has no in-tree caller today — the ZeRO and `CheckOverflow` paths use their own copies — so this fixes a latent failure on a public method of a public class rather than a currently-firing crash. I kept the change to the decorator alone and did not touch the surrounding overflow logic.

## Verification

The three real classes (`LossScalerBase`, `LossScaler`, `DynamicLossScaler`) were sliced out of the actual file by AST (decorator-aware line ranges) and executed with `has_inf_or_nan` stubbed, then `has_overflow_serial` was called with one parameter carrying a gradient:

| | `LossScaler._has_inf_or_nan` is staticmethod | `DynamicLossScaler._has_inf_or_nan` is staticmethod | `has_overflow_serial([param])` |
|---|---|---|---|
| current `master` | `False` | `False` | `TypeError: ... takes 1 positional argument but 2 were given` |
| this PR | `True` | `True` | returns `False`, and the stubbed `has_inf_or_nan` is invoked once |

The stub call count matters: it shows the delegation actually happens now, rather than the exception merely disappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
