### PR TITLE
Include the last sample when packing variable-size batches

### DIFF
--- a/deepspeed/runtime/data_pipeline/data_sampling/variable_batch_size_and_lr.py
+++ b/deepspeed/runtime/data_pipeline/data_sampling/variable_batch_size_and_lr.py
@@ -90,8 +90,11 @@ def batch_by_seqlens(
     while batch_init < len(metrics):
 
         # we iterate over possible effective batch sizes (groups of microbatches of same size)
+        # `len(metrics) + 1` because `batch_end` is the exclusive end of `metrics[batch_init:batch_end]`,
+        # so stopping at `len(metrics)` never offers the slice that reaches the last sample and the
+        # final sample of the dataset was never placed in a microbatch.
         valid_batch_end = batch_init
-        for batch_end in range(batch_init + equal_size_multiple, len(metrics), equal_size_multiple):
+        for batch_end in range(batch_init + equal_size_multiple, len(metrics) + 1, equal_size_multiple):
 
             # attempt effective batch
             batch = metrics[batch_init:batch_end]

--- a/tests/unit/runtime/test_variable_batch_size_and_lr.py
+++ b/tests/unit/runtime/test_variable_batch_size_and_lr.py
@@ -12,16 +12,73 @@ def batched_sample_ids(microbatch_ids):
     return sorted(sample_id for _, sample_ids in microbatch_ids for sample_id in sample_ids)
 
 
+@pytest.mark.parametrize("required_microbatches_of_same_size", [False, True])
 @pytest.mark.parametrize("n_samples,max_tokens", [(5, 100), (6, 10), (8, 30), (9, 20)])
-def test_every_sample_is_batched(n_samples, max_tokens):
-    """No sample may be left out of the epoch. `batch_end` is the exclusive end of
-    `metrics[batch_init:batch_end]`, so a range stopping at `len(metrics)` never
-    offered the slice that reaches the last sample and it was silently dropped."""
+def test_every_sample_is_batched(n_samples, max_tokens, required_microbatches_of_same_size):
+    """With one microbatch per batch nothing is aligned away and the trim below is a no-op,
+    so the epoch has to contain every sample. `batch_end` is the exclusive end of
+    `metrics[batch_init:batch_end]`, so a range stopping at `len(metrics)` never offered the
+    slice that reaches the last sample and it was silently dropped."""
     seqlens = [5] * n_samples
 
-    microbatch_ids, _, _ = batch_by_seqlens(seqlens=seqlens, max_tokens=max_tokens, effective_batch_size=1)
+    microbatch_ids, _, _ = batch_by_seqlens(
+        seqlens=seqlens,
+        max_tokens=max_tokens,
+        effective_batch_size=1,
+        required_microbatches_of_same_size=required_microbatches_of_same_size,
+    )
 
     assert batched_sample_ids(microbatch_ids) == list(range(n_samples))
+
+
+@pytest.mark.parametrize("effective_batch_size,required_microbatches_of_same_size,n_samples,max_tokens", [
+    (2, True, 6, 10),
+    (2, True, 8, 30),
+    (2, True, 10, 10),
+    (2, False, 8, 30),
+    (4, True, 8, 30),
+])
+def test_larger_effective_batches_also_reach_the_last_sample(effective_batch_size, required_microbatches_of_same_size,
+                                                             n_samples, max_tokens):
+    """The loop steps by `equal_size_multiple`, which is the effective batch size when
+    microbatches must match, so the exclusive end matters at every step size and not only at
+    one. These are the shapes where the last stride lands exactly on `len(metrics)`: each of
+    them lost its tail before the fix, half the dataset in the last case."""
+    seqlens = [5] * n_samples
+
+    microbatch_ids, _, _ = batch_by_seqlens(
+        seqlens=seqlens,
+        max_tokens=max_tokens,
+        effective_batch_size=effective_batch_size,
+        required_microbatches_of_same_size=required_microbatches_of_same_size,
+    )
+
+    assert batched_sample_ids(microbatch_ids) == list(range(n_samples))
+
+
+@pytest.mark.parametrize("effective_batch_size", [1, 2, 4])
+@pytest.mark.parametrize("required_microbatches_of_same_size", [False, True])
+@pytest.mark.parametrize("n_samples,max_tokens", [(9, 10), (10, 10), (12, 10)])
+def test_only_an_unalignable_tail_is_dropped(effective_batch_size, required_microbatches_of_same_size, n_samples,
+                                             max_tokens):
+    """Above one microbatch per batch the epoch is deliberately allowed to fall short: the
+    microbatch list is trimmed to a multiple of the effective batch size so every dataloader
+    gets the same count. What has to hold in every mode is that the samples which survive are
+    the leading ones in order, with nothing repeated and nothing over the token cap."""
+    seqlens = [5] * n_samples
+
+    microbatch_ids, _, _ = batch_by_seqlens(
+        seqlens=seqlens,
+        max_tokens=max_tokens,
+        effective_batch_size=effective_batch_size,
+        required_microbatches_of_same_size=required_microbatches_of_same_size,
+    )
+
+    sample_ids = batched_sample_ids(microbatch_ids)
+    assert sample_ids == list(range(len(sample_ids))), "a sample was dropped from the middle, not the tail"
+    assert len(microbatch_ids) % effective_batch_size == 0, "every dataloader must get the same microbatch count"
+    for _, ids_in_microbatch in microbatch_ids:
+        assert sum(seqlens[sample_id] for sample_id in ids_in_microbatch) <= max_tokens
 
 
 def test_microbatches_stay_within_max_tokens():

--- a/tests/unit/runtime/test_variable_batch_size_and_lr.py
+++ b/tests/unit/runtime/test_variable_batch_size_and_lr.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+
+from deepspeed.runtime.data_pipeline.data_sampling.variable_batch_size_and_lr import batch_by_seqlens
+
+
+def batched_sample_ids(microbatch_ids):
+    return sorted(sample_id for _, sample_ids in microbatch_ids for sample_id in sample_ids)
+
+
+@pytest.mark.parametrize("n_samples,max_tokens", [(5, 100), (6, 10), (8, 30), (9, 20)])
+def test_every_sample_is_batched(n_samples, max_tokens):
+    """No sample may be left out of the epoch. `batch_end` is the exclusive end of
+    `metrics[batch_init:batch_end]`, so a range stopping at `len(metrics)` never
+    offered the slice that reaches the last sample and it was silently dropped."""
+    seqlens = [5] * n_samples
+
+    microbatch_ids, _, _ = batch_by_seqlens(seqlens=seqlens, max_tokens=max_tokens, effective_batch_size=1)
+
+    assert batched_sample_ids(microbatch_ids) == list(range(n_samples))
+
+
+def test_microbatches_stay_within_max_tokens():
+    """Packing every sample must not come at the cost of the token cap."""
+    seqlens = [3, 7, 2, 8, 5, 5, 1, 9]
+    max_tokens = 12
+
+    microbatch_ids, _, _ = batch_by_seqlens(seqlens=seqlens, max_tokens=max_tokens, effective_batch_size=1)
+
+    assert batched_sample_ids(microbatch_ids) == list(range(len(seqlens)))
+    for _, sample_ids in microbatch_ids:
+        assert sum(seqlens[sample_id] for sample_id in sample_ids) <= max_tokens


### PR DESCRIPTION
### The bug

`batch_by_seqlens` (`deepspeed/runtime/data_pipeline/data_sampling/variable_batch_size_and_lr.py`) packs samples into microbatches by growing a candidate slice and keeping the widest one that stays under the token cap:

```python
valid_batch_end = batch_init
for batch_end in range(batch_init + equal_size_multiple, len(metrics), equal_size_multiple):
    batch = metrics[batch_init:batch_end]
    ...
    if is_batch_valid:
        valid_batch_end = batch_end

if batch_init == valid_batch_end: break  # last batch is not valid (size zero), so we are done
```

`batch_end` is the exclusive end of `metrics[batch_init:batch_end]`, and `range` stops before its own end, so `batch_end` never reaches `len(metrics)`. The widest slice ever offered is `metrics[batch_init:len(metrics) - 1]`, and the last sample of the dataset is never placed in a microbatch. When `batch_init` finally lands on that sample the range is empty, `valid_batch_end` stays equal to `batch_init`, and the `break` comment reads it as "no more data".

Five samples that comfortably fit in one microbatch:

```python
>>> microbatch_ids, _, _ = batch_by_seqlens(seqlens=[1, 2, 3, 4, 5], max_tokens=100, effective_batch_size=1)
>>> sorted(i for _, ids in microbatch_ids for i in ids)
[0, 1, 2, 3]
```

It is silent, and it is every epoch, not a one-off: the sample is dropped from training for good with `sequence_picking_order="dataloader"` or `"seqlen"`, and a different sample is dropped each epoch with `"random"`.

### The fix

Stop at `len(metrics) + 1` so the full-width slice is offered. Nothing else moves: `is_microbatch_valid` still applies the token cap and the min/max batch sizes, and the trim to a whole number of effective batches still decides what survives.

### Test

`tests/unit/runtime/test_variable_batch_size_and_lr.py`, the first tests for this file. Plain CPU pytest functions, no accelerator needed.

- `test_every_sample_is_batched`, parametrized over four dataset sizes and token caps, asserts the batched sample ids are exactly `range(n_samples)`.
- `test_microbatches_stay_within_max_tokens` asserts the same coverage on ragged sequence lengths and that no microbatch exceeds `max_tokens`, so the packing is not bought at the cap's expense.

Before the change:

```
5 failed in 6.14s
```

After:

```
5 passed in 7.10s
```

I also swept the other modes (`sequence_picking_order` in dataloader/seqlen/random x `required_microbatches_of_same_size` in False/True x `effective_batch_size` in 1/2/4, 24 ragged samples, `max_tokens=15`): no duplicated sample ids anywhere, every microbatch within the cap, and full coverage except where the deliberate trim to a whole number of effective batches removes the tail.

`yapf --diff` and `flake8` are clean on both files.
