### PR TITLE
Assert the scattered sequence length is divisible by the SP size

### DIFF
--- a/deepspeed/sequence/layer.py
+++ b/deepspeed/sequence/layer.py
@@ -30,6 +30,7 @@ def _generate_layout_params(scatter_idx, batch_dim_idx, seq_world_size, input):
     if batch_dim_idx == 0:
         if scatter_idx < 2:
             bs, global_seq_len, num_local_head, head_dim = input.shape
+            assert global_seq_len % seq_world_size == 0, f"Sequence length ({global_seq_len}) must be divisible by the sequence parallel size ({seq_world_size})!"
             pre_all2all_inp_shape = [bs, seq_world_size, global_seq_len // seq_world_size, num_local_head, head_dim]
             pre_all2all_permute_idx = (1, 0, 2, 3, 4)
 
@@ -46,6 +47,7 @@ def _generate_layout_params(scatter_idx, batch_dim_idx, seq_world_size, input):
     else:
         if scatter_idx < 2:
             global_seq_len, bs, num_local_head, head_dim = input.shape
+            assert global_seq_len % seq_world_size == 0, f"Sequence length ({global_seq_len}) must be divisible by the sequence parallel size ({seq_world_size})!"
             pre_all2all_inp_shape = [seq_world_size, global_seq_len // seq_world_size, bs, num_local_head, head_dim]
             pre_all2all_permute_idx = None
 


### PR DESCRIPTION
Refs #7384. @stas00 — this is the "original implementation" half of your reply, plus the
answer to what you asked.

## The new implementation does already check

`UlyssesSPDataLoaderAdapter.refill()` validates it before sharding
(`deepspeed/runtime/sequence_parallel/ulysses_sp.py`):

```python
if seq_length % self.sp_world_size != 0:
    raise ValueError(f"batch's seqlen={seq_length} isn't divisible by sp-size={self.sp_world_size}")
```

So the new path is fine. `deepspeed/sequence/layer.py` has no equivalent.

## What this changes

`_generate_layout_params` asserts the head count divides evenly in both branches that
scatter heads:

```python
assert num_total_head % seq_world_size == 0, f"Number of heads ({num_total_head}) must be divisible by the sequence parallel size ({seq_world_size})!"
```

The two branches that scatter the *sequence* had no equivalent — they just computed
`global_seq_len // seq_world_size`, so a length that is not a multiple of the SP size was
silently truncated and the all2all buffers then disagreed. This adds the matching
assertion, so it now fails the same way a head mismatch already does:

```
AssertionError: Sequence length (9) must be divisible by the sequence parallel size (2)!
```

## What it does not cover, and why

**This does not fully close #7384**, which is why the commit says `Refs` rather than
`Fixes`.

The reporter pre-shards with `torch.tensor_split(t, world_size, dim=2)[rank]` and passes
`scatter_idx=1, gather_idx=2`. With a global length of 9 over 2 ranks that hands rank 0 a
size-5 shard and rank 1 a size-4 shard, so the ranks disagree on the **gather** dimension.
No rank can detect that locally — each one's own shard looks perfectly valid — and the
mismatch only surfaces inside `all_to_all_single`, where gloo aborts the process group with
no Python traceback at all.

Catching that case needs a cross-rank check, e.g. an `all_gather` of the local shape
compared across ranks before the all2all. That is a collective on every all2all call, so it
is a performance trade I did not want to make on your behalf. Happy to add it behind a flag,
or only under a debug/validation mode, if you want it.

## Verification

Two ranks over gloo on CPU:

| case | before | after |
|---|---|---|
| seq 8, world 2, full sequence at the scattered dim | works, matches single-device attention | unchanged |
| seq 9, world 2, full sequence at the scattered dim | process group aborts, no message | `AssertionError` naming both numbers |
| seq 9, world 2, pre-sharded unevenly (the report) | aborts | still aborts — see above |

The divisible case was checked against single-device `scaled_dot_product_attention` on the
same input to confirm the harness itself is sound before trusting the failing case.

`yapf --style .style.yapf` reports no diff; the two new lines are the same shape and length
as the head assertions directly below them.

I could not run `tests/unit/sequence_parallelism/` here — no NVIDIA GPU on this machine — so
that is worth a look in CI.
