### PR TITLE
perf(rollout): combine shared prefill with CUDA Graph decode

### DIFF
--- a/deepspeed/runtime/hybrid_engine.py
+++ b/deepspeed/runtime/hybrid_engine.py
@@ -198,8 +198,6 @@ class DeepSpeedHybridEngine(DeepSpeedEngine):
             raise RuntimeError("Shared prefill does not support inference tensor parallelism")
         if hybrid_config.release_inference_cache:
             raise RuntimeError("Shared prefill does not support release_inference_cache")
-        if hybrid_config.enable_cuda_graph:
-            raise RuntimeError("Shared prefill does not support CUDA graph capture")
         if len(self._inference_containers) == 0:
             raise RuntimeError("Shared prefill requires HybridEngine inference containers")
 

--- a/deepspeed/runtime/rollout/hybrid_engine_rollout.py
+++ b/deepspeed/runtime/rollout/hybrid_engine_rollout.py
@@ -27,10 +27,16 @@ class _ForwardProfiler:
     def __init__(self, accelerator):
         self.event_type = accelerator.Event
         self.use_host_timer = accelerator.use_host_timers()
+        # Host intervals are only reliable when there is no asynchronous device
+        # work, as on CPU. MPS exposes events but cannot time them, so its host
+        # intervals would measure enqueue latency rather than model execution.
+        self.is_available = not self.use_host_timer or self.event_type is None
         self.active_start = None
         self.measurements = []
 
     def register(self, module):
+        if not self.is_available:
+            return ()
         pre_handle = module.register_forward_pre_hook(self._start_forward)
         post_handle = module.register_forward_hook(self._end_forward)
         return pre_handle, post_handle

--- a/deepspeed/runtime/rollout/hybrid_engine_rollout.py
+++ b/deepspeed/runtime/rollout/hybrid_engine_rollout.py
@@ -152,6 +152,7 @@ class HybridEngineRollout(RolloutEngine):
                     prompt_ids,
                     attention_mask=prompt_attn,
                     max_new_tokens=max_new_tokens,
+                    min_new_tokens=max_new_tokens,
                     # ZeRO-3 gathers parameters during each decode forward, so every
                     # data-parallel rank must execute the same number of iterations.
                     eos_token_id=None,

--- a/deepspeed/runtime/rollout/hybrid_engine_rollout.py
+++ b/deepspeed/runtime/rollout/hybrid_engine_rollout.py
@@ -21,6 +21,48 @@ from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.rollout.base import RolloutBatch, RolloutEngine, RolloutRequest, SamplingConfig
 
 
+class _ForwardProfiler:
+    """Measure top-level model forwards without synchronizing each call."""
+
+    def __init__(self, accelerator):
+        self.event_type = accelerator.Event
+        self.use_host_timer = accelerator.use_host_timers()
+        self.active_start = None
+        self.measurements = []
+
+    def register(self, module):
+        pre_handle = module.register_forward_pre_hook(self._start_forward)
+        post_handle = module.register_forward_hook(self._end_forward)
+        return pre_handle, post_handle
+
+    def get_stage_times(self):
+        if not self.measurements:
+            return None, None, 0
+
+        durations = [self._elapsed_time(start, end) for start, end in self.measurements]
+        return durations[0], sum(durations[1:]), len(durations) - 1
+
+    def _start_forward(self, _module, _args):
+        self.active_start = self._record_time()
+
+    def _end_forward(self, _module, _args, _output):
+        end = self._record_time()
+        self.measurements.append((self.active_start, end))
+        self.active_start = None
+
+    def _record_time(self):
+        if self.use_host_timer:
+            return time.perf_counter()
+        event = self.event_type(enable_timing=True)
+        event.record()
+        return event
+
+    def _elapsed_time(self, start, end):
+        if self.use_host_timer:
+            return (end - start) * 1000.0
+        return start.elapsed_time(end)
+
+
 @dataclass
 class HybridEngineRolloutConfig:
     """Configuration for HybridEngineRollout."""
@@ -81,13 +123,19 @@ class HybridEngineRollout(RolloutEngine):
 
         is_greedy = sampling.temperature <= 0.0
 
+        forward_profiler = None
+        forward_profile_handles = []
+        if self.enable_profiling and not (self.use_graph_capture and is_greedy):
+            forward_profiler = _ForwardProfiler(accelerator)
+            forward_profile_handles = forward_profiler.register(module)
+
         shared_prefill_handles = []
-        if self.use_shared_prefill and n > 1:
-            if self.use_graph_capture:
-                raise RuntimeError("Shared prefill does not support CUDA graph capture")
-            self.engine.prepare_shared_prefill(B, n, prompt_len)
-            shared_prefill_handles = self._register_shared_prefill_hooks(module, B, n)
         try:
+            if self.use_shared_prefill and n > 1:
+                if self.use_graph_capture:
+                    raise RuntimeError("Shared prefill does not support CUDA graph capture")
+                self.engine.prepare_shared_prefill(B, n, prompt_len)
+                shared_prefill_handles = self._register_shared_prefill_hooks(module, B, n)
             if self.use_graph_capture and is_greedy:
                 output_ids = self._generate_graph(prompt_ids, prompt_attn, max_new_tokens, pad_token_id, module,
                                                   device)
@@ -108,6 +156,8 @@ class HybridEngineRollout(RolloutEngine):
                 )
         finally:
             for handle in shared_prefill_handles:
+                handle.remove()
+            for handle in forward_profile_handles:
                 handle.remove()
 
         if self.enable_profiling:
@@ -147,6 +197,15 @@ class HybridEngineRollout(RolloutEngine):
             generation_ms = (generation_end - expansion_end) * 1000.0
             post_processing_ms = (post_processing_end - generation_end) * 1000.0
             total_ms = (post_processing_end - profile_start) * 1000.0
+            prefill_forward_ms = None
+            decode_forward_ms = None
+            num_decode_forwards = 0
+            if forward_profiler is not None:
+                prefill_forward_ms, decode_forward_ms, num_decode_forwards = forward_profiler.get_stage_times()
+            generation_overhead_ms = generation_ms
+            if prefill_forward_ms is not None:
+                generation_overhead_ms -= prefill_forward_ms + decode_forward_ms
+                generation_overhead_ms = max(0.0, generation_overhead_ms)
             response_length = int(output_ids.shape[1] - prompt_len)
             num_generated_tokens = int(output_ids.shape[0] * response_length)
             tokens_per_second = 0.0
@@ -155,6 +214,10 @@ class HybridEngineRollout(RolloutEngine):
             self._last_profile = {
                 "prompt_expansion_ms": prompt_expansion_ms,
                 "generation_ms": generation_ms,
+                "prefill_forward_ms": prefill_forward_ms,
+                "decode_forward_ms": decode_forward_ms,
+                "generation_overhead_ms": generation_overhead_ms,
+                "num_decode_forwards": num_decode_forwards,
                 "post_processing_ms": post_processing_ms,
                 "total_ms": total_ms,
                 "num_generated_tokens": num_generated_tokens,

--- a/docs/code-docs/source/inference-engine.rst
+++ b/docs/code-docs/source/inference-engine.rst
@@ -70,6 +70,8 @@ branches. The option is disabled by default.
 
 Shared prefill currently requires HybridEngine kernel injection, ZeRO stage 0,
 inference tensor-parallel size 1, an internal KV cache, and a prompt longer than
-one token. It cannot be combined with CUDA graph capture or
+one token. It can be combined with native HybridEngine decode graphs enabled by
+``hybrid_engine.enable_cuda_graph`` for greedy fixed-length generation, but not
+with ``HybridEngineRolloutConfig(use_graph_capture=True)`` or
 ``release_inference_cache``. Sampling still happens independently for every
 response branch after the shared prompt forward.

--- a/docs/code-docs/source/inference-engine.rst
+++ b/docs/code-docs/source/inference-engine.rst
@@ -35,11 +35,26 @@ behavior and adds overhead. Enable it through ``HybridEngineRolloutConfig``::
     profile = rollout.get_last_profile()
 
 The profile contains synchronized times for prompt expansion, generation,
-post-processing, and the complete rollout. Times are reported in milliseconds.
-``num_generated_tokens`` counts all returned response positions across the
-expanded batch, including padding positions. ``tokens_per_second`` divides
-that count by the end-to-end rollout time. The profile also records the input
-batch size, samples per prompt, prompt length, and returned response length.
+post-processing, and the complete rollout. Generation is further divided into
+the first model forward (``prefill_forward_ms``), all later model forwards
+(``decode_forward_ms``), and residual generation work
+(``generation_overhead_ms``). The residual includes sampling, generation-loop
+bookkeeping, shared-cache expansion, and other work outside the top-level model
+forwards. ``num_decode_forwards`` reports how many forwards contributed to the
+decode time.
+
+Forward timings use accelerator events where supported and synchronize once at
+the end of generation instead of after every generated token. Accelerators that
+require host timers use synchronous wall-clock timings. The forward breakdown
+is unavailable for the CUDA graph path because graph replays bypass model
+forward hooks; its forward fields are ``None`` and its complete generation time
+is reported as generation overhead.
+
+Times are reported in milliseconds. ``num_generated_tokens`` counts all
+returned response positions across the expanded batch, including padding
+positions. ``tokens_per_second`` divides that count by the end-to-end rollout
+time. The profile also records the input batch size, samples per prompt, prompt
+length, and returned response length.
 For benchmark matrices, cases execute from the largest effective batch to the
 smallest because HybridEngine sizes its inference workspace on the first
 forward. Results remain in the user-requested matrix order.

--- a/docs/code-docs/source/inference-engine.rst
+++ b/docs/code-docs/source/inference-engine.rst
@@ -44,11 +44,12 @@ forwards. ``num_decode_forwards`` reports how many forwards contributed to the
 decode time.
 
 Forward timings use accelerator events where supported and synchronize once at
-the end of generation instead of after every generated token. Accelerators that
-require host timers use synchronous wall-clock timings. The forward breakdown
-is unavailable for the CUDA graph path because graph replays bypass model
-forward hooks; its forward fields are ``None`` and its complete generation time
-is reported as generation overhead.
+the end of generation instead of after every generated token. Synchronous
+accelerators without events, such as CPU, use wall-clock timings. The forward
+breakdown is unavailable when an asynchronous accelerator lacks event timing,
+such as MPS, and for the CUDA graph path because graph replays bypass model
+forward hooks. In both cases its forward fields are ``None`` and its complete
+generation time is reported as generation overhead.
 
 Times are reported in milliseconds. ``num_generated_tokens`` counts all
 returned response positions across the expanded batch, including padding

--- a/tests/unit/hybrid_engine/test_he_cuda_graph.py
+++ b/tests/unit/hybrid_engine/test_he_cuda_graph.py
@@ -2,6 +2,7 @@
 # DeepSpeed Team
 
 import os
+from types import SimpleNamespace
 import pytest
 import torch
 import deepspeed
@@ -196,3 +197,60 @@ class TestHybridEngineCudaGraphEquivalence(DistributedTest):
             eager = engine.generate(**gen_kwargs).clone()
 
         assert torch.equal(graphed, eager), "CUDA graph generation diverged from eager generation"
+
+    def test_shared_prefill_graph_generation_matches_eager(self):
+        from transformers import AutoModelForCausalLM
+
+        from deepspeed.runtime.rollout.base import RolloutRequest, SamplingConfig
+        from deepspeed.runtime.rollout.hybrid_engine_rollout import HybridEngineRollout, HybridEngineRolloutConfig
+
+        model_name = "facebook/opt-125m"
+        prompt_len, gen_len, source_batch_size, repeats = 32, 16, 1, 2
+        target_batch_size = source_batch_size * repeats
+        local_rank = int(os.getenv("LOCAL_RANK", "0"))
+        device = f"{get_accelerator().device_name()}:{local_rank}"
+
+        config = {
+            "train_batch_size": target_batch_size,
+            "train_micro_batch_size_per_gpu": target_batch_size,
+            "steps_per_print": 10**9,
+            "zero_optimization": {
+                "stage": 0
+            },
+            "fp16": {
+                "enabled": True
+            },
+            "hybrid_engine": {
+                "enabled": True,
+                "max_out_tokens": prompt_len + gen_len,
+                "enable_cuda_graph": True,
+            },
+        }
+
+        model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.half)
+        model.config.use_cache = True
+        engine, *_ = deepspeed.initialize(model=model, model_parameters=model.parameters(), config=config)
+        assert engine._decode_graphs is not None, "CUDA graphs should be active for this config"
+
+        torch.manual_seed(0)
+        prompt_ids = torch.randint(100, 1000, (source_batch_size, prompt_len), device=device)
+        request = RolloutRequest(
+            prompt_ids=prompt_ids,
+            prompt_attention_mask=torch.ones_like(prompt_ids),
+        )
+        sampling = SamplingConfig(max_new_tokens=gen_len, temperature=0.0, n_samples_per_prompt=repeats)
+        tokenizer = SimpleNamespace(pad_token_id=1, eos_token_id=None)
+        rollout = HybridEngineRollout(engine, tokenizer, HybridEngineRolloutConfig(use_shared_prefill=True))
+
+        engine.eval()
+        with torch.no_grad():
+            graphed = rollout.generate(request, sampling).input_ids.clone()
+        assert engine._decode_graphs.captured_positions == gen_len - 1
+
+        # Detach the graph dispatcher and repeat the same shared-prefill generation eagerly.
+        engine.module.forward = engine._orig_module_forward
+        engine._decode_graphs = None
+        with torch.no_grad():
+            eager = rollout.generate(request, sampling).input_ids.clone()
+
+        assert torch.equal(graphed, eager), "Shared-prefill CUDA graph generation diverged from eager generation"

--- a/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
+++ b/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
@@ -20,6 +20,7 @@ from deepspeed.runtime.rollout.base import RolloutRequest, SamplingConfig
 from deepspeed.runtime.rollout.hybrid_engine_rollout import (
     HybridEngineRollout,
     HybridEngineRolloutConfig,
+    _ForwardProfiler,
 )
 
 
@@ -46,6 +47,19 @@ def _make_request():
 
 def _make_sampling(n_samples_per_prompt=1):
     return SamplingConfig(max_new_tokens=2, temperature=0, n_samples_per_prompt=n_samples_per_prompt)
+
+
+class _ForwardingGenerateModule(torch.nn.Module):
+
+    def forward(self, input_ids, **_kwargs):
+        return SimpleNamespace(logits=input_ids[:, :, None].float())
+
+    def generate(self, input_ids, attention_mask, max_new_tokens, **_kwargs):
+        self(input_ids, attention_mask=attention_mask)
+        for _ in range(max_new_tokens - 1):
+            self(input_ids[:, -1:], attention_mask=attention_mask)
+        response = torch.full((input_ids.shape[0], max_new_tokens), 5, dtype=input_ids.dtype)
+        return torch.cat((input_ids, response), dim=1)
 
 
 # -- config defaults ----------------------------------------------------
@@ -100,6 +114,10 @@ def test_generate_records_profile_when_enabled(mock_get_accelerator, mock_perf_c
     profile = rollout.get_last_profile()
     assert profile["prompt_expansion_ms"] == pytest.approx(1.0)
     assert profile["generation_ms"] == pytest.approx(10.0)
+    assert profile["prefill_forward_ms"] is None
+    assert profile["decode_forward_ms"] is None
+    assert profile["generation_overhead_ms"] == pytest.approx(10.0)
+    assert profile["num_decode_forwards"] == 0
     assert profile["post_processing_ms"] == pytest.approx(2.0)
     assert profile["total_ms"] == pytest.approx(13.0)
     assert profile["num_generated_tokens"] == 8
@@ -111,6 +129,60 @@ def test_generate_records_profile_when_enabled(mock_get_accelerator, mock_perf_c
     expected_prompt_masks = [[0, 1, 1], [0, 1, 1], [0, 1, 1], [0, 1, 1]]
     assert output.attention_mask[:, :3].tolist() == expected_prompt_masks
     assert mock_get_accelerator.return_value.synchronize.call_count == 4
+
+
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
+def test_generate_profiles_prefill_and_decode_forwards(mock_get_accelerator, mock_perf_counter):
+    engine = _make_engine()
+    engine.module = _ForwardingGenerateModule()
+    rollout = HybridEngineRollout(engine, _make_tokenizer(), HybridEngineRolloutConfig(enable_profiling=True))
+    mock_get_accelerator.return_value.use_host_timers.return_value = True
+    mock_perf_counter.side_effect = [
+        1.000,
+        1.001,
+        1.002,
+        1.006,
+        1.007,
+        1.009,
+        1.016,
+        1.018,
+    ]
+
+    rollout.generate(_make_request(), _make_sampling())
+
+    profile = rollout.get_last_profile()
+    assert profile["generation_ms"] == pytest.approx(15.0)
+    assert profile["prefill_forward_ms"] == pytest.approx(4.0)
+    assert profile["decode_forward_ms"] == pytest.approx(2.0)
+    assert profile["generation_overhead_ms"] == pytest.approx(9.0)
+    assert profile["num_decode_forwards"] == 1
+    assert not engine.module._forward_pre_hooks
+    assert not engine.module._forward_hooks
+
+
+def test_forward_profiler_uses_accelerator_events_without_synchronizing():
+    prefill_start, prefill_end, decode_start, decode_end = [MagicMock() for _ in range(4)]
+    prefill_start.elapsed_time.return_value = 4.0
+    decode_start.elapsed_time.return_value = 2.0
+    event_type = MagicMock(side_effect=[prefill_start, prefill_end, decode_start, decode_end])
+    accelerator = SimpleNamespace(Event=event_type, use_host_timers=lambda: False)
+    profiler = _ForwardProfiler(accelerator)
+    module = _ForwardingGenerateModule()
+    handles = profiler.register(module)
+
+    module(torch.ones(2, 3, dtype=torch.long))
+    module(torch.ones(2, 1, dtype=torch.long))
+    for handle in handles:
+        handle.remove()
+
+    prefill_ms, decode_ms, num_decode_forwards = profiler.get_stage_times()
+    assert prefill_ms == 4.0
+    assert decode_ms == 2.0
+    assert num_decode_forwards == 1
+    assert event_type.call_count == 4
+    for event in (prefill_start, prefill_end, decode_start, decode_end):
+        event.record.assert_called_once_with()
 
 
 @patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
@@ -397,12 +469,15 @@ def test_sync_weights_is_noop():
 # -- generate dispatches correctly -------------------------------------
 
 
-def test_generate_calls_graph_capture_when_enabled():
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
+def test_generate_calls_graph_capture_when_enabled(mock_get_accelerator, mock_perf_counter):
     engine = _make_engine()
     tok = _make_tokenizer()
-    cfg = HybridEngineRolloutConfig(use_graph_capture=True)
+    cfg = HybridEngineRolloutConfig(use_graph_capture=True, enable_profiling=True)
     rollout = HybridEngineRollout(engine, tok, cfg=cfg)
     rollout._generate_graph = MagicMock(return_value=torch.zeros(1, 5, dtype=torch.long))
+    mock_perf_counter.side_effect = [1.0, 1.001, 1.011, 1.013]
 
     req = MagicMock()
     req.prompt_ids = torch.tensor([[1, 2]])
@@ -414,6 +489,11 @@ def test_generate_calls_graph_capture_when_enabled():
 
     rollout.generate(req, sampling)
     rollout._generate_graph.assert_called_once()
+    profile = rollout.get_last_profile()
+    assert profile["prefill_forward_ms"] is None
+    assert profile["decode_forward_ms"] is None
+    assert profile["generation_overhead_ms"] == pytest.approx(10.0)
+    assert profile["num_decode_forwards"] == 0
 
 
 def test_generate_keeps_ranks_in_lockstep_and_pads_after_eos():

--- a/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
+++ b/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
@@ -138,6 +138,7 @@ def test_generate_profiles_prefill_and_decode_forwards(mock_get_accelerator, moc
     engine.module = _ForwardingGenerateModule()
     rollout = HybridEngineRollout(engine, _make_tokenizer(), HybridEngineRolloutConfig(enable_profiling=True))
     mock_get_accelerator.return_value.use_host_timers.return_value = True
+    mock_get_accelerator.return_value.Event = None
     mock_perf_counter.side_effect = [
         1.000,
         1.001,
@@ -183,6 +184,28 @@ def test_forward_profiler_uses_accelerator_events_without_synchronizing():
     assert event_type.call_count == 4
     for event in (prefill_start, prefill_end, decode_start, decode_end):
         event.record.assert_called_once_with()
+
+
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
+def test_generate_skips_forward_breakdown_without_event_timing(mock_get_accelerator, mock_perf_counter):
+    engine = _make_engine()
+    engine.module = _ForwardingGenerateModule()
+    rollout = HybridEngineRollout(engine, _make_tokenizer(), HybridEngineRolloutConfig(enable_profiling=True))
+    mock_get_accelerator.return_value.use_host_timers.return_value = True
+    mock_get_accelerator.return_value.Event = MagicMock()
+    mock_perf_counter.side_effect = [1.000, 1.001, 1.016, 1.018]
+
+    rollout.generate(_make_request(), _make_sampling())
+
+    profile = rollout.get_last_profile()
+    assert profile["generation_ms"] == pytest.approx(15.0)
+    assert profile["prefill_forward_ms"] is None
+    assert profile["decode_forward_ms"] is None
+    assert profile["generation_overhead_ms"] == pytest.approx(15.0)
+    assert profile["num_decode_forwards"] == 0
+    assert not engine.module._forward_pre_hooks
+    assert not engine.module._forward_hooks
 
 
 @patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")

--- a/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
+++ b/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
@@ -536,7 +536,11 @@ def test_generate_keeps_ranks_in_lockstep_and_pads_after_eos():
 
     result = rollout.generate(req, sampling)
 
-    assert engine.module.generate.call_args.kwargs['eos_token_id'] is None
+    generate_kwargs = engine.module.generate.call_args.kwargs
+    assert generate_kwargs['max_new_tokens'] == sampling.max_new_tokens
+    assert generate_kwargs['min_new_tokens'] == sampling.max_new_tokens
+    assert generate_kwargs['min_new_tokens'] == generate_kwargs['max_new_tokens']
+    assert generate_kwargs['eos_token_id'] is None
     assert result.input_ids.tolist() == [[10, 11, 5, 2, 0, 0]]
     assert result.attention_mask.tolist() == [[1, 1, 1, 1, 0, 0]]
 


### PR DESCRIPTION
## Summary

Enable native HybridEngine CUDA Graph decode for fixed-length rollout generation and allow it to compose with shared prefill.

The rollout-level StaticCache graph path remains incompatible with shared prefill.

Depends on #8350.

## Validation

- Shared-prefill graph/eager output equivalence: 1 passed
- Changed-file pre-commit hooks: passed
- OPT-6.7B FP16, RTX A4500, world size 1
- Batch 1, samples 4, prompt 512, response 128
- Warmup 5, iterations 20

| Metric | Eager | Shared | Graph | Shared + graph |
|---|---:|---:|---:|---:|
| Prefill (ms) | 455.899 | 133.497 | 456.884 | 133.824 |
| Decode (ms) | 3606.478 | 3606.113 | 3518.189 | 3516.792 |
| Total (ms) | 4104.628 | 3784.307 | 4012.964 | 3692.591 |
| Throughput (tok/s) | 124.738 | 135.296 | 127.587 | 138.656 |
| Peak memory (MiB) | 13144.629 | 13178.629 | 13203.820 | 13237.820 |

Compared with eager, the combined path reduces total latency by 10.04% and improves throughput by 11.16%, with about 93 MiB additional peak memory.

Thank you for reviewing!