### PR TITLE
[AutoEP]Fix optimizer and replaced MOE parameter mismatch

### DIFF
--- a/deepspeed/compile/custom_ops/tp_collectives.py
+++ b/deepspeed/compile/custom_ops/tp_collectives.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+from typing import List
+
 import torch
 import deepspeed.comm as dist
 from deepspeed.utils import groups
@@ -47,7 +49,7 @@ def reduce_from_tp_region_fake(input: torch.Tensor):
 
 
 @torch.library.custom_op("autotp::gather_from_tp_region", mutates_args=())
-def gather_from_tp_region(input: torch.Tensor, partition_sizes: list[int]) -> torch.Tensor:
+def gather_from_tp_region(input: torch.Tensor, partition_sizes: List[int]) -> torch.Tensor:
     """All-gather the last dimension using the frozen shard widths.
 
     Inserted after a column-parallel matmul whose layer asks for gather_output, so that
@@ -85,7 +87,7 @@ def gather_from_tp_region(input: torch.Tensor, partition_sizes: list[int]) -> to
 
 
 @torch.library.register_fake("autotp::gather_from_tp_region")
-def gather_from_tp_region_fake(input: torch.Tensor, partition_sizes: list[int]):
+def gather_from_tp_region_fake(input: torch.Tensor, partition_sizes: List[int]):
     return input.new_empty((*input.shape[:-1], sum(partition_sizes)))
 
 

--- a/deepspeed/module_inject/auto_ep.py
+++ b/deepspeed/module_inject/auto_ep.py
@@ -544,12 +544,20 @@ class AutoEP:
         specs: list[MoELayerSpec],
         ep_size: int,
         ep_rank: int,
-    ) -> None:
-        """Replace multiple MoE modules and batch post-replacement recorder retargeting."""
+    ) -> dict[int, list[nn.Parameter]]:
+        """Replace multiple MoE modules and batch post-replacement recorder retargeting.
+
+        Returns the source parameters behind each replacement parameter, keyed by ``id()``, so
+        that a caller-supplied optimizer can put each replacement back into the param group its
+        sources belonged to. The entries are popped off the layers as they are collected, so the
+        discarded source tensors are only referenced until the engine has finished the remap.
+        """
         replacements: list[tuple[MoELayerSpec, nn.Module]] = []
+        replacement_sources: dict[int, list[nn.Parameter]] = {}
         for spec in specs:
             replacement = self._replace_moe_layer_without_retarget(spec, ep_size, ep_rank)
             replacements.append((spec, replacement))
+            replacement_sources.update(replacement.__dict__.pop("_autoep_replacement_sources", {}))
             logger.info(f"AutoEP: replaced '{spec.moe_module_name}' with AutoEPMoELayer "
                         f"(ep_size={ep_size}, ep_rank={ep_rank}, "
                         f"local_experts={replacement.num_local_experts})")
@@ -561,6 +569,8 @@ class AutoEP:
 
         for spec, replacement in retarget_groups.values():
             self._retarget_transformers_output_recorders(spec, replacement)
+
+        return replacement_sources
 
     def _apply_config_overrides(self, preset: MoEModelPreset) -> MoEModelPreset:
         return apply_config_overrides(self.config, preset)

--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -25,7 +25,8 @@ from deepspeed.utils import logger
 from deepspeed.moe.ep_router import TokenChoiceTopKRouter
 from deepspeed.moe.ep_count import count_tokens_per_expert
 from deepspeed.moe.ep_experts import GroupedExperts
-from deepspeed.moe.ep_repack import _gather_source_zero_params, repack_expert_requires_grad_flags, repack_expert_weights
+from deepspeed.moe.ep_repack import (_gather_source_zero_params, repack_expert_requires_grad_flags,
+                                     repack_expert_source_params, repack_expert_weights)
 
 # ---------------------------------------------------------------------------
 # Named tuples
@@ -470,6 +471,34 @@ class AutoEPMoELayer(nn.Module):
         self.experts.w1.requires_grad_(w1_requires_grad)
         self.experts.w2.requires_grad_(w2_requires_grad)
         self.experts.w3.requires_grad_(w3_requires_grad)
+
+        # Record which source parameters produced each replacement. A caller-supplied optimizer
+        # has already sorted the sources into param groups, so this is what lets the engine put
+        # every replacement back into the group its sources came from. AutoEP.replace_moe_layers
+        # pops the attribute straight away, so the discarded source tensors are not kept alive.
+        w1_sources, w2_sources, w3_sources = repack_expert_source_params(
+            experts_source=getattr(source_module, spec.experts_name),
+            spec=spec,
+            ep_rank=ep_rank,
+            ep_size=ep_size,
+        )
+        replacement_sources = {
+            id(self.experts.w1): list(w1_sources),
+            id(self.experts.w2): list(w2_sources),
+            id(self.experts.w3): list(w3_sources),
+            id(self.router.gate.weight): [source_gate.weight],
+        }
+        if spec.gate_bias and source_gate_bias is not None:
+            replacement_sources[id(self.router.gate.bias)] = [source_gate_bias]
+        if source_ecb is not None and isinstance(source_ecb, nn.Parameter):
+            replacement_sources[id(self.router.e_score_correction_bias)] = [source_ecb]
+        # Anything else the router or the grouped experts allocated has no counterpart in the
+        # source module, so tie it to this block's gate weight: it carries no pretrained value of
+        # its own, but it still belongs with the rest of this block's parameters.
+        for fresh_module in (self.router, self.experts):
+            for param in fresh_module.parameters():
+                replacement_sources.setdefault(id(param), [source_gate.weight])
+        self._autoep_replacement_sources = replacement_sources
 
         self.shared_experts = getattr(source_module, spec.shared_experts_name,
                                       None) if spec.has_shared_experts else None

--- a/deepspeed/moe/ep_repack.py
+++ b/deepspeed/moe/ep_repack.py
@@ -94,6 +94,48 @@ def repack_expert_requires_grad_flags(
         raise ValueError(f"Unknown expert_storage type: {spec.expert_storage}")
 
 
+def repack_expert_source_params(
+    experts_source: nn.Module,
+    spec: MoELayerSpec,
+    ep_rank: int,
+    ep_size: int,
+) -> tuple[list[nn.Parameter], list[nn.Parameter], list[nn.Parameter]]:
+    """Return the source parameters that feed each repacked (w1, w2, w3) tensor.
+
+    A caller-supplied optimizer has already sorted the source parameters into param groups, so
+    the replacements have to be placed in the group their sources came from. Each entry is a
+    list because the mapping is not one-to-one: the fused gate/up layout feeds both w1 and w3
+    from a single source parameter, and module_list storage feeds one grouped tensor from one
+    parameter per local expert.
+    """
+    num_local_experts = spec.num_experts // ep_size
+    expert_start = ep_rank * num_local_experts
+    expert_end = expert_start + num_local_experts
+
+    if spec.expert_storage == "fused_3d":
+        w1_source = getattr(experts_source, spec.expert_w1_name)
+        w2_source = getattr(experts_source, spec.expert_w2_name)
+        if spec.expert_w3_name is None:
+            # gate and up are packed into one source tensor, so it feeds both w1 and w3
+            return [w1_source], [w2_source], [w1_source]
+        return [w1_source], [w2_source], [getattr(experts_source, spec.expert_w3_name)]
+    elif spec.expert_storage == "module_list":
+        w1_sources = []
+        w2_sources = []
+        w3_sources = []
+        for expert_idx in range(expert_start, expert_end):
+            expert = experts_source[expert_idx]
+            w1_sources.append(_get_expert_weight(expert, spec.expert_w1_name))
+            w2_sources.append(_get_expert_weight(expert, spec.expert_w2_name))
+            if spec.expert_w3_name is not None:
+                w3_sources.append(_get_expert_weight(expert, spec.expert_w3_name))
+        if spec.expert_w3_name is None:
+            w3_sources = list(w1_sources)
+        return w1_sources, w2_sources, w3_sources
+    else:
+        raise ValueError(f"Unknown expert_storage type: {spec.expert_storage}")
+
+
 def _repack_fused_3d(
     experts_source: nn.Module,
     spec: MoELayerSpec,

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -238,6 +238,48 @@ def _eigenvalue_summary_events(block_eigenvalue, global_samples):
             for i, ev_value in enumerate(block_eigenvalue.values())]
 
 
+def _resolve_replacement_param_groups(missing, replacement_sources, param_groups, stale_groups):
+    """Pick the param group each replacement parameter belongs to.
+
+    A replacement inherits the group its source parameters were in. Replacements the module
+    replacement could not trace back to a source fall back to the single group that lost
+    parameters, which is the only choice that cannot mis-assign hyper-parameters.
+    """
+    group_of_source = {}
+    for group_index, group in enumerate(param_groups):
+        for param in group["params"]:
+            group_of_source[id(param)] = group_index
+
+    placement = {}
+    untraced = []
+    for param in missing:
+        sources = replacement_sources.get(id(param), [])
+        source_groups = sorted({group_of_source[id(s)] for s in sources if id(s) in group_of_source})
+        if len(source_groups) > 1:
+            raise RuntimeError("Module replacement (AutoEP) built a single parameter from sources that the client "
+                               f"optimizer had split across param groups {source_groups}, so it cannot be assigned "
+                               "unambiguously. Put those source parameters in one param group, declare the optimizer "
+                               'in the DeepSpeed config ("optimizer": {...}) so it is built after replacement, or '
+                               "construct it after deepspeed.initialize().")
+        if source_groups:
+            placement[id(param)] = source_groups[0]
+        else:
+            untraced.append(param)
+
+    if untraced:
+        candidates = sorted(set(placement.values())) or stale_groups
+        if len(candidates) != 1:
+            raise RuntimeError(f"Module replacement (AutoEP) invalidated optimizer parameters in param groups "
+                               f"{stale_groups} and {len(untraced)} replacement parameter(s) could not be traced back "
+                               "to a source, so they cannot be assigned unambiguously. Declare the optimizer in the "
+                               'DeepSpeed config ("optimizer": {...}) so it is built after replacement, or construct '
+                               "it after deepspeed.initialize().")
+        for param in untraced:
+            placement[id(param)] = candidates[0]
+
+    return placement
+
+
 def _checkpoint_parallel_metadata(mpu):
     from deepspeed.utils.bwc import bwc_pipeline_parallel_world_size, bwc_tensor_model_parallel_world_size
 
@@ -328,8 +370,8 @@ class DeepSpeedEngine(Module):
         self._do_sanity_check()
         if self.log_level() is not None:
             set_log_level_from_string(self.log_level())
-        self._configure_expert_parallel(model)
-        self._remap_client_optimizer_after_module_replacement(model)
+        autoep_replacement_sources = self._configure_expert_parallel(model)
+        self._remap_client_optimizer_after_module_replacement(model, autoep_replacement_sources)
         if self.autotp_size() > 1:
             self._configure_tensor_parallel(model, self.tensor_parallel_config())
         see_memory_usage("DeepSpeed Engine: After args sanity test", force=self.memory_breakdown())
@@ -568,7 +610,7 @@ class DeepSpeedEngine(Module):
                 else:
                     p.ds_offload = False
 
-    def _remap_client_optimizer_after_module_replacement(self, model):
+    def _remap_client_optimizer_after_module_replacement(self, model, replacement_sources=None):
         """Re-point a caller-supplied optimizer at the post-replacement parameters.
 
         AutoEP swaps every MoE block for an ``AutoEPMoELayer`` in
@@ -586,40 +628,42 @@ class DeepSpeedEngine(Module):
             'partition_numel'`` from ``_create_fp16_sub_groups``, because the stale params
             were never converted.
 
-        Rebuilding the groups here keeps caller-supplied optimizers working and preserves
-        each group's hyper-parameters. When the mapping is ambiguous we raise rather than
-        guess, since guessing wrong silently mis-assigns weight decay.
+        A parameter counts as stale only when the replacement detached it from the module
+        tree. Frozen parameters are still part of the model, so they keep their place and are
+        left for the ZeRO optimizers to filter out; counting them as stale would make an
+        otherwise unambiguous remap look like it spanned several param groups.
+
+        ``replacement_sources`` maps each replacement parameter to the source parameters it was
+        built from, so a replacement rejoins the group its sources were already in. That keeps
+        per-layer groupings such as layer-wise learning-rate decay working, where every MoE layer
+        sits in a param group of its own. When a replacement's own sources were split across
+        groups we raise rather than guess, since guessing wrong silently mis-assigns weight decay.
         """
         optimizer = self.client_optimizer
         if optimizer is None or not hasattr(optimizer, "param_groups"):
-            return  # DummyOptim / config-built optimizer: DeepSpeed builds it post-replacement
+            return  # config-built or callable optimizer: DeepSpeed builds it post-replacement
 
-        live = {id(p): p for p in model.parameters() if p.requires_grad}
-        groups = optimizer.param_groups
+        live = {id(p): p for p in model.parameters()}
+        param_groups = optimizer.param_groups
 
         stale_by_group = {}
-        for gi, group in enumerate(groups):
+        for gi, group in enumerate(param_groups):
             stale = [p for p in group["params"] if id(p) not in live]
             if stale:
                 stale_by_group[gi] = len(stale)
         if not stale_by_group:
             return  # nothing was replaced under this optimizer
 
-        owned = {id(p) for group in groups for p in group["params"]}
-        missing = [p for p in live.values() if id(p) not in owned]
+        owned = {id(p) for group in param_groups for p in group["params"]}
+        missing = [p for p in live.values() if p.requires_grad and id(p) not in owned]
 
-        if len(stale_by_group) > 1 and missing:
-            raise RuntimeError(
-                "Module replacement (AutoEP) invalidated optimizer parameters in more than one "
-                f"param group ({sorted(stale_by_group)}), so the replacement parameters cannot be "
-                "assigned unambiguously. Declare the optimizer in the DeepSpeed config "
-                '("optimizer": {...}) so it is built after replacement, or construct it after '
-                "deepspeed.initialize().")
+        placement = _resolve_replacement_param_groups(missing, replacement_sources or {}, param_groups,
+                                                      sorted(stale_by_group))
 
-        target = next(iter(stale_by_group)) if stale_by_group else 0
-        for group in groups:
+        for group in param_groups:
             group["params"] = [p for p in group["params"] if id(p) in live]
-        groups[target]["params"].extend(missing)
+        for param in missing:
+            param_groups[placement[id(param)]]["params"].append(param)
 
         # Adam/AdamW key their state dict on the parameter object; stale entries would leak.
         state = getattr(optimizer, "state", None)
@@ -627,16 +671,19 @@ class DeepSpeedEngine(Module):
             for p in [p for p in list(state.keys()) if id(p) not in live]:
                 del state[p]
 
-        n_stale = sum(stale_by_group.values())
+        added_per_group = {}
+        for group_index in placement.values():
+            added_per_group[group_index] = added_per_group.get(group_index, 0) + 1
+        added_summary = ", ".join(f"{count} to group {gi}" for gi, count in sorted(added_per_group.items()))
         logger.info(
             "Remapped client optimizer after module replacement: dropped %d stale parameter(s), "
-            "added %d replacement parameter(s) to param group %d.", n_stale, len(missing), target)
+            "added %d replacement parameter(s) (%s).", sum(stale_by_group.values()), len(missing), added_summary)
 
     def _configure_expert_parallel(self, model):
         """Initialize AutoEP: detect MoE layers, create EP groups, replace with EP-enabled layers."""
         autoep_config = self._config.expert_parallel_config
         if autoep_config is None or not autoep_config.enabled:
-            return
+            return {}
 
         from deepspeed.module_inject.auto_ep import AutoEP
         from deepspeed.module_inject.auto_ep_config import validate_autoep_config, validate_autoep_post_detection
@@ -702,14 +749,16 @@ class DeepSpeedEngine(Module):
         auto_ep = AutoEP(model, autoep_config)
         specs = auto_ep.ep_parser()
 
+        replacement_sources = {}
         if specs:
             validate_autoep_post_detection(autoep_config, specs)
-            auto_ep.replace_moe_layers(specs, ep_size=ep_size, ep_rank=ep_rank)
+            replacement_sources = auto_ep.replace_moe_layers(specs, ep_size=ep_size, ep_rank=ep_rank)
             logger.info(f"AutoEP: replaced {len(specs)} MoE layer(s) with ep_size={ep_size}")
 
             # Re-tag optimizer flags for newly created AutoEP parameters
             from deepspeed import set_optimizer_flags
             set_optimizer_flags(self._config, model)
+        return replacement_sources
 
     def _autoep_sequence_parallel_world_size(self):
         if self.mpu is not None and hasattr(self.mpu, 'get_sequence_parallel_world_size'):

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -329,6 +329,7 @@ class DeepSpeedEngine(Module):
         if self.log_level() is not None:
             set_log_level_from_string(self.log_level())
         self._configure_expert_parallel(model)
+        self._remap_client_optimizer_after_module_replacement(model)
         if self.autotp_size() > 1:
             self._configure_tensor_parallel(model, self.tensor_parallel_config())
         see_memory_usage("DeepSpeed Engine: After args sanity test", force=self.memory_breakdown())
@@ -566,6 +567,70 @@ class DeepSpeedEngine(Module):
                     p.offload()
                 else:
                     p.ds_offload = False
+
+    def _remap_client_optimizer_after_module_replacement(self, model):
+        """Re-point a caller-supplied optimizer at the post-replacement parameters.
+
+        AutoEP swaps every MoE block for an ``AutoEPMoELayer`` in
+        ``_configure_expert_parallel`` (above), which runs long before
+        ``_configure_optimizer``. ``torch.optim.Optimizer.__init__`` materialises its
+        argument eagerly (``param_groups = list(params)``), so an optimizer the caller
+        built from ``model.parameters()`` still holds the discarded expert tensors while
+        the live ``GroupedExperts`` weights belong to no param group at all.
+
+        Symptoms without this remap:
+          * with ``zero.Init`` -- silent. The stale params are still valid ZeRO params, so
+            ZeRO-3 accepts them and every expert and router simply never updates. Loss
+            still falls because attention, shared experts and norms train normally.
+          * without ``zero.Init`` -- ``AttributeError: 'Parameter' object has no attribute
+            'partition_numel'`` from ``_create_fp16_sub_groups``, because the stale params
+            were never converted.
+
+        Rebuilding the groups here keeps caller-supplied optimizers working and preserves
+        each group's hyper-parameters. When the mapping is ambiguous we raise rather than
+        guess, since guessing wrong silently mis-assigns weight decay.
+        """
+        optimizer = self.client_optimizer
+        if optimizer is None or not hasattr(optimizer, "param_groups"):
+            return  # DummyOptim / config-built optimizer: DeepSpeed builds it post-replacement
+
+        live = {id(p): p for p in model.parameters() if p.requires_grad}
+        groups = optimizer.param_groups
+
+        stale_by_group = {}
+        for gi, group in enumerate(groups):
+            stale = [p for p in group["params"] if id(p) not in live]
+            if stale:
+                stale_by_group[gi] = len(stale)
+        if not stale_by_group:
+            return  # nothing was replaced under this optimizer
+
+        owned = {id(p) for group in groups for p in group["params"]}
+        missing = [p for p in live.values() if id(p) not in owned]
+
+        if len(stale_by_group) > 1 and missing:
+            raise RuntimeError(
+                "Module replacement (AutoEP) invalidated optimizer parameters in more than one "
+                f"param group ({sorted(stale_by_group)}), so the replacement parameters cannot be "
+                "assigned unambiguously. Declare the optimizer in the DeepSpeed config "
+                '("optimizer": {...}) so it is built after replacement, or construct it after '
+                "deepspeed.initialize().")
+
+        target = next(iter(stale_by_group)) if stale_by_group else 0
+        for group in groups:
+            group["params"] = [p for p in group["params"] if id(p) in live]
+        groups[target]["params"].extend(missing)
+
+        # Adam/AdamW key their state dict on the parameter object; stale entries would leak.
+        state = getattr(optimizer, "state", None)
+        if state is not None:
+            for p in [p for p in list(state.keys()) if id(p) not in live]:
+                del state[p]
+
+        n_stale = sum(stale_by_group.values())
+        logger.info(
+            "Remapped client optimizer after module replacement: dropped %d stale parameter(s), "
+            "added %d replacement parameter(s) to param group %d.", n_stale, len(missing), target)
 
     def _configure_expert_parallel(self, model):
         """Initialize AutoEP: detect MoE layers, create EP groups, replace with EP-enabled layers."""

--- a/tests/unit/v1/moe/test_autoep_client_optimizer.py
+++ b/tests/unit/v1/moe/test_autoep_client_optimizer.py
@@ -25,8 +25,10 @@ a separate pre-existing requirement and is not addressed here.
 """
 
 import deepspeed
+import pytest
 import torch
 
+from deepspeed.runtime.engine import DeepSpeedEngine
 from unit.common import DistributedTest
 from unit.v1.moe.autoep_test_utils import (
     MockMoETransformer,
@@ -89,9 +91,7 @@ class TestAutoEPClientOptimizer(DistributedTest):
         model = _make_model()
         client_optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
 
-        engine, _, _, _ = deepspeed.initialize(model=model,
-                                               optimizer=client_optimizer,
-                                               config=_config(zero_stage=3))
+        engine, _, _, _ = deepspeed.initialize(model=model, optimizer=client_optimizer, config=_config(zero_stage=3))
 
         owned = {id(p) for group in engine.optimizer.fp16_groups for p in group}
         trainable = [(name, param) for name, param in engine.module.named_parameters() if param.requires_grad]
@@ -115,9 +115,7 @@ class TestAutoEPClientOptimizer(DistributedTest):
         model = _make_model()
         client_optimizer = torch.optim.AdamW(model.parameters(), lr=0.1)
 
-        engine, _, _, _ = deepspeed.initialize(model=model,
-                                               optimizer=client_optimizer,
-                                               config=_config(zero_stage=3))
+        engine, _, _, _ = deepspeed.initialize(model=model, optimizer=client_optimizer, config=_config(zero_stage=3))
 
         before = {name: _local_shard(param) for name, param in engine.module.named_parameters()}
 
@@ -133,7 +131,13 @@ class TestAutoEPClientOptimizer(DistributedTest):
         assert not frozen, f"parameters unchanged after an optimizer step: {frozen}"
 
     def test_client_optimizer_preserves_param_group_hyperparameters(self):
-        """Replacement parameters must inherit the group they came from, not group 0 by default."""
+        """Both param groups must survive initialize with their hyper-parameters intact.
+
+        The expert weights live in the decayed group, which is listed second here so the remap
+        has to target a group other than 0. Which group they actually land in is asserted by
+        ``test_replacement_params_join_the_group_their_source_was_in`` below -- ZeRO-3 empties
+        the client optimizer's param groups during init, so it cannot be checked from here.
+        """
         _seed_everything(1234)
         model = _make_model()
         decayed = [p for n, p in model.named_parameters() if not n.endswith("bias")]
@@ -141,20 +145,18 @@ class TestAutoEPClientOptimizer(DistributedTest):
         client_optimizer = torch.optim.AdamW(
             [
                 {
-                    "params": decayed,
-                    "weight_decay": 0.1
-                },
-                {
                     "params": no_decay,
                     "weight_decay": 0.0
+                },
+                {
+                    "params": decayed,
+                    "weight_decay": 0.1
                 },
             ],
             lr=1e-3,
         )
 
-        engine, _, _, _ = deepspeed.initialize(model=model,
-                                               optimizer=client_optimizer,
-                                               config=_config(zero_stage=3))
+        engine, _, _, _ = deepspeed.initialize(model=model, optimizer=client_optimizer, config=_config(zero_stage=3))
 
         owned = {id(p) for group in engine.optimizer.fp16_groups for p in group}
         orphans = [n for n, p in engine.module.named_parameters() if p.requires_grad and id(p) not in owned]
@@ -162,3 +164,175 @@ class TestAutoEPClientOptimizer(DistributedTest):
 
         weight_decays = {group.get("weight_decay") for group in engine.optimizer.param_groups}
         assert weight_decays == {0.1, 0.0}, f"param-group hyper-parameters were not preserved: {weight_decays}"
+
+
+class _StubEngine:
+    """The remap only reads ``self.client_optimizer``, so the logic can be exercised without
+    paying for a distributed AutoEP run."""
+
+    def __init__(self, optimizer):
+        self.client_optimizer = optimizer
+
+
+def _detach_moe_blocks(model):
+    """Do to the module tree what AutoEP does: every MoE block's parameters become new objects
+    (a fresh router gate plus ``GroupedExperts`` w1/w2/w3), so the originals leave the model.
+
+    Returns the same source mapping AutoEP hands the engine. The fused ``gate_up_proj`` feeds
+    both w1 and w3, matching ``repack_expert_source_params``.
+    """
+    replacement_sources = {}
+    for layer in model.model.layers:
+        source_gate = layer.mlp.gate
+        source_experts = layer.mlp.experts
+        replacement = torch.nn.Module()
+        replacement.router = torch.nn.Module()
+        replacement.router.gate = torch.nn.Linear(HIDDEN, NUM_EXPERTS, bias=False)
+        replacement.experts = torch.nn.Module()
+        for name in ("w1", "w2", "w3"):
+            shard = torch.nn.Parameter(torch.empty(NUM_EXPERTS // EP_SIZE, INTERMEDIATE, HIDDEN))
+            setattr(replacement.experts, name, shard)
+        replacement_sources[id(replacement.router.gate.weight)] = [source_gate.weight]
+        replacement_sources[id(replacement.experts.w1)] = [source_experts.gate_up_proj]
+        replacement_sources[id(replacement.experts.w3)] = [source_experts.gate_up_proj]
+        replacement_sources[id(replacement.experts.w2)] = [source_experts.down_proj]
+        layer.mlp = replacement
+    return replacement_sources
+
+
+def _remap(optimizer, model, replacement_sources=None):
+    DeepSpeedEngine._remap_client_optimizer_after_module_replacement(_StubEngine(optimizer), model,
+                                                                     replacement_sources)
+
+
+def _owned_ids(optimizer):
+    return {id(p) for group in optimizer.param_groups for p in group["params"]}
+
+
+def test_replacement_params_join_the_group_their_source_was_in():
+    """The replacements must follow their source group, not fall back to group 0."""
+    model = _make_model()
+    named = list(model.named_parameters())
+    no_decay = [p for n, p in named if n.endswith("bias")]
+    decayed = [p for n, p in named if not n.endswith("bias")]
+    # no_decay first: the expert weights belong to group 1, so a fallback to group 0 would fail
+    optimizer = torch.optim.AdamW([{
+        "params": no_decay,
+        "weight_decay": 0.0
+    }, {
+        "params": decayed,
+        "weight_decay": 0.1
+    }],
+                                  lr=1e-3)
+
+    replacement_sources = _detach_moe_blocks(model)
+    _remap(optimizer, model, replacement_sources)
+
+    replaced = {id(p) for name, p in model.named_parameters() if ".experts." in name or ".router." in name}
+    holders = [gi for gi, group in enumerate(optimizer.param_groups) if replaced & {id(p) for p in group["params"]}]
+    assert holders == [1], f"replacement parameters landed in group(s) {holders}, expected [1]"
+    assert optimizer.param_groups[1]["weight_decay"] == 0.1
+
+
+def test_frozen_params_are_not_mistaken_for_replaced_ones():
+    """A frozen parameter is still in the model, so it must not look like a replaced one.
+
+    Counting frozen parameters as stale puts every group that holds one into ``stale_by_group``,
+    which makes an unambiguous remap raise "invalidated optimizer parameters in more than one
+    param group" even though only the MoE block was replaced.
+    """
+    model = _make_model()
+    for name, param in model.named_parameters():
+        if ".mlp." not in name:
+            param.requires_grad_(False)
+    named = list(model.named_parameters())
+    decayed = [p for n, p in named if not n.endswith("bias")]
+    no_decay = [p for n, p in named if n.endswith("bias")]
+    optimizer = torch.optim.AdamW([{
+        "params": decayed,
+        "weight_decay": 0.1
+    }, {
+        "params": no_decay,
+        "weight_decay": 0.0
+    }],
+                                  lr=1e-3)
+
+    replacement_sources = _detach_moe_blocks(model)
+    _remap(optimizer, model, replacement_sources)
+
+    owned = _owned_ids(optimizer)
+    orphans = [name for name, p in model.named_parameters() if p.requires_grad and id(p) not in owned]
+    assert not orphans, f"trainable parameters left out of the optimizer: {orphans}"
+
+    dropped = [name for name, p in model.named_parameters() if not p.requires_grad and id(p) not in owned]
+    assert not dropped, f"frozen parameters were removed from the client optimizer: {dropped}"
+
+
+def test_remap_is_a_noop_when_nothing_was_replaced():
+    """Without a module replacement the caller's optimizer must be left exactly as it was."""
+    model = _make_model()
+    for name, param in model.named_parameters():
+        if ".mlp." not in name:
+            param.requires_grad_(False)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    before = [list(group["params"]) for group in optimizer.param_groups]
+
+    _remap(optimizer, model)
+
+    after = [list(group["params"]) for group in optimizer.param_groups]
+    assert after == before, "the optimizer was modified even though no module was replaced"
+
+
+def test_per_layer_param_groups_survive_replacement():
+    """Layer-wise learning-rate decay gives each layer its own group, so the replacement spans
+    several groups at once. Each layer's replacements must rejoin that layer's group."""
+    model = _make_model()
+    groups = []
+    for layer_index in range(len(model.model.layers)):
+        prefix = f"model.layers.{layer_index}."
+        groups.append({
+            "params": [p for name, p in model.named_parameters() if name.startswith(prefix)],
+            "lr": 1e-4 * (0.9**layer_index)
+        })
+    groups.append({
+        "params": [p for name, p in model.named_parameters() if not name.startswith("model.layers.")],
+        "lr": 1e-4
+    })
+    optimizer = torch.optim.AdamW(groups)
+
+    replacement_sources = _detach_moe_blocks(model)
+    _remap(optimizer, model, replacement_sources)
+
+    owned = _owned_ids(optimizer)
+    orphans = [name for name, p in model.named_parameters() if p.requires_grad and id(p) not in owned]
+    assert not orphans, f"trainable parameters left out of the optimizer: {orphans}"
+
+    for layer_index, layer in enumerate(model.model.layers):
+        in_group = {id(p) for p in optimizer.param_groups[layer_index]["params"]}
+        stranded = [name for name, p in layer.mlp.named_parameters() if id(p) not in in_group]
+        assert not stranded, f"layer {layer_index} replacements missed its own param group: {stranded}"
+
+
+def test_sources_split_across_groups_raise():
+    """``module_list`` storage packs one grouped tensor from one weight per expert. If the caller
+    put those weights in different param groups the replacement has no unambiguous home."""
+    model = _make_model()
+    first_layer = model.model.layers[0].mlp
+    source_gate_up = first_layer.experts.gate_up_proj
+    source_down = first_layer.experts.down_proj
+    others = [p for _, p in model.named_parameters() if p is not source_down]
+    optimizer = torch.optim.AdamW([{
+        "params": others,
+        "weight_decay": 0.1
+    }, {
+        "params": [source_down],
+        "weight_decay": 0.0
+    }],
+                                  lr=1e-3)
+
+    replacement_sources = _detach_moe_blocks(model)
+    w1 = model.model.layers[0].mlp.experts.w1
+    replacement_sources[id(w1)] = [source_gate_up, source_down]
+
+    with pytest.raises(RuntimeError, match="split across param groups"):
+        _remap(optimizer, model, replacement_sources)

--- a/tests/unit/v1/moe/test_autoep_client_optimizer.py
+++ b/tests/unit/v1/moe/test_autoep_client_optimizer.py
@@ -1,0 +1,164 @@
+# Copyright (c) DeepSpeed Team.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""AutoEP with a caller-supplied optimizer.
+
+AutoEP replaces every MoE module in ``_configure_expert_parallel`` (engine.py), which runs before
+``_configure_optimizer``. ``torch.optim.Optimizer.__init__`` materialises its argument eagerly
+(``param_groups = list(params)``), so an optimizer the caller built from ``model.parameters()`` --
+what HF Trainer and Accelerate do when the DeepSpeed config declares no ``optimizer`` block -- holds
+the discarded expert tensors while the live ``GroupedExperts`` weights belong to no param group.
+
+Without the remap in ``_remap_client_optimizer_after_module_replacement`` the symptoms are:
+  * with ``zero.Init``: silent -- every expert and router is frozen, loss still falls because
+    attention, shared experts and norms train normally;
+  * without ``zero.Init``: ``AttributeError: 'Parameter' object has no attribute 'partition_numel'``
+    from ``_create_fp16_sub_groups``, because the stale params were never ZeRO-converted.
+
+Every other AutoEP test supplies the optimizer through ``ds_config``, so this path is otherwise
+uncovered.
+
+Scope: ZeRO-3 only. A caller-supplied optimizer on ZeRO-1/2 with MoE layers additionally requires
+param groups marked ``{"moe": True}`` (``stage_1_and_2.py:780``, ``bf16_optimizer.py:128``); that is
+a separate pre-existing requirement and is not addressed here.
+"""
+
+import deepspeed
+import torch
+
+from unit.common import DistributedTest
+from unit.v1.moe.autoep_test_utils import (
+    MockMoETransformer,
+    engine_input_dtype as _engine_input_dtype,
+    seed_everything as _seed_everything,
+)
+
+HIDDEN = 128
+INTERMEDIATE = 256
+NUM_EXPERTS = 4
+EP_SIZE = 2
+
+
+def _make_model():
+    # num_experts * hidden = 512, far below stage3_param_persistence_threshold (100_000), so the
+    # separate router-release bug cannot confound this test.
+    return MockMoETransformer(num_layers=2,
+                              num_experts=NUM_EXPERTS,
+                              hidden_size=HIDDEN,
+                              intermediate_size=INTERMEDIATE)
+
+
+def _config(zero_stage):
+    # bf16 deliberately, not the shared fp16 helper: fp16 carries a loss scaler that skips the first
+    # optimizer step(s) on overflow, so no parameter would move and the update test below could not
+    # distinguish "frozen because of the bug" from "frozen because the step was skipped".
+    return {
+        "bf16": {
+            "enabled": True
+        },
+        "train_micro_batch_size_per_gpu": 1,
+        "zero_optimization": {
+            "stage": zero_stage
+        },
+        "expert_parallel": {
+            "enabled": True,
+            "autoep_size": EP_SIZE,
+            "preset_model": "mixtral",
+            "use_grouped_mm": False,
+        },
+    }
+
+
+def _local_shard(param):
+    """Local ZeRO-3 shard when partitioned, else the tensor itself."""
+    tensor = getattr(param, "ds_tensor", None)
+    return (tensor if tensor is not None else param.data).detach().float().clone()
+
+
+def _expert_param_names(module):
+    return [name for name, _ in module.named_parameters() if ".experts." in name]
+
+
+class TestAutoEPClientOptimizer(DistributedTest):
+    world_size = 2
+
+    def test_client_optimizer_covers_replacement_parameters(self):
+        """Every trainable parameter of the replaced module must be optimized."""
+        _seed_everything(1234)
+        model = _make_model()
+        client_optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+        engine, _, _, _ = deepspeed.initialize(model=model,
+                                               optimizer=client_optimizer,
+                                               config=_config(zero_stage=3))
+
+        owned = {id(p) for group in engine.optimizer.fp16_groups for p in group}
+        trainable = [(name, param) for name, param in engine.module.named_parameters() if param.requires_grad]
+
+        orphans = [name for name, param in trainable if id(param) not in owned]
+        assert not orphans, f"parameters in the model but in no optimizer param group: {orphans}"
+
+        # The replacement really did happen, so the assertion above is meaningful.
+        expert_names = _expert_param_names(engine.module)
+        assert expert_names, "AutoEP did not replace any MoE layer"
+        assert all(name.endswith((".w1", ".w2", ".w3")) for name in expert_names), expert_names
+
+        # And nothing detached from the module is being optimized in their place.
+        live = {id(p) for _, p in engine.module.named_parameters()}
+        ghosts = [p for group in engine.optimizer.fp16_groups for p in group if id(p) not in live]
+        assert not ghosts, f"{len(ghosts)} optimized parameters are not part of the model"
+
+    def test_client_optimizer_updates_expert_weights(self):
+        """A step must move the expert weights, not leave them frozen."""
+        _seed_everything(1234)
+        model = _make_model()
+        client_optimizer = torch.optim.AdamW(model.parameters(), lr=0.1)
+
+        engine, _, _, _ = deepspeed.initialize(model=model,
+                                               optimizer=client_optimizer,
+                                               config=_config(zero_stage=3))
+
+        before = {name: _local_shard(param) for name, param in engine.module.named_parameters()}
+
+        inputs = torch.randn(1, 8, HIDDEN, device=engine.device, dtype=_engine_input_dtype(engine))
+        loss = engine(inputs).float().pow(2).mean()
+        engine.backward(loss)
+        engine.step()
+
+        frozen = [
+            name for name, param in engine.module.named_parameters()
+            if param.requires_grad and torch.equal(_local_shard(param), before[name])
+        ]
+        assert not frozen, f"parameters unchanged after an optimizer step: {frozen}"
+
+    def test_client_optimizer_preserves_param_group_hyperparameters(self):
+        """Replacement parameters must inherit the group they came from, not group 0 by default."""
+        _seed_everything(1234)
+        model = _make_model()
+        decayed = [p for n, p in model.named_parameters() if not n.endswith("bias")]
+        no_decay = [p for n, p in model.named_parameters() if n.endswith("bias")]
+        client_optimizer = torch.optim.AdamW(
+            [
+                {
+                    "params": decayed,
+                    "weight_decay": 0.1
+                },
+                {
+                    "params": no_decay,
+                    "weight_decay": 0.0
+                },
+            ],
+            lr=1e-3,
+        )
+
+        engine, _, _, _ = deepspeed.initialize(model=model,
+                                               optimizer=client_optimizer,
+                                               config=_config(zero_stage=3))
+
+        owned = {id(p) for group in engine.optimizer.fp16_groups for p in group}
+        orphans = [n for n, p in engine.module.named_parameters() if p.requires_grad and id(p) not in owned]
+        assert not orphans, f"parameters in the model but in no optimizer param group: {orphans}"
+
+        weight_decays = {group.get("weight_decay") for group in engine.optimizer.param_groups}
+        assert weight_decays == {0.1, 0.0}, f"param-group hyper-parameters were not preserved: {weight_decays}"


### PR DESCRIPTION
# Fix: AutoEP silently drops expert parameters from a caller-supplied optimizer

## Problem

`_configure_expert_parallel` (engine.py) replaces every MoE module, and it runs *before*
`_configure_optimizer`. Nothing remaps optimizer param groups in between —
`set_optimizer_flags` only sets Muon flags.

`torch.optim.Optimizer.__init__` materialises its argument eagerly (`param_groups = list(params)`),
so an optimizer the caller built from `model.parameters()` keeps hard references to the discarded
expert tensors, while the live `GroupedExperts` weights belong to no param group.

This is the path HF Trainer and Accelerate take whenever the DeepSpeed config declares no
`optimizer` block (`transformers/integrations/deepspeed.py`: `optimizer = trainer.create_optimizer()`
in the `else` branch).

Two symptoms, same cause:

| setup | result |
|---|---|
| with `zero.Init` (`zero3_init_flag: true`) | **silent** — every expert and router is frozen. Loss still falls because attention, shared experts and norms train normally. |
| without `zero.Init` | `AttributeError: 'Parameter' object has no attribute 'partition_numel'` from `_create_fp16_sub_groups` (stage3.py), because the stale params were never ZeRO-converted. |

Measured on a 2-layer / 4-expert model, ZeRO-3, `autoep_size=2`, one step at lr=0.1:

```
parameter                                kind   max |delta|  verdict
model.layers.0.self_attn.*               LIVE   1.003e-01    moved
model.layers.0.mlp.router.gate.weight    LIVE   0.000e+00    *** FROZEN ***
model.layers.0.mlp.experts.w1/w2/w3      LIVE   0.000e+00    *** FROZEN ***
model.layers.0.mlp.experts.gate_up_proj  GHOST  0.000e+00    frozen   (detached from the model)
```

The same run with the optimizer declared in `ds_config` moves every tensor by `1.005e-01`.

## Fix

`_remap_client_optimizer_after_module_replacement`, called immediately after
`_configure_expert_parallel`:

* no-op unless a caller supplied a real optimizer (`DummyOptim` / config-built paths return early);
* no-op unless something was actually replaced;
* drops params no longer in the module, adds the new ones **to the group the stale ones came from**,
  so per-group hyper-parameters (e.g. a weight-decay split) survive;
* purges stale `optimizer.state` entries, which Adam keys on the parameter object;
* raises rather than guesses if replacement invalidated params across more than one group — a wrong
  assignment would silently mis-apply weight decay.

## Tests

New `tests/unit/v1/moe/test_autoep_client_optimizer.py`, `world_size = 2`:

* `test_client_optimizer_covers_replacement_parameters` — every trainable param is in a param group;
  replacement actually happened; no optimized param is detached from the module.
* `test_client_optimizer_updates_expert_weights` — after one real step, no parameter is
  bit-identical. This is the test that catches the silent freeze.
* `test_client_optimizer_preserves_param_group_hyperparameters` — with decay / no-decay groups,
  replacement params land in the right group and both `weight_decay` values survive.

3 passed with the fix; 3 failed with `engine.py` reverted and everything else identical.

The tests use bf16 rather than the shared `mixed_precision_config()` helper: fp16 carries a loss
scaler that skips the first optimizer step on overflow, which would leave *every* parameter
unchanged and make the update test vacuous.

## Scope

ZeRO-3 only. A caller-supplied optimizer with MoE on ZeRO-1/2 additionally requires param groups
marked `{"moe": True}` (`stage_1_and_2.py:780`, `bf16_optimizer.py:128`) — a separate pre-existing
requirement, not addressed here.

## Why this was not caught

Every existing AutoEP test supplies the optimizer through `ds_config`
(`"optimizer": {"type": "Adam"}` in `make_autoep_config`), so DeepSpeed builds it *after*
replacement and the client-optimizer path is never exercised.
