### PR TITLE
Fix the dead grad_accum branch in the ZenFlow gradient copy

### DIFF
--- a/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
+++ b/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
@@ -685,15 +685,14 @@ class ZenFlowZeroOptimizerParallel(ZenFlowZeroOptimizer):
             0, dest_offset, num_elements)
 
         grad_accum = self.get_param_gradient_attribute(param)
-        if grad_accum is None:
-            src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
-        else:
-            src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
+        assert grad_accum is not None
+
+        src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
         if src_tensor.dtype != self.master_weights_and_grads_dtype:
             src_tensor = src_tensor.to(self.master_weights_and_grads_dtype)
 
         dest_tensor.copy_(src_tensor, non_blocking=True)
-        param.grad = None  #offload only
+        self.clear_grad_attribute(param)  #offload only
 
     def _wait_for_optimizer_process(self):
         """Block until the optimizer process signals the submitted step is done.

--- a/tests/unit/runtime/zenflow/test_zf.py
+++ b/tests/unit/runtime/zenflow/test_zf.py
@@ -3,10 +3,14 @@
 
 # DeepSpeed Team
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 import deepspeed.comm as dist
 from deepspeed.accelerator import get_accelerator
-from deepspeed.runtime.zenflow.zenflow_stage_1_and_2 import _num_selected_columns
+from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
+from deepspeed.runtime.zenflow.zenflow_stage_1_and_2 import ZenFlowZeroOptimizerParallel, _num_selected_columns
 
 from unit.common import DistributedTest
 from unit.simple_model import SimpleModel, random_dataloader
@@ -20,6 +24,45 @@ import deepspeed
 ])
 def test_num_selected_columns_has_nonzero_floor(num_columns, topk_ratio, expected):
     assert _num_selected_columns(num_columns, topk_ratio) == expected
+
+
+def _offload_copy_stub(**overrides):
+    # The smallest object `async_inplace_copy_grad_to_fp32_buffer_from_gpu` reads from. The two
+    # gradient accessors are the real ones so the override is exercised against the base contract.
+    stub = SimpleNamespace(
+        grad_position={0: [0, 0, 0, 4]},
+        single_partition_of_fp32_groups=[SimpleNamespace(overlap_grad=[torch.zeros(4)])],
+        master_weights_and_grads_dtype=torch.float32,
+        get_param_id=lambda param: 0,
+        get_overlap_step_state=lambda: 0,
+        use_grad_accum_attribute=True,
+    )
+    stub.get_param_gradient_attribute = DeepSpeedZeroOptimizer.get_param_gradient_attribute.__get__(stub)
+    stub.clear_grad_attribute = DeepSpeedZeroOptimizer.clear_grad_attribute.__get__(stub)
+    for key, value in overrides.items():
+        setattr(stub, key, value)
+    return stub
+
+
+def test_async_inplace_copy_grad_requires_a_gradient():
+    # The base ZeRO-1/2 copy asserts the gradient attribute is set. The override branched on
+    # `grad_accum is None` and then called `.view()` on the None it had just tested for, so a
+    # missing gradient surfaced as an AttributeError from inside the copy.
+    param = SimpleNamespace(grad=None, grad_accum=None)
+
+    with pytest.raises(AssertionError):
+        ZenFlowZeroOptimizerParallel.async_inplace_copy_grad_to_fp32_buffer_from_gpu(_offload_copy_stub(), param)
+
+
+def test_async_inplace_copy_grad_clears_the_attribute_it_consumed():
+    # With use_grad_accum_attribute the copy reads param.grad_accum, so that is what has to be
+    # cleared. Setting param.grad instead leaves the consumed gradient in place, and the next
+    # micro step's _fill_param_grad_accum_attribute adds onto it.
+    param = SimpleNamespace(grad=None, grad_accum=torch.ones(4))
+
+    ZenFlowZeroOptimizerParallel.async_inplace_copy_grad_to_fp32_buffer_from_gpu(_offload_copy_stub(), param)
+
+    assert param.grad_accum is None
 
 
 class BaseZenFlowTest:


### PR DESCRIPTION
`ZenFlowZeroOptimizerParallel.async_inplace_copy_grad_to_fp32_buffer_from_gpu` overrides the ZeRO-1/2 copy and diverges from it in two places.

## 1. The dead `grad_accum is None` branch

```python
grad_accum = self.get_param_gradient_attribute(param)
if grad_accum is None:
    src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
else:
    src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
```

Both arms are the same expression, so the arm meant to handle a missing gradient is the one that cannot run: it raises `AttributeError: 'NoneType' object has no attribute 'view'` from inside the copy instead of the assertion the base declares.

`DeepSpeedZeroOptimizer.async_inplace_copy_grad_to_fp32_buffer_from_gpu` carried the identical four lines until Coverity flagged them, and 1a8ad24f (#7431, 2025-08-02) replaced them with `assert grad_accum is not None`. `zenflow_stage_1_and_2.py` landed thirteen days later in #7391, written against the pre-#7431 base, so it reintroduced the branch.

## 2. Clearing the wrong gradient attribute

The base ends with `self.clear_grad_attribute(param)`; the override ends with `param.grad = None`. Both read through `get_param_gradient_attribute`, so under `use_grad_accum_attribute` (ZeRO-1 with a `grad_accum_dtype` that differs from the parameter dtype) the copy consumes `param.grad_accum` and then clears `param.grad`, which `_fill_param_grad_accum_attribute` has already set to None. The consumed gradient stays live, and the next micro step's `param.grad_accum.add_(...)` accumulates onto it.

## Verification

ZenFlow needs an accelerator, so the two methods were driven out of the source files with a stub:

| | master | this PR |
|---|---|---|
| gradient attribute missing | `AttributeError: 'NoneType' object has no attribute 'view'` | `AssertionError`, as the base declares |
| `param.grad_accum` after the copy | `tensor([1., 1., 1., 1.])` | `None` |

The copied buffer is `[1.0, 1.0, 1.0, 1.0]` either way, so the copy itself is unchanged.

## Test

Two cases in `tests/unit/runtime/zenflow/test_zf.py`, plain functions next to the existing `test_num_selected_columns_has_nonzero_floor`, neither needing an accelerator: one asserts the missing-gradient contract, one asserts the consumed attribute is cleared. Both use the real `get_param_gradient_attribute` and `clear_grad_attribute` off `DeepSpeedZeroOptimizer` so the override is checked against the base behaviour rather than a copy of it.

`yapf --diff` and `flake8` with the repo's own `.style.yapf` and `.flake8` are clean on both files.

Scanning the rest of `deepspeed/runtime/zenflow/` turns up no other branch of either shape.

I have not run a full ZenFlow ZeRO-1 job with a separate `grad_accum_dtype` end to end, so part 2 rests on the base-class contract rather than on a measured loss curve. Happy to split it out if you would rather review the two separately.
