### PR TITLE
Reuse existing hpZeRO group in nested zero.Init contexts

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -1103,8 +1103,16 @@ class Init(InsertPostInitMethodToModuleSubClasses):
 
         self.zero_param_process_group = zero_param_parallel_group
         if _ds_config is not None and _ds_config.zero_config.zero_hpz_partition_size > 1 and self.zero_param_process_group is None:
-            groups._create_zero_param_parallel_group(_ds_config.zero_config.zero_hpz_partition_size)
+            hpz_partition_size = min(_ds_config.zero_config.zero_hpz_partition_size, dist.get_world_size())
             self.zero_param_process_group = groups._get_zero_param_intra_parallel_group()
+            if self.zero_param_process_group is None:
+                groups._create_zero_param_parallel_group(hpz_partition_size)
+                self.zero_param_process_group = groups._get_zero_param_intra_parallel_group()
+            elif dist.get_world_size(group=self.zero_param_process_group) != hpz_partition_size:
+                raise RuntimeError(
+                    "zero.Init cannot reuse an existing ZeRO parameter parallel group with a different size: "
+                    f"existing={dist.get_world_size(group=self.zero_param_process_group)}, requested={hpz_partition_size}"
+                )
 
         self.num_ranks_in_param_group = self.dp_world_size
         self.rank_in_group = self.rank

--- a/tests/unit/runtime/zero/test_zero_context.py
+++ b/tests/unit/runtime/zero/test_zero_context.py
@@ -143,6 +143,27 @@ class TestMiCSGatheredParametersFree(DistributedTest):
         assert model.l1.weight.numel() == 0, "outside of GatheredParameters the param should go back to be 0-sized"
 
 
+class TestNestingInitWithHpZ(DistributedTest):
+    world_size = 2
+
+    def test(self):
+        config_dict = {
+            "train_batch_size": self.world_size,
+            "zero_optimization": {
+                "stage": 3,
+                "zero_hpz_partition_size": self.world_size,
+            },
+        }
+
+        with deepspeed.zero.Init(config_dict_or_path=config_dict):
+            with deepspeed.zero.Init(config_dict_or_path=config_dict):
+                model = torch.nn.Linear(4, 4)
+
+        assert hasattr(model.weight, "ds_id")
+        assert model.weight.ds_zero_param_process_group is not None
+        assert dist.get_world_size(group=model.weight.ds_zero_param_process_group) == self.world_size
+
+
 class TestGatheredParametersAllRanksErrorOnModification(DistributedTest):
     world_size = 2
 


### PR DESCRIPTION
# Reuse existing hpZeRO groups in nested `zero.Init` contexts

## Problem

Nested `deepspeed.zero.Init` contexts fail when `zero_hpz_partition_size > 1` because each context unconditionally calls `_create_zero_param_parallel_group()`. The outer context has already initialized the process-wide HPZ group, so the inner context raises:

```text
AssertionError: ZeRO parameter intra parallel group is already initialized
```

This occurs in real model composition flows where an outer model is constructed under ZeRO-3 and a nested `from_pretrained()` call enters another `zero.Init` context. It is reported in #4901 and reproduced again in #7066.

## Fix

- Reuse the existing ZeRO parameter parallel group when its effective size matches the requested HPZ partition size.
- Create the group only when no group exists yet.
- Fail early with an actionable `RuntimeError` when nested contexts request incompatible HPZ sizes instead of silently attaching the wrong group.

The change is local to `zero.Init`; it does not change public APIs or the non-HPZ path.

## Test

Added a two-rank regression that nests two `zero.Init` contexts with ZeRO-3 + HPZ, constructs a parameterized module, and checks that the parameter is partitioned with the expected HPZ group.

Validation on a single-node RTX 3090 host, based on `87d9ecd8e0a4fd7778a58ac0f69cc85951f78ea0`:

- Baseline 2-GPU reproduction: fails on both ranks with the existing-group assertion.
- Patched focused regression: `1 passed`.
- `tests/unit/runtime/zero/test_zero_context.py`: `12 passed`.
- `pre-commit run --files deepspeed/runtime/zero/partition_parameters.py tests/unit/runtime/zero/test_zero_context.py`: passed all hooks.
- `pip wheel --no-deps --no-build-isolation .`: passed with `DS_BUILD_OPS=0`.
- Fixed-seed ZeRO-3 training controls at world sizes 1, 2, and 4: nested and non-nested initialization produced identical per-step losses and final parameter sums.
- Four-rank incompatible-size check (`outer HPZ=2`, `inner HPZ=4`): all ranks failed with the intended actionable error.

Related: #4901, #7066

