### PR TITLE
Reshape instead of view in TiledFusedLogitsLoss

### DIFF
--- a/deepspeed/runtime/sequence_parallel/ulysses_sp.py
+++ b/deepspeed/runtime/sequence_parallel/ulysses_sp.py
@@ -1145,10 +1145,12 @@ class TiledFusedLogitsLoss(torch.autograd.Function):
         bs, seqlen = x.shape[:2]
 
         # flatten bs+seqlen to avoid having stride issues when narrowing into seqlen w/ bs>1
-        x = x.view(-1, *x.shape[2:])
-        y = y.view(-1, *y.shape[2:])
+        # reshape rather than view: a caller may pass a non-contiguous x, y or mask (a transposed or
+        # channel-sliced activation), for which view cannot produce the flattened shape
+        x = x.reshape(-1, *x.shape[2:])
+        y = y.reshape(-1, *y.shape[2:])
         if mask is not None:
-            mask = mask.view(-1)
+            mask = mask.reshape(-1)
         incoming_grad = torch.tensor(1.0, dtype=x.dtype, device=x.device)
 
         # we are faking the incoming gradient, and since we perform a reduction outside of `autograd.backward` below we need to pre-adjust the incoming gradient. in the case of "sum" the gradient is 1.0, in the case of "mean" it's 1.0/num_elements, which in this case is 1/shards.

--- a/tests/unit/ulysses_alst/test_tiled_compute.py
+++ b/tests/unit/ulysses_alst/test_tiled_compute.py
@@ -401,3 +401,44 @@ class TestTiledFusedLogitsLoss(DistributedTest):
 
         # restore
         MyModel.forward = MyModel.forward_orig
+
+
+@pytest.mark.parametrize("shards", [2, 4])
+class TestTiledFusedLogitsLossInputLayout:
+    """
+    Same caller contract as TestTiledMLPInputLayout, on the loss. TiledFusedLogitsLoss flattens batch and
+    sequence into one axis before sharding, and a transposed activation cannot be flattened by a view.
+    """
+
+    def make_model(self, hidden_dim, vocab_size, dtype):
+        model = Linear(hidden_dim, vocab_size, bias=False, dtype=dtype)
+        torch.nn.init.normal_(model.weight, std=0.02)
+        return model
+
+    @staticmethod
+    def loss_fn(model, x_shard, y_shard):
+        return torch.nn.functional.cross_entropy(model(x_shard), y_shard, reduction="sum")
+
+    def test_transposed_input_matches_a_contiguous_copy(self,
+                                                        shards,
+                                                        batch_size=2,
+                                                        seqlen=12,
+                                                        hidden_dim=16,
+                                                        vocab_size=32):
+        dtype = torch.float32
+        torch.manual_seed(0)
+        # [bs, hidden, seqlen] transposed into [bs, seqlen, hidden] keeps the original strides
+        source = torch.rand((batch_size, hidden_dim, seqlen), dtype=dtype)
+        strided = source.transpose(1, 2).detach().requires_grad_(True)
+        assert not strided.is_contiguous(), "input is contiguous, so it does not exercise the flattening"
+        contiguous = strided.detach().clone().contiguous().requires_grad_(True)
+        y = torch.randint(0, vocab_size, (batch_size, seqlen))
+
+        model = self.make_model(hidden_dim, vocab_size, dtype)
+        losses = []
+        for x in (strided, contiguous):
+            model.zero_grad()
+            loss = TiledFusedLogitsLoss.apply(self.loss_fn, model, x, y, None, shards, list(model.parameters()), "sum")
+            losses.append(loss)
+
+        torch_assert_close(losses[0], losses[1])

--- a/tests/unit/ulysses_alst/test_tiled_compute.py
+++ b/tests/unit/ulysses_alst/test_tiled_compute.py
@@ -435,10 +435,17 @@ class TestTiledFusedLogitsLossInputLayout:
         y = torch.randint(0, vocab_size, (batch_size, seqlen))
 
         model = self.make_model(hidden_dim, vocab_size, dtype)
-        losses = []
+        losses, param_grads = [], []
         for x in (strided, contiguous):
             model.zero_grad()
             loss = TiledFusedLogitsLoss.apply(self.loss_fn, model, x, y, None, shards, list(model.parameters()), "sum")
+            # The backward scatters into a zeros_like of the same flattened activation, so the
+            # gradient path runs through the flatten under test as well as the forward.
+            loss.backward()
             losses.append(loss)
+            param_grads.append([p.grad.detach().clone() for p in model.parameters()])
 
         torch_assert_close(losses[0], losses[1])
+        torch_assert_close(strided.grad, contiguous.grad)
+        for grad_a, grad_b in zip(*param_grads):
+            torch_assert_close(grad_a, grad_b)


### PR DESCRIPTION
Follow-up to #8348, in the same file.

That PR moved `TiledMLP.backward` off `view` because the flatten of batch and sequence into one axis needs a copy when a caller hands in a non-contiguous activation. `TiledFusedLogitsLoss.forward` does the same flatten, under the same comment, and is still on `view`:

```python
# flatten bs+seqlen to avoid having stride issues when narrowing into seqlen w/ bs>1
x = x.view(-1, *x.shape[2:])
y = y.view(-1, *y.shape[2:])
if mask is not None:
    mask = mask.view(-1)
```

A transposed activation — one of the two layouts #8348's test covers — fails there:

```
RuntimeError: view size is not compatible with input tensor's size and stride
(at least one dimension spans across two contiguous subspaces)
```

### What is and is not reachable

I ran the four input shapes through `TiledFusedLogitsLoss.apply` on master:

| input | contiguous | master |
| --- | --- | --- |
| `x` contiguous | yes | ok |
| **`x` transposed** | no | **RuntimeError: view size is not compatible …** |
| `x` channel slice | no | ok |
| `y` / `mask` strided | no | ok |

Only the transposed case is reachable today. A hidden-dimension slice keeps the wider row stride, and that still admits merging batch into sequence, so it survives — same for the strided `y` and `mask` I tried. `y` and `mask` go through the same flatten and are changed with it rather than left on a spelling that happens to hold.

The unflatten at the end of `forward` stays a `view`: `x_grad` comes from `zeros_like()` of the already-flattened `x`, so it is contiguous by construction. Same reasoning for the `x_grad.view(x_shape_orig)` that #8348 left alone in `TiledMLP.backward`.

`TiledLoss` has no such flatten, so nothing to do there.

### Test

`TestTiledFusedLogitsLossInputLayout` mirrors `TestTiledMLPInputLayout` and checks the loss against the same input made contiguous, so it pins the value and not just the absence of a throw.

On master:

```
FAILED tests/unit/ulysses_alst/test_tiled_compute.py::TestTiledFusedLogitsLossInputLayout::test_transposed_input_matches_a_contiguous_copy[2]
FAILED ...[4]
RuntimeError: view size is not compatible with input tensor's size and stride
2 failed
```

With this PR:

```
tests/unit/ulysses_alst/test_tiled_compute.py   14 passed
yapf --diff / flake8                           clean
```
