### PR TITLE
ZeRO-1/2: synchronize IPG buffer reuse per buffer

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1243,7 +1243,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 # keeping the gradients contiguous to prevent memory fragmentation, and avoid flattening
                 if self.overlap_comm and not get_accelerator().resolves_data_dependency():
                     producer_stream = get_accelerator().current_stream()
-                    self._wait_for_ipg_buffer_reuse(bucket, producer_stream)
+                    if producer_stream not in bucket.copy_streams:
+                        self._wait_for_ipg_buffer_reuse(bucket, producer_stream)
                 new_grad_tensor = bucket.buffer[bucket.index].narrow(0, bucket.elements, param.numel())
                 new_grad_tensor.copy_(
                     grad_reduc.view(-1) if not self.zenflow else grad_reduc.permute(

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -127,6 +127,15 @@ class IPGBucket:
     # hooks run on different autograd streams), not just the current one (#8061).
     copy_streams: set = field(default_factory=set)
 
+    def set_buffers(self, buffers):
+        self.buffer = buffers
+        self.reduction_complete_events = [None] * len(buffers)
+        self.index = 0
+
+    def add_buffer(self, buf):
+        self.buffer.append(buf)
+        self.reduction_complete_events.append(None)
+
     def clear(self):
         self.params.clear()
         self.grads.clear()
@@ -840,8 +849,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
     def _release_ipg_buffers(self):
         if self.contiguous_gradients:
             for bucket in self.ipg_buckets.values():
-                bucket.buffer.clear()
-                bucket.reduction_complete_events.clear()
+                bucket.set_buffers([])
 
             self.grads_in_partition = None
             self.grads_in_partition_offset = 0
@@ -878,11 +886,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         # with PP we must create ipg buffer, since backward is handled outside zero
         if pipeline_parallel and self.contiguous_gradients:
             for dtype, bucket in self.ipg_buckets.items():
-                bucket.buffer.append(
+                bucket.add_buffer(
                     torch.empty(int(self.reduce_bucket_size),
                                 dtype=dtype,
                                 device=get_accelerator().current_device_name()))
-                bucket.reduction_complete_events = [None] * len(bucket.buffer)
                 bucket.index = 0
 
         if not self.overlap_comm:
@@ -1271,8 +1278,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         self.report_ipg_memory_usage("End ipg_remove_grads", 0)
 
     def _wait_for_ipg_buffer_reuse(self, bucket, producer_stream):
-        if bucket.index >= len(bucket.reduction_complete_events):
-            return
         completion_event = bucket.reduction_complete_events[bucket.index]
         if completion_event is not None:
             producer_stream.wait_event(completion_event)
@@ -2526,14 +2531,11 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
             if self.contiguous_gradients:
                 for _, bucket in self.ipg_buckets.items():
-                    bucket.buffer.clear()
-
                     # Buffer's dtype is the same as the dtype of optimizer, not dtype for autocast
                     buf_0 = torch.empty(int(self.reduce_bucket_size),
                                         dtype=self.dtype,
                                         device=get_accelerator().current_device_name())
-                    bucket.buffer.append(buf_0)
-                    bucket.index = 0
+                    bucket.set_buffers([buf_0])
 
                 # Use double buffers to avoid data access conflict when overlap_comm is enabled.
                 if self.overlap_comm:
@@ -2541,10 +2543,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                         buf_1 = torch.empty(int(self.reduce_bucket_size),
                                             dtype=self.dtype,
                                             device=get_accelerator().current_device_name())
-                        bucket.buffer.append(buf_1)
-
-                for _, bucket in self.ipg_buckets.items():
-                    bucket.reduction_complete_events = [None] * len(bucket.buffer)
+                        bucket.add_buffer(buf_1)
 
             self.ready_for_gradients = True
 

--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -114,6 +114,8 @@ def _pad_tensor_by_size(src_tensor, pad_size, dtype, device):
 @dataclass
 class IPGBucket:
     buffer: List[torch.Tensor] = field(default_factory=list)
+    # Completion of the most recent reduction-stream use of each physical buffer.
+    reduction_complete_events: List = field(default_factory=list)
     params: List[torch.Tensor] = field(default_factory=list)
     grads: List[torch.Tensor] = field(default_factory=list)
     elements: int = 0
@@ -839,6 +841,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         if self.contiguous_gradients:
             for bucket in self.ipg_buckets.values():
                 bucket.buffer.clear()
+                bucket.reduction_complete_events.clear()
 
             self.grads_in_partition = None
             self.grads_in_partition_offset = 0
@@ -879,6 +882,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     torch.empty(int(self.reduce_bucket_size),
                                 dtype=dtype,
                                 device=get_accelerator().current_device_name()))
+                bucket.reduction_complete_events = [None] * len(bucket.buffer)
                 bucket.index = 0
 
         if not self.overlap_comm:
@@ -1237,6 +1241,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 self.extra_large_param_to_reduce[comm_dtype] = param
             else:
                 # keeping the gradients contiguous to prevent memory fragmentation, and avoid flattening
+                if self.overlap_comm and not get_accelerator().resolves_data_dependency():
+                    producer_stream = get_accelerator().current_stream()
+                    self._wait_for_ipg_buffer_reuse(bucket, producer_stream)
                 new_grad_tensor = bucket.buffer[bucket.index].narrow(0, bucket.elements, param.numel())
                 new_grad_tensor.copy_(
                     grad_reduc.view(-1) if not self.zenflow else grad_reduc.permute(
@@ -1247,7 +1254,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 # Record the stream this copy ran on so average_tensor can wait on
                 # every producer of the bucket, not just the current stream (#8061).
                 if self.overlap_comm and not get_accelerator().resolves_data_dependency():
-                    bucket.copy_streams.add(get_accelerator().current_stream())
+                    bucket.copy_streams.add(producer_stream)
 
         bucket.elements += param.numel()
 
@@ -1261,6 +1268,16 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
             bucket.has_moe_params = True
 
         self.report_ipg_memory_usage("End ipg_remove_grads", 0)
+
+    def _wait_for_ipg_buffer_reuse(self, bucket, producer_stream):
+        if bucket.index >= len(bucket.reduction_complete_events):
+            return
+        completion_event = bucket.reduction_complete_events[bucket.index]
+        if completion_event is not None:
+            producer_stream.wait_event(completion_event)
+
+    def _record_ipg_buffer_reduction_complete(self, bucket):
+        bucket.reduction_complete_events[bucket.index] = self.reduction_stream.record_event()
 
     def print_rank_0(self, message):
         if dist.get_rank() == 0:
@@ -1370,7 +1387,6 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                 producer_streams = bucket.copy_streams or {get_accelerator().current_stream()}
                 for producer_stream in producer_streams:
                     stream.wait_stream(producer_stream)
-                get_accelerator().current_stream().wait_stream(stream)
         else:
             stream = get_accelerator().current_stream()
 
@@ -1702,6 +1718,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         dtypes = sort_dtypes(self.ipg_buckets.keys())
         if comm_dtype is not None:
             dtypes = [comm_dtype]
+        reduced_ipg_buffer_dtypes = set()
         for comm_dtype in dtypes:
             bucket = self.ipg_buckets[comm_dtype]
 
@@ -1723,6 +1740,7 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     del self.extra_large_param_to_reduce[comm_dtype]
                 else:
                     self.average_tensor(bucket.buffer[bucket.index].narrow(0, 0, bucket.elements), comm_dtype)
+                    reduced_ipg_buffer_dtypes.add(comm_dtype)
             else:
                 self.buffered_reduce_fallback(None, bucket.grads, comm_dtype, elements_per_buffer=bucket.elements)
 
@@ -1762,6 +1780,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                     else:  # zero stage 1 - partition only optimizer state
                         if self.contiguous_gradients and self.is_param_in_current_partition[param_id]:
                             self.copy_grads_in_partition(param)
+                if comm_dtype in reduced_ipg_buffer_dtypes and self.overlap_comm:
+                    if not get_accelerator().resolves_data_dependency():
+                        self._record_ipg_buffer_reduction_complete(bucket)
                 bucket.clear()
         #####################################################################
 
@@ -2520,6 +2541,9 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
                                             dtype=self.dtype,
                                             device=get_accelerator().current_device_name())
                         bucket.buffer.append(buf_1)
+
+                for _, bucket in self.ipg_buckets.items():
+                    bucket.reduction_complete_events = [None] * len(bucket.buffer)
 
             self.ready_for_gradients = True
 

--- a/tests/unit/v1/zero/test_overlap_comm_record_stream.py
+++ b/tests/unit/v1/zero/test_overlap_comm_record_stream.py
@@ -495,6 +495,13 @@ def _assert_zero2_runs_match(actual, expected):
         torch.testing.assert_close(actual_param, expected_param, rtol=5e-3, atol=5e-3)
 
 
+def _require_cuda_sleep():
+    if get_accelerator().device_name() != "cuda":
+        pytest.skip("CUDA sleep stress test requires a CUDA accelerator.")
+    if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
+        pytest.skip("CUDA sleep helper is unavailable.")
+
+
 class TestZero2IPGBufferReuse(DistributedTest):
     world_size = 2
 
@@ -502,8 +509,7 @@ class TestZero2IPGBufferReuse(DistributedTest):
     def test_parameter_size_around_bucket_boundary(self, reduce_bucket_size, uses_ipg_buffer):
         if not bf16_required_version_check():
             pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
-        if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
-            pytest.skip("CUDA sleep helper is unavailable.")
+        _require_cuda_sleep()
 
         reference = _run_zero2_buffer_reuse(overlap_comm=False, reduce_bucket_size=reduce_bucket_size)
         overlap = _run_zero2_buffer_reuse(overlap_comm=True,
@@ -522,8 +528,7 @@ class TestZero2IPGBufferReuse(DistributedTest):
     def test_overlap_matches_non_overlap_through_repeated_buffer_reuse(self):
         if not bf16_required_version_check():
             pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
-        if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
-            pytest.skip("CUDA sleep helper is unavailable.")
+        _require_cuda_sleep()
 
         stress_cases = [(20, int(2e7)), (32, int(5e7)), (48, int(1e8))]
         stress_repeats = int(os.environ.get("DS_ZERO_BUFFER_REUSE_STRESS_REPEATS", "1"))

--- a/tests/unit/v1/zero/test_overlap_comm_record_stream.py
+++ b/tests/unit/v1/zero/test_overlap_comm_record_stream.py
@@ -3,11 +3,20 @@
 
 # DeepSpeed Team
 from contextlib import nullcontext
+import os
 
+import pytest
 import torch
+from torch.utils._python_dispatch import TorchDispatchMode
 
+import deepspeed
+import deepspeed.comm as dist
 import deepspeed.runtime.zero.stage_1_and_2 as zero_stage12
+from deepspeed.accelerator import get_accelerator
 from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
+from deepspeed.utils import safe_get_full_grad
+from unit.common import DistributedTest
+from unit.util import bf16_required_version_check
 
 
 class _FakeTensor:
@@ -117,11 +126,24 @@ def test_allreduce_and_copy_with_multiple_ranks_records_consumer_buffers(monkeyp
 class _FakeWaitStream:
     """A stream stand-in that records which streams it was told to wait on."""
 
-    def __init__(self):
+    def __init__(self, operations=None):
         self.waited_on = []
+        self.waited_on_events = []
+        self.recorded_events = []
+        self.operations = operations
 
     def wait_stream(self, other):
         self.waited_on.append(other)
+
+    def wait_event(self, event):
+        self.waited_on_events.append(event)
+
+    def record_event(self):
+        event = object()
+        self.recorded_events.append(event)
+        if self.operations is not None:
+            self.operations.append("record")
+        return event
 
 
 class _FakeAcceleratorWithCurrentStream(_FakeAccelerator):
@@ -132,6 +154,17 @@ class _FakeAcceleratorWithCurrentStream(_FakeAccelerator):
 
     def current_stream(self):
         return self._current_stream
+
+
+class _CopyOrderMode(TorchDispatchMode):
+
+    def __init__(self, operations):
+        self.operations = operations
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if func is torch.ops.aten.copy_.default:
+            self.operations.append("copy")
+        return func(*args, **(kwargs or {}))
 
 
 def _build_average_tensor_optimizer(monkeypatch, *, copy_streams):
@@ -159,11 +192,12 @@ def test_average_tensor_waits_on_all_ipg_bucket_producer_streams(monkeypatch):
     # the contiguous IPG bucket, not just the current stream, because under
     # torch.compile those copies can be issued on multiple autograd streams.
     s1, s2 = object(), object()
-    optimizer, comm_dtype, _, reduced = _build_average_tensor_optimizer(monkeypatch, copy_streams=[s1, s2])
+    optimizer, comm_dtype, current, reduced = _build_average_tensor_optimizer(monkeypatch, copy_streams=[s1, s2])
 
     optimizer.average_tensor(torch.zeros(4), comm_dtype)
 
     assert set(optimizer.reduction_stream.waited_on) == {s1, s2}
+    assert current.waited_on == []
     assert reduced == [comm_dtype]
 
 
@@ -184,3 +218,287 @@ def test_ipg_bucket_clear_resets_copy_streams():
     bucket.copy_streams.add(object())
     bucket.clear()
     assert bucket.copy_streams == set()
+
+
+def test_ipg_buffer_reuse_waits_on_matching_completion_only():
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.overlap_comm = True
+    bucket = zero_stage12.IPGBucket()
+    producer = _FakeWaitStream()
+
+    bucket.index = 0
+    optimizer._wait_for_ipg_buffer_reuse(bucket, producer)
+    assert producer.waited_on_events == []
+
+    buffer_0_complete = object()
+    buffer_1_complete = object()
+    bucket.reduction_complete_events = [buffer_0_complete, buffer_1_complete]
+
+    bucket.index = 1
+    optimizer._wait_for_ipg_buffer_reuse(bucket, producer)
+    assert producer.waited_on_events == [buffer_1_complete]
+
+    bucket.index = 0
+    optimizer._wait_for_ipg_buffer_reuse(bucket, producer)
+    assert producer.waited_on_events == [buffer_1_complete, buffer_0_complete]
+
+
+def test_records_reduction_completion_for_physical_buffer_index():
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.overlap_comm = True
+    optimizer.reduction_stream = _FakeWaitStream()
+    bucket = zero_stage12.IPGBucket()
+    bucket.reduction_complete_events = [None, None]
+
+    bucket.index = 0
+    optimizer._record_ipg_buffer_reduction_complete(bucket)
+    buffer_0_complete = optimizer.reduction_stream.recorded_events[-1]
+    assert bucket.reduction_complete_events == [buffer_0_complete, None]
+
+    bucket.index = 1
+    optimizer._record_ipg_buffer_reduction_complete(bucket)
+    buffer_1_complete = optimizer.reduction_stream.recorded_events[-1]
+    assert bucket.reduction_complete_events == [buffer_0_complete, buffer_1_complete]
+
+
+def test_ipg_bucket_clear_preserves_buffer_completion_state():
+    bucket = zero_stage12.IPGBucket()
+    completion_events = [object(), object()]
+    bucket.reduction_complete_events = completion_events
+
+    bucket.clear()
+
+    # clear() starts the next logical fill of the same physical buffer. Its prior
+    # reduction completion must remain visible until that buffer is reused.
+    assert bucket.reduction_complete_events == completion_events
+
+
+def test_setup_buckets_resets_completion_for_new_physical_buffers(monkeypatch):
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.ready_for_gradients = False
+    optimizer.micro_step_id = 0
+    optimizer.contiguous_gradients = True
+    optimizer.overlap_comm = True
+    optimizer.reduce_bucket_size = 4
+    optimizer.dtype = torch.float32
+    bucket = zero_stage12.IPGBucket()
+    bucket.reduction_complete_events = [object(), object()]
+    optimizer.ipg_buckets = {torch.float32: bucket}
+    monkeypatch.setattr(zero_stage12, "get_accelerator", lambda: _FakeAccelerator(False))
+
+    optimizer.setup_buckets()
+
+    assert len(bucket.buffer) == 2
+    assert bucket.reduction_complete_events == [None, None]
+
+
+def test_reduction_completion_is_isolated_per_dtype_bucket():
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.overlap_comm = True
+    optimizer.reduction_stream = _FakeWaitStream()
+    fp16_bucket = zero_stage12.IPGBucket()
+    bf16_bucket = zero_stage12.IPGBucket()
+    fp16_bucket.reduction_complete_events = [None, None]
+    bf16_bucket.reduction_complete_events = [None, None]
+
+    optimizer._record_ipg_buffer_reduction_complete(fp16_bucket)
+
+    assert fp16_bucket.reduction_complete_events[0] is optimizer.reduction_stream.recorded_events[-1]
+    assert bf16_bucket.reduction_complete_events == [None, None]
+
+
+def test_ipg_buffer_completion_state_machine_across_dtypes_and_producers():
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.reduction_stream = _FakeWaitStream()
+    buckets = {
+        torch.float16: zero_stage12.IPGBucket(reduction_complete_events=[None, None]),
+        torch.bfloat16: zero_stage12.IPGBucket(reduction_complete_events=[None, None]),
+    }
+    sequence = [
+        (torch.float16, 0, 1),
+        (torch.bfloat16, 0, 2),
+        (torch.float16, 1, 2),
+        (torch.float16, 0, 2),
+        (torch.bfloat16, 1, 1),
+        (torch.bfloat16, 0, 2),
+        (torch.float16, 1, 1),
+    ]
+    last_completion = {}
+
+    for dtype, index, producer_count in sequence:
+        bucket = buckets[dtype]
+        bucket.index = index
+        expected_event = last_completion.get((dtype, index))
+        for _ in range(producer_count):
+            producer = _FakeWaitStream()
+            optimizer._wait_for_ipg_buffer_reuse(bucket, producer)
+            assert producer.waited_on_events == ([] if expected_event is None else [expected_event])
+
+        optimizer._record_ipg_buffer_reduction_complete(bucket)
+        completion_event = optimizer.reduction_stream.recorded_events[-1]
+        last_completion[(dtype, index)] = completion_event
+        bucket.clear()
+        assert bucket.reduction_complete_events[index] is completion_event
+
+
+def test_reduce_ipg_grads_records_completion_after_buffer_consumers(monkeypatch):
+    operations = []
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.contiguous_gradients = True
+    optimizer.overlap_comm = True
+    optimizer.cpu_offload = False
+    optimizer.partition_gradients = True
+    optimizer.reduction_stream = _FakeWaitStream(operations)
+    optimizer.extra_large_param_to_reduce = {}
+    optimizer.params_already_reduced = {7: False}
+    optimizer.is_param_in_current_partition = {7: True}
+    optimizer.bit16_groups = [[object()]]
+    optimizer.copy_grads_in_partition = lambda param: operations.append("copy")
+    optimizer.average_tensor = lambda tensor, dtype: operations.append("average")
+    bucket = zero_stage12.IPGBucket(buffer=[torch.zeros(4)], reduction_complete_events=[None], elements=4)
+    bucket.params = [(0, 0, 7)]
+    optimizer.ipg_buckets = {torch.float32: bucket}
+    monkeypatch.setattr(
+        zero_stage12,
+        "get_accelerator",
+        lambda: _FakeAcceleratorWithCurrentStream(False, _FakeWaitStream()),
+    )
+
+    optimizer.reduce_ipg_grads(torch.float32)
+
+    assert operations == ["average", "copy", "record"]
+
+
+def test_ipg_buffer_reuse_wait_precedes_gradient_copy(monkeypatch):
+    operations = []
+    optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
+    optimizer.reduce_bucket_size = 4
+    optimizer.contiguous_gradients = True
+    optimizer.overlap_comm = True
+    optimizer.zenflow = False
+    optimizer.params_already_reduced = {7: False}
+    optimizer._maybe_reduce_autoep_folding_tp_gradient = lambda param, grad: None
+    optimizer.get_param_id = lambda param: 7
+    optimizer.get_param_comm_dtype = lambda param: torch.float32
+    optimizer.get_gradient_for_reduction = lambda param: param.grad
+    optimizer.report_ipg_memory_usage = lambda *args: None
+    optimizer._wait_for_ipg_buffer_reuse = lambda bucket, stream: operations.append("wait")
+    bucket = zero_stage12.IPGBucket(buffer=[torch.zeros(4), torch.zeros(4)])
+    bucket.reduction_complete_events = [object(), None]
+    optimizer.ipg_buckets = {torch.float32: bucket}
+    current = _FakeWaitStream()
+    monkeypatch.setattr(
+        zero_stage12,
+        "get_accelerator",
+        lambda: _FakeAcceleratorWithCurrentStream(False, current),
+    )
+    param = torch.nn.Parameter(torch.zeros(2))
+    param.grad = torch.ones(2)
+    param.param_idx_in_group = 0
+
+    with _CopyOrderMode(operations):
+        optimizer.reduce_independent_p_g_buckets_and_remove_grads(param, 0)
+
+    assert operations[:2] == ["wait", "copy"]
+
+
+class _MultiBucketModel(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.ModuleList([torch.nn.Linear(4, 4, bias=False) for _ in range(8)])
+        with torch.no_grad():
+            for index, layer in enumerate(self.layers):
+                values = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+                layer.weight.copy_((values + index + 1) / 32)
+
+    def forward(self, inputs):
+        for layer in self.layers:
+            inputs = torch.tanh(layer(inputs))
+        return inputs
+
+
+def _run_zero2_buffer_reuse(overlap_comm, reduce_bucket_size, delay_cycles=0):
+    model = _MultiBucketModel().to(dtype=torch.bfloat16)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    config = {
+        "train_micro_batch_size_per_gpu": 2,
+        "zero_allow_untested_optimizer": True,
+        "bf16": {
+            "enabled": True,
+        },
+        "zero_optimization": {
+            "stage": 2,
+            "overlap_comm": overlap_comm,
+            "contiguous_gradients": True,
+            "reduce_scatter": True,
+            "reduce_bucket_size": reduce_bucket_size,
+        },
+    }
+    engine, *_ = deepspeed.initialize(model=model, optimizer=optimizer, config=config)
+    reuse_waits = 0
+    if overlap_comm:
+        original_wait = engine.optimizer._wait_for_ipg_buffer_reuse
+
+        def count_reuse_waits(bucket, producer_stream):
+            nonlocal reuse_waits
+            if bucket.reduction_complete_events[bucket.index] is not None:
+                reuse_waits += 1
+            original_wait(bucket, producer_stream)
+
+        engine.optimizer._wait_for_ipg_buffer_reuse = count_reuse_waits
+        original_average = engine.optimizer.average_tensor
+
+        def delayed_average(tensor, communication_data_type):
+            with get_accelerator().stream(engine.optimizer.reduction_stream):
+                torch.cuda._sleep(delay_cycles)  #ignore-cuda
+            return original_average(tensor, communication_data_type)
+
+        engine.optimizer.average_tensor = delayed_average
+
+    losses = []
+    gradients = []
+    try:
+        device = get_accelerator().current_device_name()
+        rank = dist.get_rank()
+        for step in range(4):
+            values = torch.arange(8, device=device, dtype=torch.float32).reshape(2, 4)
+            inputs = ((values + rank * 3 + step) / 8).to(torch.bfloat16)
+            loss = engine(inputs).float().square().mean()
+            engine.backward(loss)
+            losses.append(loss.detach().cpu())
+            gradients.append(
+                [safe_get_full_grad(param).detach().float().cpu() for param in engine.module.parameters()])
+            engine.step()
+        parameters = [param.detach().float().cpu() for param in engine.module.parameters()]
+    finally:
+        engine.destroy()
+    return losses, gradients, parameters, reuse_waits
+
+
+class TestZero2IPGBufferReuse(DistributedTest):
+    world_size = 2
+
+    def test_overlap_matches_non_overlap_through_repeated_buffer_reuse(self):
+        if not bf16_required_version_check():
+            pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
+        if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
+            pytest.skip("CUDA sleep helper is unavailable.")
+
+        stress_cases = [(20, int(2e7)), (32, int(5e7)), (48, int(1e8))]
+        stress_repeats = int(os.environ.get("DS_ZERO_BUFFER_REUSE_STRESS_REPEATS", "1"))
+        for repeat in range(stress_repeats):
+            reduce_bucket_size, delay_cycles = stress_cases[repeat % len(stress_cases)]
+            reference = _run_zero2_buffer_reuse(overlap_comm=False, reduce_bucket_size=reduce_bucket_size)
+            overlap = _run_zero2_buffer_reuse(overlap_comm=True,
+                                              reduce_bucket_size=reduce_bucket_size,
+                                              delay_cycles=delay_cycles)
+
+            assert overlap[3] >= 2
+            for actual, expected in zip(overlap[0], reference[0]):
+                torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+            for actual_step, expected_step in zip(overlap[1], reference[1]):
+                for actual, expected in zip(actual_step, expected_step):
+                    torch.testing.assert_close(actual, expected, rtol=5e-3, atol=5e-3)
+            for actual, expected in zip(overlap[2], reference[2]):
+                torch.testing.assert_close(actual, expected, rtol=5e-3, atol=5e-3)

--- a/tests/unit/v1/zero/test_overlap_comm_record_stream.py
+++ b/tests/unit/v1/zero/test_overlap_comm_record_stream.py
@@ -437,6 +437,7 @@ def _run_zero2_buffer_reuse(overlap_comm, reduce_bucket_size, delay_cycles=0):
     }
     engine, *_ = deepspeed.initialize(model=model, optimizer=optimizer, config=config)
     reuse_waits = 0
+    completion_records = 0
     if overlap_comm:
         original_wait = engine.optimizer._wait_for_ipg_buffer_reuse
 
@@ -447,6 +448,14 @@ def _run_zero2_buffer_reuse(overlap_comm, reduce_bucket_size, delay_cycles=0):
             original_wait(bucket, producer_stream)
 
         engine.optimizer._wait_for_ipg_buffer_reuse = count_reuse_waits
+        original_record = engine.optimizer._record_ipg_buffer_reduction_complete
+
+        def count_completion_records(bucket):
+            nonlocal completion_records
+            completion_records += 1
+            original_record(bucket)
+
+        engine.optimizer._record_ipg_buffer_reduction_complete = count_completion_records
         original_average = engine.optimizer.average_tensor
 
         def delayed_average(tensor, communication_data_type):
@@ -473,11 +482,42 @@ def _run_zero2_buffer_reuse(overlap_comm, reduce_bucket_size, delay_cycles=0):
         parameters = [param.detach().float().cpu() for param in engine.module.parameters()]
     finally:
         engine.destroy()
-    return losses, gradients, parameters, reuse_waits
+    return losses, gradients, parameters, reuse_waits, completion_records
+
+
+def _assert_zero2_runs_match(actual, expected):
+    for actual_loss, expected_loss in zip(actual[0], expected[0]):
+        torch.testing.assert_close(actual_loss, expected_loss, rtol=1e-5, atol=1e-6)
+    for actual_step, expected_step in zip(actual[1], expected[1]):
+        for actual_grad, expected_grad in zip(actual_step, expected_step):
+            torch.testing.assert_close(actual_grad, expected_grad, rtol=5e-3, atol=5e-3)
+    for actual_param, expected_param in zip(actual[2], expected[2]):
+        torch.testing.assert_close(actual_param, expected_param, rtol=5e-3, atol=5e-3)
 
 
 class TestZero2IPGBufferReuse(DistributedTest):
     world_size = 2
+
+    @pytest.mark.parametrize("reduce_bucket_size,uses_ipg_buffer", [(15, False), (16, True), (17, True)])
+    def test_parameter_size_around_bucket_boundary(self, reduce_bucket_size, uses_ipg_buffer):
+        if not bf16_required_version_check():
+            pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
+        if not hasattr(torch.cuda, "_sleep"):  #ignore-cuda
+            pytest.skip("CUDA sleep helper is unavailable.")
+
+        reference = _run_zero2_buffer_reuse(overlap_comm=False, reduce_bucket_size=reduce_bucket_size)
+        overlap = _run_zero2_buffer_reuse(overlap_comm=True,
+                                          reduce_bucket_size=reduce_bucket_size,
+                                          delay_cycles=int(2e7))
+
+        _assert_zero2_runs_match(overlap, reference)
+        if uses_ipg_buffer:
+            assert overlap[3] >= 2
+            assert overlap[4] > 0
+        else:
+            # Oversized gradients bypass the physical IPG buffers, so their
+            # producer streams never wait for a physical buffer reuse.
+            assert overlap[3] == 0
 
     def test_overlap_matches_non_overlap_through_repeated_buffer_reuse(self):
         if not bf16_required_version_check():
@@ -495,10 +535,5 @@ class TestZero2IPGBufferReuse(DistributedTest):
                                               delay_cycles=delay_cycles)
 
             assert overlap[3] >= 2
-            for actual, expected in zip(overlap[0], reference[0]):
-                torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
-            for actual_step, expected_step in zip(overlap[1], reference[1]):
-                for actual, expected in zip(actual_step, expected_step):
-                    torch.testing.assert_close(actual, expected, rtol=5e-3, atol=5e-3)
-            for actual, expected in zip(overlap[2], reference[2]):
-                torch.testing.assert_close(actual, expected, rtol=5e-3, atol=5e-3)
+            assert overlap[4] > 0
+            _assert_zero2_runs_match(overlap, reference)

--- a/tests/unit/v1/zero/test_overlap_comm_record_stream.py
+++ b/tests/unit/v1/zero/test_overlap_comm_record_stream.py
@@ -3,7 +3,6 @@
 
 # DeepSpeed Team
 from contextlib import nullcontext
-import os
 
 import pytest
 import torch
@@ -369,16 +368,16 @@ def test_reduce_ipg_grads_records_completion_after_buffer_consumers(monkeypatch)
     assert operations == ["average", "copy", "record"]
 
 
-def test_ipg_buffer_reuse_wait_precedes_gradient_copy(monkeypatch):
+def test_ipg_buffer_reuse_waits_once_before_gradient_copies_from_same_stream(monkeypatch):
     operations = []
     optimizer = DeepSpeedZeroOptimizer.__new__(DeepSpeedZeroOptimizer)
     optimizer.reduce_bucket_size = 4
     optimizer.contiguous_gradients = True
     optimizer.overlap_comm = True
     optimizer.zenflow = False
-    optimizer.params_already_reduced = {7: False}
+    optimizer.params_already_reduced = {7: False, 8: False}
     optimizer._maybe_reduce_autoep_folding_tp_gradient = lambda param, grad: None
-    optimizer.get_param_id = lambda param: 7
+    optimizer.get_param_id = lambda param: param.test_id
     optimizer.get_param_comm_dtype = lambda param: torch.float32
     optimizer.get_gradient_for_reduction = lambda param: param.grad
     optimizer.report_ipg_memory_usage = lambda *args: None
@@ -392,14 +391,17 @@ def test_ipg_buffer_reuse_wait_precedes_gradient_copy(monkeypatch):
         "get_accelerator",
         lambda: _FakeAcceleratorWithCurrentStream(False, current),
     )
-    param = torch.nn.Parameter(torch.zeros(2))
-    param.grad = torch.ones(2)
-    param.param_idx_in_group = 0
+    params = [torch.nn.Parameter(torch.zeros(2)), torch.nn.Parameter(torch.zeros(2))]
+    for param_id, param in enumerate(params, start=7):
+        param.grad = torch.ones(2)
+        param.param_idx_in_group = 0
+        param.test_id = param_id
 
     with _CopyOrderMode(operations):
-        optimizer.reduce_independent_p_g_buckets_and_remove_grads(param, 0)
+        for param in params:
+            optimizer.reduce_independent_p_g_buckets_and_remove_grads(param, 0)
 
-    assert operations[:2] == ["wait", "copy"]
+    assert operations == ["wait", "copy", "copy"]
 
 
 class _MultiBucketModel(torch.nn.Module):
@@ -525,20 +527,17 @@ class TestZero2IPGBufferReuse(DistributedTest):
             # producer streams never wait for a physical buffer reuse.
             assert overlap[3] == 0
 
-    def test_overlap_matches_non_overlap_through_repeated_buffer_reuse(self):
+    @pytest.mark.parametrize("reduce_bucket_size,delay_cycles", [(20, int(2e7)), (32, int(5e7)), (48, int(1e8))])
+    def test_overlap_matches_non_overlap_through_repeated_buffer_reuse(self, reduce_bucket_size, delay_cycles):
         if not bf16_required_version_check():
             pytest.skip("BF16 ZeRO-2 test requires BF16 accelerator support.")
         _require_cuda_sleep()
 
-        stress_cases = [(20, int(2e7)), (32, int(5e7)), (48, int(1e8))]
-        stress_repeats = int(os.environ.get("DS_ZERO_BUFFER_REUSE_STRESS_REPEATS", "1"))
-        for repeat in range(stress_repeats):
-            reduce_bucket_size, delay_cycles = stress_cases[repeat % len(stress_cases)]
-            reference = _run_zero2_buffer_reuse(overlap_comm=False, reduce_bucket_size=reduce_bucket_size)
-            overlap = _run_zero2_buffer_reuse(overlap_comm=True,
-                                              reduce_bucket_size=reduce_bucket_size,
-                                              delay_cycles=delay_cycles)
+        reference = _run_zero2_buffer_reuse(overlap_comm=False, reduce_bucket_size=reduce_bucket_size)
+        overlap = _run_zero2_buffer_reuse(overlap_comm=True,
+                                          reduce_bucket_size=reduce_bucket_size,
+                                          delay_cycles=delay_cycles)
 
-            assert overlap[3] >= 2
-            assert overlap[4] > 0
-            _assert_zero2_runs_match(overlap, reference)
+        assert overlap[3] >= 2
+        assert overlap[4] > 0
+        _assert_zero2_runs_match(overlap, reference)

--- a/tests/unit/v1/zero/test_overlap_comm_record_stream.py
+++ b/tests/unit/v1/zero/test_overlap_comm_record_stream.py
@@ -225,10 +225,6 @@ def test_ipg_buffer_reuse_waits_on_matching_completion_only():
     bucket = zero_stage12.IPGBucket()
     producer = _FakeWaitStream()
 
-    bucket.index = 0
-    optimizer._wait_for_ipg_buffer_reuse(bucket, producer)
-    assert producer.waited_on_events == []
-
     buffer_0_complete = object()
     buffer_1_complete = object()
     bucket.reduction_complete_events = [buffer_0_complete, buffer_1_complete]


### PR DESCRIPTION
## Summary

Fixes #8364.

ZeRO-1/2 currently protects IPG ping-pong buffer reuse by making the current/autograd stream wait on the entire reduction stream in `average_tensor()`. That reverse dependency also waits for unrelated work already queued on the reduction stream, serializing the next backward bucket behind the preceding collective.

This change scopes that dependency to the physical IPG buffer being reused:

- preserve the producer-stream to reduction-stream waits added for multi-stream gradient copies;
- record reduction completion per physical IPG buffer after its final reduction-stream consumer;
- wait on that event immediately before the same buffer is overwritten;
- initialize and release event state together with the physical buffers.

Oversized gradients and non-contiguous fallback reductions do not participate in physical IPG buffer reuse. Accelerators that resolve data dependencies implicitly retain their existing path.

## Stream ordering: before and after

Time flows left to right. `P0`/`P1` are producer copies, `R0`/`R1` are reductions, and `E0` is the completion event for physical buffer 0.

### Before: wait on the whole reduction-stream tail

```text
current/autograd  [ P0 ][ backward + P1 ][ wait for reduction_stream ........ ][ next backward ]
                              |                         ^
                              | producer dependency     | broad reverse wait
                              v                         |
reduction_stream         [ wait P0 ][ R0 collective ...][ wait P1 ][ R1 ... ]

Result: preparing or enqueueing the next bucket can stall behind the preceding collective.
```

### After: wait only before reusing the same physical buffer

```text
current/autograd  [ P0 ][ backward + P1 ][ more backward ][ wait E0 ][ overwrite buffer 0 ]
                     |          |                              ^
                     v          v                              | buffer-0 reuse only
reduction_stream  [ wait P0 ][ R0 ... ][ record E0 ][ wait P1 ][ R1 ... ]

buffer index            0                    1                       0 (reused)

Result: producer-to-reduction safety remains, while unrelated backward work overlaps R0.
```

## Correctness invariants

- A reduction never reads a buffer before all producer copies complete.
- A producer never overwrites a physical buffer before that buffer's previous reduction-stream consumers complete.
- Backward compute for a different ping-pong buffer does not wait on the reduction stream's unrelated tail.
- Completion state is isolated by communication dtype and physical buffer index, and survives logical bucket clears until reuse.

## Tests / validation

- `pre-commit run --files deepspeed/runtime/zero/stage_1_and_2.py tests/unit/v1/zero/test_overlap_comm_record_stream.py`
- Local focused suite: 14 passed; CUDA distributed cases skipped on the CPU-only host.
- Modal 2x H200 stress: 10 repeated overlap/non-overlap comparisons across three bucket sizes and delayed reduction-stream work. Losses, full gradients, and final parameters matched.
- Modal 2x H200 related regression selection: overlap on/off, contiguous/non-contiguous gradients, ZeRO stages 1/2/3, multi-bucket overflow, gradient accumulation, unused parameters, and shared backward graphs. The initial run passed 44 cases and exposed one over-constrained new test assertion; after narrowing it to the actual oversized-gradient invariant, the corrected case passed.
- Bucket boundary coverage exercises parameter size at bucket size - 1, equal to bucket size, and bucket size + 1. Bucketed gradients record and wait for reuse; oversized gradients bypass reuse waits.

The correctness suite deliberately delays reduction-stream work to amplify reuse races. I have not repeated the issue's original 8x H200 profiler experiment in this PR; the performance evidence and expected recoverable interval are documented in #8364.
