### PR TITLE
Validate positive inference min output tokens

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -265,7 +265,7 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
     to the required token-length required for your use-case.
     """
 
-    min_out_tokens: int = Field(1, alias="min_tokens")
+    min_out_tokens: int = Field(1, alias="min_tokens", gt=0)
     """
     This argument communicates to the runtime the minimum number of tokens you
     expect you will need to generate. This will cause the runtime to error

--- a/tests/unit/inference/test_inference_config.py
+++ b/tests/unit/inference/test_inference_config.py
@@ -7,6 +7,8 @@ import pytest
 import torch
 import deepspeed
 from deepspeed.accelerator import get_accelerator
+from pydantic import ValidationError
+from deepspeed.inference.config import DeepSpeedInferenceConfig
 from unit.common import DistributedTest
 from unit.simple_model import create_config_from_dict
 
@@ -38,6 +40,14 @@ class TestInferenceCudaGraphConfig:
                     "replace_with_kernel_inject": True,
                 },
             )
+
+
+@pytest.mark.inference
+@pytest.mark.parametrize("field", ["min_out_tokens", "min_tokens"])
+@pytest.mark.parametrize("value", [-1, 0])
+def test_min_out_tokens_must_be_positive(field, value):
+    with pytest.raises(ValidationError):
+        DeepSpeedInferenceConfig(**{field: value})
 
 
 @pytest.mark.inference


### PR DESCRIPTION
## Description

`DeepSpeedInferenceConfig.min_out_tokens` has no lower-bound validation, so a negative or
zero value passes Pydantic construction and is only ever caught later, deep in
`GenWorkSpace`'s C++ workspace allocation (`inference_context.h`), which takes it as an
unsigned parameter. #8343 added the same `gt=0` constraint to the architecturally
identical sibling field `max_out_tokens`; this completes it on `min_out_tokens`, which
that PR does not touch.

Refs #8339 (reports the `max_out_tokens` half of this gap, already being fixed by #8343).

## Testing

Verified with a plain Pydantic construction check, no model or GPU required:

- Before: `DeepSpeedInferenceConfig(min_out_tokens=-1)` and `DeepSpeedInferenceConfig(min_out_tokens=0)` both construct without error.
- After: both raise `ValidationError`, and `min_out_tokens=50` (or the default `1`) still constructs normally.
- New parametrized test in `tests/unit/inference/test_inference_config.py` (mirrors #8343's shape for `max_out_tokens`) fails on unmodified `master` and passes on this branch; ran with `pytest -m inference tests/unit/inference/test_inference_config.py`.
- `pre-commit run --files deepspeed/inference/config.py tests/unit/inference/test_inference_config.py`: all hooks pass.
- Not run: the CUDA/ROCm `GenWorkSpace` path itself, since this VPS has no GPU. The C++ guard at `inference_context.h:150` is untouched and stays as a defense in depth; this PR only stops the invalid value earlier, at config time.
