### PR TITLE
docs: add test discipline rules to agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
 - Changes that affect the external contract at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
-- Integration tests must be executed on an actual device, not merely written: report the execution hardware spec and results in the PR.
+- Integration tests must be executed on actual devices, not merely written: report the execution hardware spec and results in the PR.
 
 ## Tool Caveats
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
 - Changes that affect the external contract at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
+- Integration tests must be executed on an actual device, not merely written: report the execution hardware spec and results in the PR.
 
 ## Tool Caveats
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,14 @@
 - Comments should explain **why**, not **what**. Describe the purpose and reasoning, not the mechanics that the code already shows.
 - New features must include corresponding tests and documentation updates.
 
+### Test discipline
+
+- Tests verify contracts, not implementations: a test is well-formed only if a different correct implementation of the same contract passes it.
+- Before writing a test, name the concrete incorrect behavior it would catch; if you cannot name one, do not write it.
+- Assert on observable outcomes through public/stable interfaces; do not assert private method return values or exact internal strings unless pinning a specific fixed bug (justify in a comment).
+- Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
+- Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
+
 ## Tool Caveats
 
 ### Edit tool auto-formatter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - Assert on observable outcomes through public/stable interfaces; do not assert private method return values or exact internal strings unless pinning a specific fixed bug (justify in a comment).
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
-- Contract changes observable only at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
+- Changes that affect the external contract at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
 
 ## Tool Caveats
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - Assert on observable outcomes through public/stable interfaces; do not assert private method return values or exact internal strings unless pinning a specific fixed bug (justify in a comment).
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
+- Contract changes observable only at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
 
 ## Tool Caveats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
 - Changes that affect the external contract at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
-- Integration tests must be executed on an actual device, not merely written: report the execution hardware spec and results in the PR.
+- Integration tests must be executed on actual devices, not merely written: report the execution hardware spec and results in the PR.
 
 ## Tool Caveats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
 - Changes that affect the external contract at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
+- Integration tests must be executed on an actual device, not merely written: report the execution hardware spec and results in the PR.
 
 ## Tool Caveats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@
 - Comments should explain **why**, not **what**. Describe the purpose and reasoning, not the mechanics that the code already shows.
 - New features must include corresponding tests and documentation updates.
 
+### Test discipline
+
+- Tests verify contracts, not implementations: a test is well-formed only if a different correct implementation of the same contract passes it.
+- Before writing a test, name the concrete incorrect behavior it would catch; if you cannot name one, do not write it.
+- Assert on observable outcomes through public/stable interfaces; do not assert private method return values or exact internal strings unless pinning a specific fixed bug (justify in a comment).
+- Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
+- Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
+
 ## Tool Caveats
 
 ### Edit tool auto-formatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@
 - Assert on observable outcomes through public/stable interfaces; do not assert private method return values or exact internal strings unless pinning a specific fixed bug (justify in a comment).
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
-- Contract changes observable only at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
+- Changes that affect the external contract at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
 
 ## Tool Caveats
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@
 - Assert on observable outcomes through public/stable interfaces; do not assert private method return values or exact internal strings unless pinning a specific fixed bug (justify in a comment).
 - Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
 - Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.
+- Contract changes observable only at the training-loop or inference level require integration tests, not just unit tests (e.g. a minimal training loop with `SimpleModel`).
 
 ## Tool Caveats
 


### PR DESCRIPTION
## Motivation

AI coding agents increasingly submit tests alongside features, and a recurring failure mode of such contributions is tests coupled to the implementation rather than the contract:

- asserting private method return values or exact internal strings,
- re-implementing the logic under test as the test's own reference,
- mocks that stand in for internals instead of a documented collaborator contract.

Such tests pass trivially, break on harmless refactors (or worse, survive bugs they should catch), and give false coverage confidence.

## What this PR adds

A `### Test discipline` section to the agent guidelines (`AGENTS.md` + `CLAUDE.md`, kept in sync as the file header requires) with operational rules:

1. A test is well-formed only if a different correct implementation of the same contract passes it.
2. Name the concrete incorrect behavior a test would catch before writing it; if none can be named, do not write it.
3. Assert observable outcomes through public/stable interfaces; white-box pinning only for specific fixed bugs, justified in a comment.
4. Anchor to an external oracle or an independently derived reference instead of re-implementing the logic under test.
5. Mocks must stand in for a collaborator's documented contract (schema, protocol), never for internals of the module under test.

The rules are deliberately example-free to keep the guide lean.