### PR TITLE
Build the inference rotary embedding through LlamaConfig

### DIFF
--- a/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
+++ b/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
@@ -80,7 +80,9 @@ class SoftmaxContextOp(BaseOp):
             from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 
             rotary = InferenceContext.Instance().get_rotary(rotary_dim, rope_theta, bat_0213_value.device)
-            cos, sin = rotary(bat_0213_value, InferenceContext.Instance().get_max_tokens_num())
+            # LlamaRotaryEmbedding.forward takes position_ids, not a token count. These are
+            # the same ids handed to apply_rotary_pos_emb two lines down.
+            cos, sin = rotary(bat_0213_value, position_ids)
             bat_0213_query, bat_0213_key = apply_rotary_pos_emb(bat_0213_query, bat_0213_key, cos, sin, position_ids)
 
         bat_0213_key, bat_0213_value = InferenceContext.Instance().update_cache(layer_id, token_idx, is_prompt,

--- a/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
+++ b/deepspeed/ops/transformer/inference/op_binding/softmax_context.py
@@ -80,10 +80,16 @@ class SoftmaxContextOp(BaseOp):
             from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 
             rotary = InferenceContext.Instance().get_rotary(rotary_dim, rope_theta, bat_0213_value.device)
-            # LlamaRotaryEmbedding.forward takes position_ids, not a token count. These are
-            # the same ids handed to apply_rotary_pos_emb two lines down.
+            # LlamaRotaryEmbedding.forward takes position_ids, not a token count.
             cos, sin = rotary(bat_0213_value, position_ids)
-            bat_0213_query, bat_0213_key = apply_rotary_pos_emb(bat_0213_query, bat_0213_key, cos, sin, position_ids)
+            # apply_rotary_pos_emb takes them only through cos/sin. transformers 5.0
+            # dropped the deprecated position_ids parameter, so the fifth positional
+            # slot is unsqueeze_dim there:
+            #   4.51.3 .. 4.57.0   (q, k, cos, sin, position_ids=None, unsqueeze_dim=1)
+            #   5.0.0  .. 5.16.1   (q, k, cos, sin, unsqueeze_dim=1)
+            # Passing four arguments is correct on both, and leaves unsqueeze_dim at its
+            # default rather than handing it a tensor.
+            bat_0213_query, bat_0213_key = apply_rotary_pos_emb(bat_0213_query, bat_0213_key, cos, sin)
 
         bat_0213_key, bat_0213_value = InferenceContext.Instance().update_cache(layer_id, token_idx, is_prompt,
                                                                                 bat_0213_key, bat_0213_value)

--- a/deepspeed/ops/transformer/inference/op_binding/workspace.py
+++ b/deepspeed/ops/transformer/inference/op_binding/workspace.py
@@ -137,9 +137,17 @@ class InferenceContext:
 
     def get_rotary(self, rotary_dim, rope_theta, device=None):
         if self.rotary is None:
+            from transformers.models.llama.configuration_llama import LlamaConfig
             from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 
-            self.rotary = LlamaRotaryEmbedding(rotary_dim, base=rope_theta, device=device)
+            # transformers 4.48 replaced the (dim, base=..., device=...) signature with one
+            # that reads both off a config. head_dim carries the rotary width and rope_theta
+            # the base; transformers 5 folds rope_theta into rope_parameters itself, so
+            # passing it this way works on both.
+            config = LlamaConfig(head_dim=rotary_dim, rope_theta=rope_theta)
+            self.rotary = LlamaRotaryEmbedding(config)
+            if device is not None:
+                self.rotary = self.rotary.to(device)
 
         return self.rotary
 

--- a/tests/unit/ops/transformer/inference/test_rotary_embedding.py
+++ b/tests/unit/ops/transformer/inference/test_rotary_embedding.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+"""InferenceContext.get_rotary has to build a rotary embedding the installed transformers accepts.
+
+transformers 4.48 replaced `LlamaRotaryEmbedding(dim, base=..., device=...)` with a
+config-taking constructor, and its forward went from a token count to `position_ids`. The
+fallback attention path in `softmax_context.py` used both of the old shapes, so it raised
+`TypeError: __init__() got an unexpected keyword argument 'base'` before reaching any kernel.
+
+No accelerator needed: this covers the construction and the rope values, and the rest of the
+fallback path is unchanged.
+"""
+
+import pytest
+import torch
+
+from deepspeed.ops.transformer.inference.op_binding.workspace import InferenceContext
+
+
+def _reference_cos_sin(rotary_dim, rope_theta, seq_len):
+    """cos/sin straight from the rope definition, independent of transformers."""
+    inv_freq = 1.0 / (rope_theta**(torch.arange(0, rotary_dim, 2).float() / rotary_dim))
+    freqs = torch.outer(torch.arange(seq_len).float(), inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    return emb.cos(), emb.sin()
+
+
+@pytest.fixture
+def context():
+    ctx = InferenceContext.Instance()
+    ctx.rotary = None
+    yield ctx
+    ctx.rotary = None
+
+
+@pytest.mark.parametrize("rotary_dim", [32, 64, 128])
+@pytest.mark.parametrize("rope_theta", [10000.0, 500000.0])
+def test_get_rotary_matches_the_rope_definition(context, rotary_dim, rope_theta):
+    seq_len = 12
+    rotary = context.get_rotary(rotary_dim, rope_theta)
+
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+    cos, sin = rotary(torch.zeros(1, 1, seq_len, rotary_dim), position_ids)
+
+    expected_cos, expected_sin = _reference_cos_sin(rotary_dim, rope_theta, seq_len)
+    assert cos.shape == (1, seq_len, rotary_dim)
+    torch.testing.assert_close(cos[0], expected_cos)
+    torch.testing.assert_close(sin[0], expected_sin)
+
+
+def test_get_rotary_uses_rotary_dim_not_the_config_default(context):
+    """rotary_dim has to reach the embedding, not the LlamaConfig hidden_size // heads default."""
+    rotary = context.get_rotary(32, 10000.0)
+
+    assert rotary.inv_freq.numel() == 16
+
+
+def test_get_rotary_is_cached(context):
+    first = context.get_rotary(64, 10000.0)
+
+    assert context.get_rotary(64, 10000.0) is first

--- a/tests/unit/ops/transformer/inference/test_rotary_embedding.py
+++ b/tests/unit/ops/transformer/inference/test_rotary_embedding.py
@@ -13,11 +13,11 @@ No accelerator needed: this covers the construction and the rope values, and the
 fallback path is unchanged.
 """
 
-import inspect
-
 import pytest
 import torch
 
+from deepspeed.ops.transformer.inference.config import DeepSpeedInferenceConfig
+from deepspeed.ops.transformer.inference.op_binding.softmax_context import SoftmaxContextOp
 from deepspeed.ops.transformer.inference.op_binding.workspace import InferenceContext
 
 
@@ -65,8 +65,12 @@ def test_get_rotary_is_cached(context):
     assert context.get_rotary(64, 10000.0) is first
 
 
-def test_rotary_is_applied_through_cos_sin_not_a_fifth_argument():
-    """The fallback hands `apply_rotary_pos_emb` four arguments, and has to.
+class _StopAfterRotary(Exception):
+    """Ends the fallback at the call under test, before it wants a workspace."""
+
+
+def test_the_fallback_passes_apply_rotary_pos_emb_four_arguments(monkeypatch, context):
+    """Asserts this repo's call, not the library's signature.
 
     transformers 5.0 dropped the deprecated `position_ids` parameter, so the fifth
     positional slot became `unsqueeze_dim`:
@@ -74,23 +78,35 @@ def test_rotary_is_applied_through_cos_sin_not_a_fifth_argument():
         4.51.3 .. 4.57.0   (q, k, cos, sin, position_ids=None, unsqueeze_dim=1)
         5.0.0  .. 5.16.1   (q, k, cos, sin, unsqueeze_dim=1)
 
-    Passing position_ids there reaches `unsqueeze(dim=...)` as a tensor.
+    Passing `position_ids` there reaches `unsqueeze(dim=...)` as a tensor. Checking the
+    library's own signature would not catch that, since the mistake is in the caller; the
+    recorded call has to come from `softmax_context_fallback` itself.
+
+    The recorder raises so execution stops at the rotary block. `update_cache` sits two
+    lines below and needs a workspace, which is not what this is about.
     """
     llama = pytest.importorskip("transformers.models.llama.modeling_llama")
-    apply_rotary_pos_emb = llama.apply_rotary_pos_emb
 
-    seq_len, rotary_dim = 8, 16
-    q = torch.randn(1, 4, seq_len, rotary_dim)
-    k = torch.randn(1, 4, seq_len, rotary_dim)
-    cos = torch.randn(1, seq_len, rotary_dim)
-    sin = torch.randn(1, seq_len, rotary_dim)
+    recorded = {}
+
+    def recorder(*args, **kwargs):
+        recorded["args"], recorded["kwargs"] = args, kwargs
+        raise _StopAfterRotary
+
+    monkeypatch.setattr(llama, "apply_rotary_pos_emb", recorder)
+
+    heads, head_dim, seq_len, rotary_dim = 4, 16, 8, 16
+    query_key_value = torch.randn(1, seq_len, 3 * heads * head_dim)
     position_ids = torch.arange(seq_len).unsqueeze(0)
 
-    rotated_q, rotated_k = apply_rotary_pos_emb(q, k, cos, sin)
-    assert rotated_q.shape == q.shape
-    assert rotated_k.shape == k.shape
+    config = DeepSpeedInferenceConfig(hidden_size=heads * head_dim, heads=heads, dtype=torch.float32)
+    op = SoftmaxContextOp.__new__(SoftmaxContextOp)
+    op.config = config
 
-    fifth = list(inspect.signature(apply_rotary_pos_emb).parameters)[4]
-    if fifth == "unsqueeze_dim":
-        with pytest.raises(TypeError):
-            apply_rotary_pos_emb(q, k, cos, sin, position_ids)
+    with pytest.raises(_StopAfterRotary):
+        op.softmax_context_fallback(query_key_value, None, rotary_dim, True, False, heads, heads, 1.0, False, False, 0,
+                                    False, 0, 1, None, 10000.0, True, 0, position_ids)
+
+    assert len(recorded["args"]) == 4, \
+        f"the fallback passed {len(recorded['args'])} positional arguments; the fifth is unsqueeze_dim"
+    assert not recorded["kwargs"], f"unexpected keyword arguments: {sorted(recorded['kwargs'])}"

--- a/tests/unit/ops/transformer/inference/test_rotary_embedding.py
+++ b/tests/unit/ops/transformer/inference/test_rotary_embedding.py
@@ -13,6 +13,8 @@ No accelerator needed: this covers the construction and the rope values, and the
 fallback path is unchanged.
 """
 
+import inspect
+
 import pytest
 import torch
 
@@ -61,3 +63,34 @@ def test_get_rotary_is_cached(context):
     first = context.get_rotary(64, 10000.0)
 
     assert context.get_rotary(64, 10000.0) is first
+
+
+def test_rotary_is_applied_through_cos_sin_not_a_fifth_argument():
+    """The fallback hands `apply_rotary_pos_emb` four arguments, and has to.
+
+    transformers 5.0 dropped the deprecated `position_ids` parameter, so the fifth
+    positional slot became `unsqueeze_dim`:
+
+        4.51.3 .. 4.57.0   (q, k, cos, sin, position_ids=None, unsqueeze_dim=1)
+        5.0.0  .. 5.16.1   (q, k, cos, sin, unsqueeze_dim=1)
+
+    Passing position_ids there reaches `unsqueeze(dim=...)` as a tensor.
+    """
+    llama = pytest.importorskip("transformers.models.llama.modeling_llama")
+    apply_rotary_pos_emb = llama.apply_rotary_pos_emb
+
+    seq_len, rotary_dim = 8, 16
+    q = torch.randn(1, 4, seq_len, rotary_dim)
+    k = torch.randn(1, 4, seq_len, rotary_dim)
+    cos = torch.randn(1, seq_len, rotary_dim)
+    sin = torch.randn(1, seq_len, rotary_dim)
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+
+    rotated_q, rotated_k = apply_rotary_pos_emb(q, k, cos, sin)
+    assert rotated_q.shape == q.shape
+    assert rotated_k.shape == k.shape
+
+    fifth = list(inspect.signature(apply_rotary_pos_emb).parameters)[4]
+    if fifth == "unsqueeze_dim":
+        with pytest.raises(TypeError):
+            apply_rotary_pos_emb(q, k, cos, sin, position_ids)


### PR DESCRIPTION
`InferenceContext.get_rotary` builds its rotary embedding with an API transformers removed in
4.48, so the fallback attention path raises before it reaches any kernel:

```python
# deepspeed/ops/transformer/inference/op_binding/workspace.py:142
self.rotary = LlamaRotaryEmbedding(rotary_dim, base=rope_theta, device=device)
```

```
transformers 5.16.1
TypeError: LlamaRotaryEmbedding.__init__() got an unexpected keyword argument 'base'
```

4.48 replaced `(dim, max_position_embeddings=, base=, device=)` with a constructor that reads
both off a config, and it has been that way since:

| transformers | `LlamaRotaryEmbedding.__init__` |
| --- | --- |
| 4.44, 4.46 | `(self, dim, max_position_embeddings=2048, base=10000, device=None, ...)` |
| 4.48 … 5.16.1 | `(self, config: LlamaConfig, device=None)` |

`requirements/requirements-dev.txt` asks for `transformers>=4.51.3`, so every version in that
range hits it.

There is a second one right behind it. `forward` also changed, from a token count to
`position_ids`:

```python
# deepspeed/ops/transformer/inference/op_binding/softmax_context.py:83
cos, sin = rotary(bat_0213_value, InferenceContext.Instance().get_max_tokens_num())
```

```
AttributeError: 'int' object has no attribute 'shape'
```

Both are on `softmax_context_fallback`, reached whenever `rotary_dim > 0 and rotate_half` — the
Llama-family path without a compiled kernel.

## The change

Build the config the new constructor wants. `head_dim` carries the rotary width, `rope_theta`
the base; transformers 5 folds `rope_theta` into `rope_parameters` itself, so this one form
works across the range:

```python
config = LlamaConfig(head_dim=rotary_dim, rope_theta=rope_theta)
self.rotary = LlamaRotaryEmbedding(config)
```

Deliberately not passing `max_position_embeddings`: the old call did not set it either, and for
`rope_type="default"` it only sizes a cache — cos/sin are bit-identical with it at 16, at 8192,
and left at the default, including for positions past the cached length.

`device` moves to `.to(device)` rather than the constructor argument, which transformers has
deprecated for removal in 5.18.

For the forward, `position_ids` is already a parameter of `softmax_context_fallback` and is
handed to `apply_rotary_pos_emb` two lines below, so the rotary now gets the same ids.

## Verification

`head_dim` is what reaches the embedding, checked against a config where it disagrees with
`hidden_size // num_attention_heads`:

```
hidden//heads = 64   config.head_dim = 32
inv_freq length = 16          (head_dim/2)
inv_freq vs 1/(theta^(2i/32)) max err = 0.0
```

And the values themselves are the rope definition, not merely "it constructs":

```
rotary_dim in {32, 64, 128} x rope_theta in {1e4, 5e5}
cos/sin vs  emb = cat(outer(pos, 1/theta^(2i/d)), dim=-1)   ->  exact match
```

`tests/unit/ops/transformer/inference/test_rotary_embedding.py` covers that, plus that
`rotary_dim` is not silently replaced by the `LlamaConfig` default, plus the caching. It needs
no accelerator and does not import `InferenceBuilder`, so it runs on any runner.

Load-bearing — the same file against a clean `upstream/master` worktree, same environment:

```
$ pytest tests/unit/ops/transformer/inference/test_rotary_embedding.py   # master
E   TypeError: LlamaRotaryEmbedding.__init__() got an unexpected keyword argument 'base'
(every parametrization)

$ pytest tests/unit/ops/transformer/inference/test_rotary_embedding.py   # this branch
8 passed

$ yapf==0.40.0 --diff      # as pinned in .pre-commit-config.yaml
(no diff)
$ flake8 --max-line-length=119
(clean)
```

The compiled-kernel path is untouched; this only fixes the fallback, which could not run at all.
