### PR TITLE
Fix zero_to_fp32 --safe_serialization on models with tied weights

### DIFF
--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -560,9 +560,13 @@ def _get_fp32_state_dict_from_zero3_checkpoint(world_size, fp32_flat_groups, zer
     return state_dict
 
 
-def to_torch_tensor(state_dict, return_empty_tensor=False, dtype=None):
+def to_torch_tensor(state_dict, return_empty_tensor=False, dtype=None, share_tensors=True):
     """
     Convert state_dict of GatheredTensor to torch tensor
+
+    ``share_tensors=False`` gives every entry its own storage, copying tied parameters instead of
+    mapping them onto one tensor. safetensors refuses to serialize tensors that share storage, so the
+    ``safe_serialization`` path needs the copies; the pickle path keeps sharing them.
     """
     if dtype is not None:
         dtype = _resolve_output_dtype(dtype)
@@ -573,7 +577,7 @@ def to_torch_tensor(state_dict, return_empty_tensor=False, dtype=None):
         tensor_id = id(tensor)
         if tensor_id in converted_tensors:  # shared tensors
             shared_tensor = torch_state_dict[converted_tensors[tensor_id]]
-            torch_state_dict[name] = shared_tensor
+            torch_state_dict[name] = shared_tensor if share_tensors else shared_tensor.clone()
         else:
             converted_tensors[tensor_id] = name
             if return_empty_tensor:
@@ -697,7 +701,10 @@ def convert_zero_checkpoint_to_state_dict(checkpoint_dir,
     if max_shard_size is not None:
         filename_pattern = weights_name.replace(".bin", "{suffix}.bin").replace(".safetensors", "{suffix}.safetensors")
         # an memory-efficient approach for sharding
-        empty_state_dict = to_torch_tensor(state_dict, return_empty_tensor=True, dtype=dtype)
+        empty_state_dict = to_torch_tensor(state_dict,
+                                           return_empty_tensor=True,
+                                           dtype=dtype,
+                                           share_tensors=not safe_serialization)
         state_dict_split = split_torch_state_dict_into_shards(empty_state_dict,
                                                               filename_pattern=filename_pattern,
                                                               max_shard_size=max_shard_size)
@@ -712,7 +719,7 @@ def convert_zero_checkpoint_to_state_dict(checkpoint_dir,
     filename_to_tensors = state_dict_split.filename_to_tensors.items()
     for shard_file, tensors in tqdm(filename_to_tensors, desc="Saving checkpoint shards"):
         shard_state_dict = {tensor_name: state_dict[tensor_name] for tensor_name in tensors}
-        shard_state_dict = to_torch_tensor(shard_state_dict, dtype=dtype)
+        shard_state_dict = to_torch_tensor(shard_state_dict, dtype=dtype, share_tensors=not safe_serialization)
         output_path = os.path.join(output_dir, shard_file)
         if safe_serialization:
             save_file(shard_state_dict, output_path, metadata={"format": "pt"})

--- a/deepspeed/utils/zero_to_fp32.py
+++ b/deepspeed/utils/zero_to_fp32.py
@@ -577,7 +577,16 @@ def to_torch_tensor(state_dict, return_empty_tensor=False, dtype=None, share_ten
         tensor_id = id(tensor)
         if tensor_id in converted_tensors:  # shared tensors
             shared_tensor = torch_state_dict[converted_tensors[tensor_id]]
-            torch_state_dict[name] = shared_tensor if share_tensors else shared_tensor.clone()
+            if share_tensors:
+                torch_state_dict[name] = shared_tensor
+            elif return_empty_tensor:
+                # The sizing pass only needs shapes, and a shared entry still has to
+                # count separately because the copies really are written. Allocate a
+                # placeholder rather than cloning one, so planning a sharded save of a
+                # tied GB-scale embedding does not touch a second full-size buffer.
+                torch_state_dict[name] = torch.empty(shared_tensor.shape, dtype=shared_tensor.dtype)
+            else:
+                torch_state_dict[name] = shared_tensor.clone()
         else:
             converted_tensors[tensor_id] = name
             if return_empty_tensor:

--- a/tests/unit/checkpoint/test_convert_checkpoint.py
+++ b/tests/unit/checkpoint/test_convert_checkpoint.py
@@ -36,6 +36,38 @@ def test_output_dtype_conversion_preserves_shared_tensors():
         to_torch_tensor(state_dict, dtype="int8")
 
 
+def test_sizing_pass_does_not_clone_a_tied_placeholder(monkeypatch):
+    """The shard planner asks for shapes only, so it must not copy anything.
+
+    With `share_tensors=False` a tied entry needs its own storage, because both
+    copies really are written, but during `return_empty_tensor` planning that
+    storage only has to exist, not be filled from another one. Cloning would
+    touch a second full-size buffer for every tied GB-scale weight before any
+    shard is saved.
+    """
+    tensor = torch.arange(16, dtype=torch.float32)
+    state_dict = {"weight": tensor, "shared_weight": tensor}
+
+    clones = []
+    original_clone = torch.Tensor.clone
+    monkeypatch.setattr(torch.Tensor, "clone",
+                        lambda self, *args, **kwargs: (clones.append(self.shape)
+                                                       or original_clone(self, *args, **kwargs)))
+
+    empty = to_torch_tensor(state_dict, return_empty_tensor=True, share_tensors=False)
+    assert clones == [], f"the sizing pass cloned {clones}"
+
+    # The copies still have to be separate, or the shard planner undercounts.
+    assert empty["weight"].data_ptr() != empty["shared_weight"].data_ptr()
+    assert empty["weight"].shape == empty["shared_weight"].shape == tensor.shape
+
+    # The saving pass is the one that must copy, so that safetensors accepts it.
+    written = to_torch_tensor(state_dict, share_tensors=False)
+    assert clones == [tensor.shape]
+    assert written["weight"].data_ptr() != written["shared_weight"].data_ptr()
+    assert torch.equal(written["weight"], written["shared_weight"])
+
+
 def test_checkpoint_file_output_dtype(monkeypatch, tmp_path):
 
     def make_state_dict(*args, **kwargs):

--- a/tests/unit/checkpoint/test_convert_checkpoint.py
+++ b/tests/unit/checkpoint/test_convert_checkpoint.py
@@ -57,6 +57,31 @@ def test_checkpoint_file_output_dtype(monkeypatch, tmp_path):
     assert (bf16_dir / "pytorch_model.bin").stat().st_size < (fp32_dir / "pytorch_model.bin").stat().st_size * 0.6
 
 
+@pytest.mark.parametrize("max_shard_size", [None, "1GB"])
+def test_safe_serialization_with_tied_weights(monkeypatch, tmp_path, max_shard_size):
+    """safetensors rejects tensors that share storage, and tied weights (the usual
+    embedding / lm_head pair) are exactly that, so the shared entry needs its own copy."""
+    pytest.importorskip("safetensors")
+
+    def make_state_dict(*args, **kwargs):
+        weight = torch.arange(4096, dtype=torch.float32)
+        return {"weight": weight, "shared_weight": weight}
+
+    monkeypatch.setattr(zero_to_fp32, "get_fp32_state_dict_from_zero_checkpoint", make_state_dict)
+    output_dir = tmp_path / f"safetensors-{max_shard_size}"
+
+    convert_zero_checkpoint_to_state_dict("unused", output_dir, max_shard_size=max_shard_size, safe_serialization=True)
+
+    from safetensors.torch import load_file
+    state_dict = {}
+    for shard in sorted(output_dir.glob("*.safetensors")):
+        state_dict.update(load_file(shard))
+
+    assert sorted(state_dict) == ["shared_weight", "weight"]
+    torch.testing.assert_close(state_dict["weight"], state_dict["shared_weight"])
+    torch.testing.assert_close(state_dict["weight"], torch.arange(4096, dtype=torch.float32))
+
+
 def test_zero_to_torch_cli_passes_dtype(monkeypatch, tmp_path):
     call = {}
 


### PR DESCRIPTION
`zero_to_fp32 --safe_serialization` aborts on any checkpoint whose model ties weights, which is the usual embedding / `lm_head` pair, so most decoder-only models are affected:

```
RuntimeError:
    Some tensors share memory, this will lead to duplicate memory on disk and
    potential differences when loading them again: [{'lm_head.weight', 'model.embed_tokens.weight'}].
```

## Root cause

`_get_fp32_state_dict_from_zero{2,3}_checkpoint` recovers a tied parameter by pointing it at the tensor it is tied to:

```python
for pair in zero_model_states[0].shared_params:
    if pair[1] in state_dict:
        state_dict[pair[0]] = state_dict[pair[1]]
```

`to_torch_tensor` then deliberately keeps that aliasing so the pair costs one tensor rather than two:

```python
if tensor_id in converted_tensors:  # shared tensors
    shared_tensor = torch_state_dict[converted_tensors[tensor_id]]
    torch_state_dict[name] = shared_tensor
```

That is exactly what `safetensors.torch.save_file` refuses. The pickle path is fine because `torch.save` stores shared storage once and restores the aliasing on load.

Note that ordinary (untied) parameters are *not* affected even though they are all views into one flat vector: safetensors only rejects tensors that overlap, and sibling `narrow()` slices are disjoint. Only the tied pair, which is the same region twice, trips it.

## Fix

`to_torch_tensor` grows a `share_tensors` flag, and `convert_zero_checkpoint_to_state_dict` passes `share_tensors=not safe_serialization` at both call sites, so the tied entry gets its own copy on the safetensors path and nowhere else. Passing it to the `return_empty_tensor=True` call as well means `split_torch_state_dict_into_shards` sees two distinct storages and sizes the shards for what is actually written.

Cloning rather than dropping the duplicate key keeps the documented contract that the output loads with `load_state_dict()`: a tied module still lists both names in its `state_dict()`, so a strict load needs both. The pickle path is untouched and still shares the tensor, which `test_output_dtype_conversion_preserves_shared_tensors` and `test_checkpoint_file_output_dtype` already assert.

## Test

`tests/unit/checkpoint/test_convert_checkpoint.py::test_safe_serialization_with_tied_weights`, parametrized over `max_shard_size` `None` and `"1GB"` so both the single-file and the sharded writer are covered. It is a CPU test in the same monkeypatched style as the existing `test_checkpoint_file_output_dtype`.

**2 failed before the change, 2 passed after**; the 4 existing CPU tests in the file pass on both sides.

Separately I exercised the change against synthesized ZeRO-2 and ZeRO-3 checkpoints on disk (world sizes 1 to 4, odd numels, several parameter groups, frozen parameters, buffers, tied parameters, fp16/bf16 output, sharded and unsharded, safetensors and pickle), reconstructing the state dict and comparing it to the weights the checkpoint was built from. Everything round-trips, and the only failures before the change were the tied-weight-plus-safetensors combinations.
