### PR TITLE
[AutoEP] Make router weight persistent to avoid 0 tensor size crash

### DIFF
--- a/deepspeed/compile/custom_ops/tp_collectives.py
+++ b/deepspeed/compile/custom_ops/tp_collectives.py
@@ -3,6 +3,8 @@
 
 # DeepSpeed Team
 
+from typing import List
+
 import torch
 import deepspeed.comm as dist
 from deepspeed.utils import groups
@@ -47,7 +49,7 @@ def reduce_from_tp_region_fake(input: torch.Tensor):
 
 
 @torch.library.custom_op("autotp::gather_from_tp_region", mutates_args=())
-def gather_from_tp_region(input: torch.Tensor, partition_sizes: list[int]) -> torch.Tensor:
+def gather_from_tp_region(input: torch.Tensor, partition_sizes: List[int]) -> torch.Tensor:
     """All-gather the last dimension using the frozen shard widths.
 
     Inserted after a column-parallel matmul whose layer asks for gather_output, so that
@@ -85,7 +87,7 @@ def gather_from_tp_region(input: torch.Tensor, partition_sizes: list[int]) -> to
 
 
 @torch.library.register_fake("autotp::gather_from_tp_region")
-def gather_from_tp_region_fake(input: torch.Tensor, partition_sizes: list[int]):
+def gather_from_tp_region_fake(input: torch.Tensor, partition_sizes: List[int]):
     return input.new_empty((*input.shape[:-1], sum(partition_sizes)))
 
 

--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -492,6 +492,15 @@ class AutoEPMoELayer(nn.Module):
             param.allreduce = True
             mark_autoep_folding_router_parameter(param)
             param.ds_zero_placement_family = "replicated"
+            # Keep the router resident under ZeRO-3. Its gate weight is num_experts x hidden_size,
+            # which exceeds stage3_param_persistence_threshold (default 100_000) for any
+            # fine-grained MoE -- 524_288 for a 128-expert/4096-hidden model. ZeRO-3 then releases
+            # it once the parameter trace is in use (from step 2), and backward fails in
+            # zero/linear.py with a 0-length weight. Marking it here costs
+            # num_layers * num_experts * hidden * 2 bytes (~98 MB for a 94-layer 128-expert model)
+            # and, unlike escalating the whole block to a leaf module, does not change gather
+            # granularity for the experts.
+            param.ds_force_persist = True
         if self.shared_experts is not None:
             for param in self.shared_experts.parameters():
                 param.allreduce = True

--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -316,7 +316,9 @@ class DeepSpeedZeRoOffload(object):
             if param.ds_numel + total_persistent_parameters > model_threshold:
                 continue
 
-            if param.ds_numel <= param_threshold:
+            # ds_force_persist lets a transform (e.g. AutoEP) keep a parameter resident even when
+            # it is larger than the size threshold, without escalating its whole module to a leaf.
+            if param.ds_numel <= param_threshold or getattr(param, "ds_force_persist", False):
                 params_count += 1
                 param.ds_persist = True
                 persistent_params.append(param)


### PR DESCRIPTION
# Fix: ZeRO-3 releases AutoEP's router, crashing step-2 backward on fine-grained MoE

## Problem

Under ZeRO-3 + AutoEP, training dies in step-2 backward for any MoE model with
`num_experts * hidden_size > stage3_param_persistence_threshold`:

```
RuntimeError: size mismatch, got input (2048), mat (2048x128), vec (0)
  at deepspeed/runtime/zero/linear.py:126, in backward
```

`mat (2048x128)` is `[tokens, num_experts]` -- the router gate. `vec (0)` is its weight, zero
elements, the placeholder ZeRO-3 leaves after releasing a partitioned parameter.

`mark_persistent_parameters` (`parameter_offload.py:318`) pins a parameter only when
`param.ds_numel <= param_threshold` (default 100,000). AutoEP's router gate is
`num_experts x hidden_size`:

| model | router numel | above 100k? |
|---|---|---|
| `MockMoETransformer` (the AutoEP tests) | 512 | no |
| Mixtral-8x22B | 49,152 | no |
| GLM-4.5-Air, Qwen3-235B-A22B | 524,288 | **yes** |
| MiniMax-M3 | 786,432 | **yes** |
| DeepSeek-V3 / V3.2, GLM-5.2 | 1.6M-1.8M | **yes** |

Neither configuration the existing tests exercise is above the threshold, which is why this shipped.

Step 1 succeeds and step 2 fails, consistent with ZeRO-3 recording its parameter trace on the first
iteration and switching to trace-driven prefetch/release from the second.

## Evidence that the threshold is the trigger

Two runs, identical except `stage3_param_persistence_threshold`. GLM-4.5-Air @4 layers (128 experts,
hidden 4096 -> router 524,288), 8x H200, ZeRO-3, `autoep_size=8`, seq 2048, AC off. Same seed --
both report `Step 1, Loss: 12.784355`.

| threshold | router vs threshold | result |
|---|---|---|
| 100,000 (default) | above -> release candidate | **FAILED**, `vec (0)` after 1 step |
| 1,000,000 | below -> pinned | **COMPLETED**, 15/15 steps, 103,542 tok/s |

## Fix

An opt-in persistence marker a module-replacing transform can set:

```python
# deepspeed/runtime/zero/parameter_offload.py
if param.ds_numel <= param_threshold or getattr(param, "ds_force_persist", False):
```

set by AutoEP on router parameters only:

```python
# deepspeed/module_inject/auto_ep_layer.py
param.ds_force_persist = True
```

Cost is `num_layers * num_experts * hidden * 2` bytes -- about 98 MB for a 94-layer/128-expert
model -- for a tensor needed on every forward and backward.

## Verification

Same config as the failing run, with the fix:

| run | fix | result |
|---|---|---|
| 28722 | none | **FAILED** -- `vec (0)`, 1 step |
| 28724 | `ds_force_persist` | **COMPLETED** -- 15/15 steps, 104,717 tok/s |

Also exercised at scale on this branch's lineage: Qwen3-235B-A22B (235B, 64 GPUs) and GLM-5.2
(745B, 64 GPUs, `autoep_size=32`, CPU optimizer offload), both training to completion.

## Alternatives considered

**Add `AutoEPMoELayer` to `DEFAULT_LEAF_MODULE_CLASSES`.** Works -- verified independently at
108,833 tok/s with no `leaf_module` entry in the user config -- but escalates the whole MoE block to
a leaf, coarsening gather granularity for the experts too. The targeted marker leaves expert
gathering unchanged.

**`memory_efficient_linear: false`.** Not a fix. It moves the failure: step 1 then succeeds and step
2 fails elsewhere with `The size of tensor a (0) must match the size of tensor b (4096)`. Worth
noting because it looks like a fix if you stop at the first green step.

## Note on test coverage

The existing AutoEP tests cannot catch this -- their router is 512 elements, ~200x below the
threshold. A regression test needs both `num_experts * hidden_size > 100_000` (e.g.
`num_experts=64, hidden_size=2048` = 131,072) **and** more than one step, since step 1 passes. In our
testing a mock containing only MoE blocks did not reproduce it even above the threshold; the release
appears to need a full transformer execution trace, so a regression test may need a more complete
model than the current mock.
