### PR TITLE
Use the val argument in mask_nan_or_inf_with_val_inplace

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -882,7 +882,7 @@ def mask_nan_or_inf_with_val_inplace(input, device=None, val=-1.):
     norm_is_inf = input.isinf()
     norm_is_nan = input.isnan()
     inf_or_nan = norm_is_nan.logical_or(norm_is_inf)
-    err = torch.tensor(-1.0, device=device, dtype=torch.float)
+    err = torch.tensor(val, device=device, dtype=torch.float)
     input.masked_fill_(inf_or_nan, err)
 
 

--- a/tests/unit/runtime/test_runtime_utils.py
+++ b/tests/unit/runtime/test_runtime_utils.py
@@ -154,3 +154,16 @@ def test_count_used_parameters_enables_grad_for_grad_acc_lookup(monkeypatch):
     loss.backward()
     assert seen["lookup_calls"] > 0
     assert "count" in seen
+
+
+def test_mask_nan_or_inf_with_val_inplace_honors_val():
+    """The masked entries should take the requested value, not always -1."""
+    for val in (0.0, 1.5, -1.0):
+        tensor = torch.tensor([float('nan'), float('inf'), float('-inf'), 2.0])
+        ds_utils.mask_nan_or_inf_with_val_inplace(tensor, device=tensor.device, val=val)
+        assert tensor.tolist() == [val, val, val, 2.0]
+
+    # The documented default stays -1.
+    tensor = torch.tensor([float('nan'), 2.0])
+    ds_utils.mask_nan_or_inf_with_val_inplace(tensor, device=tensor.device)
+    assert tensor.tolist() == [-1.0, 2.0]


### PR DESCRIPTION
## What

`mask_nan_or_inf_with_val_inplace(input, device=None, val=-1.)` accepts `val` and then builds the fill tensor from a hardcoded `-1.0`, so the argument is dead:

```python
t = torch.tensor([float('nan'), 2.0])
mask_nan_or_inf_with_val_inplace(t, device=t.device, val=0.0)
# t -> tensor([-1.,  2.])   expected tensor([0., 2.])
```

## Why it is there

`val` arrived with the helper in #7184, which folded three copies of the inf/nan masking (`runtime/utils.py`, `zero/stage3.py`, `zero/stage_1_and_2.py`) into one function. The parameter is the knob that refactor introduced, and the body kept the literal from the code it replaced.

## Fix

One line: build `err` from `val`.

All three in-tree callers use the default, and `-1.` is the same float the body hardcoded, so the gradient-norm paths are bit-identical.

## Test

New `test_mask_nan_or_inf_with_val_inplace_honors_val` in `tests/unit/runtime/test_runtime_utils.py`, covering nan / +inf / -inf for several `val`s plus the unchanged default.

```
$ python -m pytest unit/runtime/test_runtime_utils.py -k "mask_nan_or_inf or call_to_str or count_used_parameters"
# before: 1 failed, 2 passed
#   E  assert [-1.0, -1.0, -1.0, 2.0] == [0.0, 0.0, 0.0, 2.0]
# after:  3 passed
```

The `TestClipGradNorm*` / `TestCheckOverflow` cases in the same file are `DistributedTest` and were deselected on this CPU-only box; they do not touch `val`.
