### PR TITLE
Preallocate the static KV cache with config.head_dim

### DIFF
--- a/deepspeed/utils/static_cache.py
+++ b/deepspeed/utils/static_cache.py
@@ -163,7 +163,9 @@ class DeepSpeedStaticCache:
 
         if dtype is not None and device is not None and batch_size > 0:
             num_heads = getattr(text_config, "num_key_value_heads", getattr(text_config, "num_attention_heads", 1))
-            head_dim = getattr(text_config, "hidden_size", 1) // getattr(text_config, "num_attention_heads", 1)
+            # head_dim is not always hidden_size // num_attention_heads, so prefer the config value
+            head_dim = getattr(text_config, "head_dim", None) or (getattr(text_config, "hidden_size", 1) //
+                                                                  getattr(text_config, "num_attention_heads", 1))
             self.early_initialization(batch_size, num_heads, head_dim, dtype, device)
 
     @property

--- a/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
+++ b/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
@@ -21,6 +21,7 @@ from deepspeed.runtime.rollout.hybrid_engine_rollout import (
     HybridEngineRollout,
     HybridEngineRolloutConfig,
 )
+from deepspeed.utils.static_cache import DeepSpeedStaticCache
 
 
 def _make_engine():
@@ -503,3 +504,27 @@ def test_generate_accepts_zero_pad_token_id():
     rollout.generate(req, sampling)
 
     assert engine.module.generate.call_args.kwargs['pad_token_id'] == 0
+
+
+def _cache_config(head_dim=None):
+    config = SimpleNamespace(num_hidden_layers=2, hidden_size=64, num_attention_heads=4, num_key_value_heads=2)
+    if head_dim is not None:
+        config.head_dim = head_dim
+    return config
+
+
+def test_static_cache_preallocates_with_config_head_dim():
+    cache = DeepSpeedStaticCache(_cache_config(head_dim=32),
+                                 batch_size=1,
+                                 max_cache_len=8,
+                                 device="cpu",
+                                 dtype=torch.float32)
+
+    assert tuple(cache.layers[0].keys.shape) == (1, 2, 8, 32)
+    assert tuple(cache.layers[0].values.shape) == (1, 2, 8, 32)
+
+
+def test_static_cache_falls_back_to_derived_head_dim():
+    cache = DeepSpeedStaticCache(_cache_config(), batch_size=1, max_cache_len=8, device="cpu", dtype=torch.float32)
+
+    assert tuple(cache.layers[0].keys.shape) == (1, 2, 8, 16)


### PR DESCRIPTION
`DeepSpeedStaticCache` preallocates its KV buffers with `hidden_size // num_attention_heads`. Models that set `head_dim` explicitly (Qwen3, Gemma, Llama 4) break that identity, so the buffers get the wrong last dimension and the prefill copy in `_generate_graph` dies before the graph is ever captured:

```
RuntimeError: The size of tensor a (16) must match the size of tensor b (32) at non-singleton dimension 3
```

Now it reads `head_dim` off the config and falls back to the division when the attribute is missing or None (older configs set it to None).

To reproduce on CPU: a tiny Qwen3 with `hidden_size=64`, `num_attention_heads=4`, `head_dim=32`, prefilled through the HF `StaticCache` the way `_generate_graph` does, then the copy loop at `hybrid_engine_rollout.py:346` verbatim. The prefill cache comes back `(1, 2, 8, 32)` and `DeepSpeedStaticCache` allocates `(1, 2, 8, 16)`. With `head_dim=16` the same script is fine on both sides, which is why nothing has caught this so far.

Two tests in `tests/unit/runtime/rollout/`. The `head_dim` one fails on master. No GPU on this machine, so the capture and replay path itself is not exercised, only the allocation and the copy that feeds it.
