### PR TITLE
Persist ZeRO-3 HybridMegatron QKV layout changes

### DIFF
--- a/deepspeed/module_inject/containers/features/hybrid_megatron.py
+++ b/deepspeed/module_inject/containers/features/hybrid_megatron.py
@@ -43,7 +43,9 @@ class HybridMegatronContainer(MegatronContainer, HybridEngineContainer):
             param_list = [self.qkvw, self.qkvb]
             non_active_params = [param for param in param_list if (hasattr(param, 'ds_id') and \
                             param.ds_status == ZeroParamStatus.NOT_AVAILABLE)]
-            with GatheredParameters(non_active_params):
+            # Persist the QKV layout mutation when ZeRO-3 repartitions the
+            # gathered parameters on context exit.
+            with GatheredParameters(non_active_params, modifier_rank=0):
                 self._align_qkv(self.qkvw)
                 self._align_qkv(self.qkvb)
         else:
@@ -79,7 +81,8 @@ class HybridMegatronContainer(MegatronContainer, HybridEngineContainer):
             param_list = [self.qkvw, self.qkvb]
             non_active_params = [param for param in param_list if (hasattr(param, 'ds_id') and \
                             param.ds_status == ZeroParamStatus.NOT_AVAILABLE)]
-            with GatheredParameters(non_active_params):
+            # Persist the inverse mutation before returning to training.
+            with GatheredParameters(non_active_params, modifier_rank=0):
                 self._partition_qkv(self.qkvw)
                 self._partition_qkv(self.qkvb)
         else:

--- a/tests/unit/module_inject/test_hybrid_megatron.py
+++ b/tests/unit/module_inject/test_hybrid_megatron.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import torch
+
+from deepspeed.module_inject.containers.gptneox import DS_GPTNEOXContainer
+from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+
+
+class _RecordedGather:
+
+    calls = []
+
+    def __init__(self, params, modifier_rank=None):
+        self.params = params
+        self.modifier_rank = modifier_rank
+
+    def __enter__(self):
+        self.calls.append(self.modifier_rank)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+def _partitioned_parameter(values):
+    parameter = torch.nn.Parameter(values)
+    parameter.ds_id = 0
+    parameter.ds_status = ZeroParamStatus.NOT_AVAILABLE
+    return parameter
+
+
+def test_zero3_qkv_layout_round_trip_persists_mutation(monkeypatch):
+    monkeypatch.setattr("deepspeed.runtime.zero.GatheredParameters", _RecordedGather)
+    _RecordedGather.calls.clear()
+
+    container = object.__new__(DS_GPTNEOXContainer)
+    container.num_attention_heads = 2
+    container.qkvw = _partitioned_parameter(torch.arange(48, dtype=torch.float32).reshape(12, 4))
+    container.qkvb = _partitioned_parameter(torch.arange(12, dtype=torch.float32))
+
+    initial_weight = container.qkvw.detach().clone()
+    initial_bias = container.qkvb.detach().clone()
+
+    container.transform_for_inference()
+    assert not torch.equal(container.qkvw, initial_weight)
+    assert not torch.equal(container.qkvb, initial_bias)
+
+    container.transform_for_training()
+    assert torch.equal(container.qkvw, initial_weight)
+    assert torch.equal(container.qkvb, initial_bias)
+    assert _RecordedGather.calls == [0, 0]


### PR DESCRIPTION
## Summary

- persist GPT-NeoX/Megatron QKV inference-layout mutations when ZeRO-3 repartitions gathered parameters
- persist the inverse layout mutation when returning to training
- add a focused QKV layout round-trip regression test

`GatheredParameters` needs `modifier_rank` when a gathered full parameter is modified. Without it, the transformed QKV tensor is not reliably broadcast before repartitioning, and the inference operator can interpret the original head-interleaved GPT-NeoX layout as contiguous Q/K/V.

Closes #8391.

## Validation

- DeepSpeed pre-commit checks: passed
- focused unit test on AMD MI300X: `1 passed`
- same-weight Pythia diagnostic after the fix: transformed QKV `max_abs=0`; native and HE first token both `187`
- 20-step Pythia HE training completed on 2 x MI250, 8 x MI250, and 8 x MI300X without layout-round-trip recurrence

## Scope

This PR intentionally contains only the ZeRO-3 QKV mutation-persistence fix. A separate compatibility issue in recent Transformers (`GPTNeoXAttention.hidden_size` removal) can prevent current master from reaching injection in that environment and is not bundled here.

Exact head: `73165a4a04dcc4a6c0bcc1677880f04bf2d0b841`.