### PR TITLE
Skip fp16-config tests on accelerators without fp16 support

### DIFF
--- a/tests/unit/runtime/test_multiple_models.py
+++ b/tests/unit/runtime/test_multiple_models.py
@@ -7,6 +7,7 @@ import pytest
 import deepspeed
 import deepspeed.comm as dist
 import torch
+from deepspeed import get_accelerator
 from unit.common import DistributedTest
 from unit.simple_model import SimpleModel, random_dataloader
 
@@ -76,6 +77,7 @@ class TestMultipleModels(DistributedTest):
     @pytest.mark.parametrize('fp32_grad_accum', [False, True])
     @pytest.mark.parametrize('contiguous_gradients', [False, True])
     @pytest.mark.parametrize('overlap_comm', [False, True])
+    @pytest.mark.skipif(not get_accelerator().is_fp16_supported(), reason="fp16 is not supported on this accelerator")
     def test_zero_optimizer(self, num_models, shared_loss, zero_stage, fp32_grad_accum, contiguous_gradients,
                             overlap_comm):
         config_dict = {

--- a/tests/unit/v1/moe/test_moe.py
+++ b/tests/unit/v1/moe/test_moe.py
@@ -24,6 +24,7 @@ from deepspeed.utils.torch import required_torch_version
 class TestSimpleMoE(DistributedTest):
     world_size = 2
 
+    @pytest.mark.skipif(not get_accelerator().is_fp16_supported(), reason="fp16 is not supported on this accelerator")
     def test(self, zero_stage):
         if not required_torch_version(min_version=1.8):
             pytest.skip("DeepSpeed MoE tests need torch 1.8 or higher to run correctly")
@@ -66,6 +67,7 @@ class TestSimpleMoE(DistributedTest):
 class TestMoE(DistributedTest):
     world_size = 4
 
+    @pytest.mark.skipif(not get_accelerator().is_fp16_supported(), reason="fp16 is not supported on this accelerator")
     def test(self, ep_size, zero_stage, use_residual):
         if not required_torch_version(min_version=1.8):
             pytest.skip("DeepSpeed MoE tests need torch 1.8 or higher to run correctly")
@@ -164,6 +166,7 @@ class TestMoE(DistributedTest):
 class TestPRMoE(DistributedTest):
     world_size = 4
 
+    @pytest.mark.skipif(not get_accelerator().is_fp16_supported(), reason="fp16 is not supported on this accelerator")
     def test(self, ep_size, use_residual):
         if not required_torch_version(min_version=1.8):
             pytest.skip("DeepSpeed MoE tests need torch 1.8 or higher to run correctly")

--- a/tests/unit/v1/moe/test_moe_tp.py
+++ b/tests/unit/v1/moe/test_moe_tp.py
@@ -57,6 +57,7 @@ class MPU():
 class TestMOETensorParallel(DistributedTest):
     world_size = 4
 
+    @pytest.mark.skipif(not get_accelerator().is_fp16_supported(), reason="fp16 is not supported on this accelerator")
     def test(self, ep_size, tp_size, enable_expert_tp, use_residual):
         # TODO: replace this with a true parallel mlp in the future
         # and run convergence tests


### PR DESCRIPTION
## Problem

`TestMultipleModels::test_zero_optimizer`, `TestSimpleMoE`, `TestMoE`, `TestPRMoE`, and `TestMOETensorParallel` hardcode `"fp16": {"enabled": True}` in their DeepSpeed configs. The engine's sanity check then raises:

```
ValueError: Type fp16 is not supported on your device.
```

on any accelerator whose `is_fp16_supported()` is false. On CPU that maps to the AVX512-FP16 capability of the host, and GitHub's `ubuntu-24.04` runners are hardware-heterogeneous: **the same test passes on one runner and fails on the next** (observed directly in #8381 — 146 failures appeared on one runner generation and none on another, with identical code).

## Change

Skip these tests via a capability query:

```python
@pytest.mark.skipif(not get_accelerator().is_fp16_supported(), reason="fp16 is not supported on this accelerator")
```

- capability only, no accelerator-name matching;
- mirrors the existing bf16 skip precedent in `tests/unit/v1/zero/test_zero_user_backward.py`;
- deliberately a **skip** rather than silently running bf16 — these tests exist to cover the fp16 paths.

## Validation

Validated as part of the multi-rank CPU CI experiment in #8381: the 146 hardware-lottery failures became deterministic skips, zero regressions on previously-passing tests.