### PR TITLE
Probe the device module for train_cifar's fork_rng device entries

### DIFF
--- a/tests/unit/alexnet_model.py
+++ b/tests/unit/alexnet_model.py
@@ -128,7 +128,11 @@ def train_cifar(model, config, num_steps=400, average_dp_losses=True, fp16=True,
         fork_kwargs = {"device_type": get_accelerator().device_name()}
     else:
         fork_kwargs = {}
-    with get_accelerator().random().fork_rng(devices=[get_accelerator().current_device_name()], **fork_kwargs):
+    # fork_rng only needs entries for backends with per-device generators: the global
+    # CPU RNG is always saved, and torch.cpu has no get_rng_state to call anyway.
+    device_mod = torch.get_device_module(get_accelerator().device_name())
+    fork_devices = [get_accelerator().current_device_name()] if hasattr(device_mod, 'get_rng_state') else []
+    with get_accelerator().random().fork_rng(devices=fork_devices, **fork_kwargs):
         ds_utils.set_random_seed(seed)
 
         # disable dropout


### PR DESCRIPTION
## Description

`train_cifar` unconditionally passed `devices=[get_accelerator().current_device_name()]` to `fork_rng`. On CPU that becomes `devices=['cpu']`, and `torch.cpu` has no `get_rng_state`, so the context manager raises `AttributeError` before the test body starts — the CPU RNG lives in the global generator that `fork_rng` already forks.

Probe the device module for a per-device RNG instead of matching accelerator names:

- backends whose device module has `get_rng_state` (e.g. cuda) behave exactly as before;
- backends without one (cpu) pass `devices=[]`, which changes nothing beyond the global-RNG save/restore `fork_rng` always performs.

The crash is only reachable from the multi-rank tests that call `train_cifar` (`test_onebit.py`, `test_pipe.py`), which the CPU runner currently skips at the device gate; it was exposed by the `LOCAL_SIZE=4` experiment in #8381. Sibling fixes from the same series landed as #8397, #8398 and #8399.

## Test plan

- pre-commit (yapf / flake8 / check-torchdist / codespell) passes on the changed file;
- exercised under the `LOCAL_SIZE=4` multi-rank CPU run tracked in #8381: the `test_onebit` / `test_pipe` callers got past `fork_rng` and into their test bodies with this exact change.