### PR TITLE
Forward the inputs DSUNet._forward accepts to the UNet

### DIFF
--- a/deepspeed/model_implementations/diffusers/unet.py
+++ b/deepspeed/model_implementations/diffusers/unet.py
@@ -71,11 +71,12 @@ class DSUNet(CUDAGraph, torch.nn.Module):
                  cross_attention_kwargs=None,
                  timestep_cond=None,
                  added_cond_kwargs=None):
-        if cross_attention_kwargs:
-            return self.unet(sample,
-                             timestamp,
-                             encoder_hidden_states,
-                             return_dict,
-                             cross_attention_kwargs=cross_attention_kwargs)
-        else:
-            return self.unet(sample, timestamp, encoder_hidden_states, return_dict)
+        # Everything after encoder_hidden_states goes in by keyword: the fourth positional
+        # parameter of UNet2DConditionModel.forward is class_labels, not return_dict.
+        return self.unet(sample,
+                         timestamp,
+                         encoder_hidden_states,
+                         timestep_cond=timestep_cond,
+                         cross_attention_kwargs=cross_attention_kwargs,
+                         added_cond_kwargs=added_cond_kwargs,
+                         return_dict=return_dict)

--- a/tests/unit/inference/test_stable_diffusion.py
+++ b/tests/unit/inference/test_stable_diffusion.py
@@ -46,3 +46,67 @@ class TestStableDiffusion(DistributedTest):
 
         # RMSE threshold value is arbitrary, may need to adjust as needed
         assert rmse_value <= 0.01
+
+
+class _RecordingUNet(torch.nn.Module):
+    """Records what it is called with, in UNet2DConditionModel.forward's parameter order."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(2, 2)
+        self.in_channels = 4
+        self.config = {}
+        self.seen = None
+
+    @property
+    def device(self):
+        return torch.device("cpu")
+
+    @property
+    def dtype(self):
+        return torch.float32
+
+    def forward(self,
+                sample,
+                timestep,
+                encoder_hidden_states,
+                class_labels=None,
+                timestep_cond=None,
+                attention_mask=None,
+                cross_attention_kwargs=None,
+                added_cond_kwargs=None,
+                return_dict=True):
+        self.seen = {
+            "class_labels": class_labels,
+            "timestep_cond": timestep_cond,
+            "cross_attention_kwargs": cross_attention_kwargs,
+            "added_cond_kwargs": added_cond_kwargs,
+            "return_dict": return_dict,
+        }
+        return sample
+
+
+def test_ds_unet_forwards_the_inputs_it_accepts():
+    # DSUNet._forward accepts timestep_cond and added_cond_kwargs, and passed neither on;
+    # return_dict went in positionally, where UNet2DConditionModel.forward reads class_labels.
+    from deepspeed.model_implementations.diffusers.unet import DSUNet
+
+    unet = _RecordingUNet()
+    ds_unet = DSUNet(unet, enable_cuda_graph=False)
+
+    timestep_cond = torch.ones(1, 1)
+    added_cond_kwargs = {"text_embeds": torch.zeros(1, 2)}
+    ds_unet(torch.zeros(1, 2),
+            0,
+            torch.zeros(1, 2),
+            return_dict=False,
+            timestep_cond=timestep_cond,
+            cross_attention_kwargs={"scale": 0.5},
+            added_cond_kwargs=added_cond_kwargs)
+
+    seen = unet.seen
+    assert seen["return_dict"] is False
+    assert seen["class_labels"] is None
+    assert seen["timestep_cond"] is timestep_cond
+    assert seen["added_cond_kwargs"] is added_cond_kwargs
+    assert seen["cross_attention_kwargs"] == {"scale": 0.5}


### PR DESCRIPTION
### What is wrong

`DSUNet._forward` accepts `timestep_cond` and `added_cond_kwargs` and forwards neither, and it passes `return_dict` positionally:

```python
return self.unet(sample, timestamp, encoder_hidden_states, return_dict)
```

`UNet2DConditionModel.forward`'s fourth positional parameter is **`class_labels`**, not `return_dict`:

```python
def forward(self, sample, timestep, encoder_hidden_states,
            class_labels=None, timestep_cond=None, attention_mask=None,
            cross_attention_kwargs=None, added_cond_kwargs=None, ..., return_dict=True)
```

Driving the wrapper with a stub that mirrors that signature, with `enable_cuda_graph=False` so no accelerator is needed:

| caller passes | UNet receives on master | UNet receives with this PR |
|---|---|---|
| `return_dict=False` | `class_labels=False`, `return_dict=True` | `class_labels=None`, `return_dict=False` |
| `timestep_cond=<tensor>` | `None` | the tensor |
| `added_cond_kwargs={...}` | `None` | the dict |

SDXL's UNet requires `added_cond_kwargs` (`addition_embed_type == "text_time"`), and `timestep_cond` is what a guidance-distilled model reads, so both are dropped exactly where they matter.

### What changed

Pass everything after `encoder_hidden_states` by keyword. The `if cross_attention_kwargs:` branch goes with it: `cross_attention_kwargs=None` is what omitting the argument already meant, and both of its arms carried the same positional mistake.

### Test

`test_ds_unet_forwards_the_inputs_it_accepts` in `tests/unit/inference/test_stable_diffusion.py`, a plain function alongside the existing `TestStableDiffusion` class. It drives `DSUNet` with a recording stub, needs no accelerator and downloads no model.

```
$ pytest tests/unit/inference/test_stable_diffusion.py -k ds_unet -q
master      1 failed    assert True is False   (return_dict never reached the UNet)
this PR     1 passed
```

`yapf --style .style.yapf --diff` is clean on both files.