### PR TITLE
fix: validate max_out_tokens and min_out_tokens are positive

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -321,3 +321,15 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
         if field_value and not deepspeed.HAS_TRITON:
             raise ValueError('Triton needs to be installed to use deepspeed with triton kernels')
         return field_value
+
+    @field_validator("max_out_tokens")
+    def validate_max_out_tokens(cls, field_value):
+        if field_value <= 0:
+            raise ValueError(f"max_out_tokens must be positive, got {field_value}")
+        return field_value
+
+    @field_validator("min_out_tokens")
+    def validate_min_out_tokens(cls, field_value):
+        if field_value <= 0:
+            raise ValueError(f"min_out_tokens must be positive, got {field_value}")
+        return field_value


### PR DESCRIPTION
## Description

Fixes #8339: DeepSpeed accepts negative max_out_tokens and fails generation requests at runtime

Added field validators for `max_out_tokens` and `min_out_tokens` to ensure they are positive values. This catches invalid configuration early during initialization rather than failing at runtime with a confusing error message.

## Changes

Added two `@field_validator` decorators to `deepspeed/inference/config.py`:

1. `validate_max_out_tokens`: Raises `ValueError` if `max_out_tokens <= 0`
2. `validate_min_out_tokens`: Raises `ValueError` if `min_out_tokens <= 0`

## Testing

The fix can be verified by attempting to create an inference engine with negative values:

```python
import deepspeed
engine = deepspeed.init_inference(model, config={"max_out_tokens": -1})
# Now raises: ValueError: max_out_tokens must be positive, got -1
```

Previously this would only fail later at generation time with a confusing error message.
