### PR TITLE
fix: remove dead gradient norm fallback

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -1584,11 +1584,8 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
 
     def set_norm_for_param_grad_in_gpu(self, param):
         param_id = self.get_param_id(param)
-        grad_accum = self.get_param_gradient_attribute(param)
-        if grad_accum is None:
-            accumulated_grad = param.grad
-        else:
-            accumulated_grad = grad_accum
+        accumulated_grad = self.get_param_gradient_attribute(param)
+        assert accumulated_grad is not None, "Gradient attribute is missing for a parameter being finalized"
 
         [i, source_offset, dest_offset, num_elements] = self.grad_position[param_id]
 

--- a/tests/unit/v1/zero/test_zero.py
+++ b/tests/unit/v1/zero/test_zero.py
@@ -24,6 +24,7 @@ import deepspeed
 from deepspeed.runtime.engine import DeepSpeedEngine
 from deepspeed.runtime.bf16_optimizer import BF16_Optimizer
 from deepspeed.runtime.zero.partition_parameters import ZeroParamStatus
+from deepspeed.runtime.zero.stage_1_and_2 import DeepSpeedZeroOptimizer
 from deepspeed.utils.zero_to_fp32 import load_state_dict_from_zero_checkpoint
 from deepspeed.runtime.zero.utils import ZeRORuntimeException
 from deepspeed.accelerator import get_accelerator
@@ -2018,3 +2019,36 @@ class TestZero3ClientModuleID(DistributedTest):
         post_init_m_id = model.id
         assert pre_init_m_id == post_init_m_id
         model.destroy()
+
+
+class TestSetNormForParamGradInGPU:
+
+    @pytest.mark.parametrize("use_grad_accum_attribute", [False, True])
+    def test_uses_selected_gradient_attribute(self, use_grad_accum_attribute):
+        param = Parameter(torch.ones(2))
+        param.grad = torch.tensor([3.0, 4.0]) if not use_grad_accum_attribute else None
+        param.grad_accum = torch.tensor([3.0, 4.0]) if use_grad_accum_attribute else None
+
+        optimizer = object.__new__(DeepSpeedZeroOptimizer)
+        optimizer.use_grad_accum_attribute = use_grad_accum_attribute
+        optimizer.param_id = {id(param): 0}
+        optimizer.grad_position = {0: [0, 0, 0, param.numel()]}
+        optimizer.norm_for_param_grads = {}
+
+        optimizer.set_norm_for_param_grad_in_gpu(param)
+
+        torch.testing.assert_close(optimizer.norm_for_param_grads[0], torch.tensor(5.0, dtype=torch.double))
+
+    def test_does_not_fallback_to_param_grad(self):
+        param = Parameter(torch.ones(2))
+        param.grad = torch.tensor([3.0, 4.0])
+        param.grad_accum = None
+
+        optimizer = object.__new__(DeepSpeedZeroOptimizer)
+        optimizer.use_grad_accum_attribute = True
+        optimizer.param_id = {id(param): 0}
+        optimizer.grad_position = {0: [0, 0, 0, param.numel()]}
+        optimizer.norm_for_param_grads = {}
+
+        with pytest.raises(AssertionError, match="Gradient attribute is missing"):
+            optimizer.set_norm_for_param_grad_in_gpu(param)


### PR DESCRIPTION
## Summary

Fixes #8371.

`set_norm_for_param_grad_in_gpu` previously fell back to `param.grad` when the
configured gradient attribute was `None`. That fallback is invalid for the
`grad_accum` path because the source gradient has already been moved and
cleared. The method now uses the selected attribute directly and reports a
clear assertion if the required gradient is missing.

## Tests

- `pre-commit run --files deepspeed/runtime/zero/stage_1_and_2.py tests/unit/v1/zero/test_zero.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 py -3 -m pytest -q tests/unit/v1/zero/test_zero.py::TestSetNormForParamGradInGPU` (3 passed)
- `py -3 -m compileall -q deepspeed/runtime/zero/stage_1_and_2.py tests/unit/v1/zero/test_zero.py`
- `git diff --check`

The regression test covers both configured gradient attributes and verifies
that the stale `param.grad` fallback is not used.

AI assistance was used for drafting and local validation; I reviewed the
implementation and take responsibility for the submitted changes.
