### PR TITLE
[Workflow] run modal GPU workflows only from the merge queue

### DIFF
--- a/.github/workflows/TEST_SELECTION.md
+++ b/.github/workflows/TEST_SELECTION.md
@@ -25,8 +25,9 @@ one config — see [Adding a workflow](#adding-a-new-workflow).
   the import graph from your changed files to the impacted tests, and writes the
   list to `ci/.test_selection/test_list.txt`.
 - The trusted controller validates that list, then fetches, installs, and tests
-  the exact candidate SHA inside a no-secret Modal Sandbox. `push` to `master`
-  and manual runs always run everything.
+  the exact candidate SHA inside a no-secret Modal Sandbox. The Sandbox runs
+  only for merge queue entries, `push` to `master` (always the full suite), and
+  manual runs — a plain PR event never spends Modal quota.
 - It is **fail-safe**: anything it can't reason about safely → run the *full* suite.
   It never silently runs *fewer* tests than reality.
 - Preview locally:
@@ -63,12 +64,12 @@ The design is a small, self-contained take on HuggingFace `transformers`'
 ### Job flow
 
 ```
-                pull_request_target / push / workflow_dispatch
+           pull_request_target / merge_group / push / workflow_dispatch
                                   │
                     ┌─────────────┴─────────────┐
                     │        collect-tests       │   (no secrets)
                     │  checkout exact base SHA   │
-                    │  public-fetch exact PR SHA │
+                    │ public-fetch exact head SHA│
                     │  self-test the fetcher     │
                     │  parse candidate as data   │
                     │   → mode (all|subset|none) │
@@ -83,7 +84,7 @@ The design is a small, self-contained take on HuggingFace `transformers`'
                     │  validate mode/list + SHA   │
                     │  create one L40S:2 Sandbox  │
                     │    no secrets or mounts     │
-                    │    fetch exact PR SHA       │
+                    │    fetch exact head SHA      │
                     │    install + run pytest     │
                     │  terminate/observe Sandbox  │
                     └────────────────────────────┘
@@ -95,6 +96,14 @@ The design is a small, self-contained take on HuggingFace `transformers`'
   skipped dependent job counts as success here).
 - **`subset`** → `deploy` runs pytest on exactly the impacted files.
 - **`all`** → `deploy` runs the whole scope (`tests/unit/v1`).
+
+Independent of `mode`, `deploy` is also skipped on `pull_request_target` runs,
+so pushing to a PR never spends Modal quota — the `collect-tests` summary still
+previews what the queue will run. The Sandbox actually executes on
+`merge_group` (the merged tree, gating the merge), `push` to `master`, and
+`workflow_dispatch`. On `merge_group` the candidate is the merge-group commit
+in the base repository, diffed against the queue's base SHA, so the selection
+covers exactly what the entry would introduce.
 
 
 ## How a decision is made
@@ -280,6 +289,15 @@ context and the `deploy` controller authenticates to Modal. The trust boundary i
   mitigation, **not** the trust boundary. Exact trusted base code plus Sandbox
   isolation is the primary protection.
 
+**`merge_group` runs are a separate trust context.** GitHub runs a queued
+entry's workflows from the merge-group commit — the PR's merged tree — with
+access to secrets, so the "trusted base revision" property above holds for
+`pull_request_target` runs, not for the queue. This is inherent to GitHub's
+merge queue: an entry only reaches the queue after the PR's required checks
+passed, and the queue run is what gates the merge. Review a PR that changes
+`ci/*` or these workflows knowing its merged version will run there with the
+Modal token.
+
 > **Consequence:** changes to `ci/*` (including `tests_fetcher.py` itself) take
 > effect under `pull_request_target` only after they're **merged**. A PR that
 > changes this launcher cannot prove its new PR-triggered end-to-end path by
@@ -339,4 +357,6 @@ are still publicly reachable. Do not replace this with a moving branch fallback.
 **Why didn't this PR exercise its new `pull_request_target` controller?**
 GitHub intentionally runs that event's workflow from the trusted base. The new
 controller becomes the trusted code only after merge; before then, rely on the
-focused static/unit evidence described in the security model.
+focused static/unit evidence described in the security model. (The merge-queue
+run *does* use the PR's merged controller, so `ci/*` changes are first
+exercised live there.)

--- a/.github/workflows/TEST_SELECTION.md
+++ b/.github/workflows/TEST_SELECTION.md
@@ -290,13 +290,15 @@ context and the `deploy` controller authenticates to Modal. The trust boundary i
   isolation is the primary protection.
 
 **`merge_group` runs are a separate trust context.** GitHub runs a queued
-entry's workflows from the merge-group commit — the PR's merged tree — with
-access to secrets, so the "trusted base revision" property above holds for
-`pull_request_target` runs, not for the queue. This is inherent to GitHub's
-merge queue: an entry only reaches the queue after the PR's required checks
-passed, and the queue run is what gates the merge. Review a PR that changes
-`ci/*` or these workflows knowing its merged version will run there with the
-Modal token.
+entry's workflows from the merge-group commit — the PR's merged tree — so the
+workflow YAML itself is candidate-controlled. The jobs restore the repo's
+invariant by resolving every GitHub-side checkout to the trusted base revision
+(`merge_group.base_sha`): the selector, the controller, and the accelerate
+launcher all come from master there, and the merged candidate enters only as
+validated git data (fetched by exact SHA into a separate root) or inside the
+no-secret Modal Sandbox. The residual exposure — a queued PR rewriting the
+workflow YAML itself to echo secrets — is inherent to GitHub's merge queue;
+review PRs that touch `.github/workflows/*` with that in mind.
 
 > **Consequence:** changes to `ci/*` (including `tests_fetcher.py` itself) take
 > effect under `pull_request_target` only after they're **merged**. A PR that

--- a/.github/workflows/modal-accelerate.yml
+++ b/.github/workflows/modal-accelerate.yml
@@ -14,7 +14,9 @@ name: modal-accelerate
 #
 # Modal GPUs are a limited quota, so the deploy job only runs for merge queue entries, pushes to
 # master, and manual runs. Plain PR events keep the job skipped (which still satisfies the
-# Required status); the merge queue re-runs it on the merged tree.
+# Required status); the merge queue re-runs it on the merged tree. On merge queue runs the
+# launcher (this checkout) stays on trusted master and the merged candidate is fetched as data,
+# so queued PR code never executes on this runner next to the Modal/HF tokens.
 
 
 on:
@@ -102,7 +104,26 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
         with:
+          # Trusted base revision on merge queue runs (master otherwise), so
+          # ci/accelerate.py holding the Modal/HF tokens is never queued-PR code.
+          ref: ${{ github.event.merge_group.base_sha || github.sha }}
           lfs: true
+
+      - name: Fetch merge queue candidate tree
+        if: github.event_name == 'merge_group'
+        env:
+          HEAD_REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+          BASE_REPOSITORY: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          CANDIDATE_ROOT: ${{ runner.temp }}/deepspeed-candidate
+        run: |
+          python3 ci/torch_latest.py checkout-candidate \
+            --head-repository "$HEAD_REPOSITORY" \
+            --head-sha "$HEAD_SHA" \
+            --base-repository "$BASE_REPOSITORY" \
+            --base-sha "$BASE_SHA" \
+            --destination "$CANDIDATE_ROOT"
 
       - name: Install Python
         uses: actions/setup-python@v7
@@ -116,5 +137,9 @@ jobs:
           uv pip install --system modal
 
       - name: Run tests
+        env:
+          # Tree under test: the fetched merge-group candidate on queue runs,
+          # empty (this checkout) everywhere else.
+          DS_CI_CANDIDATE_ROOT: ${{ github.event_name == 'merge_group' && format('{0}/deepspeed-candidate', runner.temp) || '' }}
         run: |
           modal run -m ci.accelerate

--- a/.github/workflows/modal-accelerate.yml
+++ b/.github/workflows/modal-accelerate.yml
@@ -12,6 +12,9 @@ name: modal-accelerate
 # collect-tests job to do the filtering for us so that the job can be skipped and satisfy the
 # Required status for PRs to pass.
 #
+# Modal GPUs are a limited quota, so the deploy job only runs for merge queue entries, pushes to
+# master, and manual runs. Plain PR events keep the job skipped (which still satisfies the
+# Required status); the merge queue re-runs it on the merged tree.
 
 
 on:
@@ -35,6 +38,14 @@ on:
     branches:
       - master
 
+  # Required checks must also trigger on merge queue entries, otherwise the
+  # merge fails waiting for a status that is never reported. This is the only
+  # PR-related event that spends Modal quota.
+  merge_group:
+    types: [checks_requested]
+    branches:
+      - master
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -55,6 +66,8 @@ jobs:
         with:
           lfs: true
 
+      # paths-filter v4.0.1+ covers merge_group natively (it diffs the event's
+      # base/head commits), so no extra inputs are needed here.
       - name: Filter changed files
         uses: dorny/paths-filter@v4
         id: filter
@@ -81,7 +94,10 @@ jobs:
       # and it too is then updated at https://github.com/deepspeedai/deepspeed/settings/secrets/actions
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
-    if: needs.collect-tests.outputs.deepspeed == 'true'
+    # Plain PR events keep this job skipped so they never spend Modal quota (a
+    # skipped dependent job still satisfies the Required status); the merge
+    # queue re-runs it on the merged tree.
+    if: needs.collect-tests.outputs.deepspeed == 'true' && github.event_name != 'pull_request_target'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -3,9 +3,10 @@ name: modal-torch-latest
 # This Required workflow selects tests on a no-secret GitHub runner, then tests
 # the exact candidate SHA inside a no-secret Modal Sandbox. Under
 # pull_request_target, every GitHub-side checkout and Python entrypoint comes
-# from the trusted base commit. The Sandbox only runs for merge queue entries,
-# pushes to master, and manual runs, so plain PR events never spend Modal quota.
-# See .github/workflows/TEST_SELECTION.md.
+# from the trusted base commit; merge queue runs resolve that trusted base from
+# merge_group.base_sha. The Sandbox only runs for merge queue entries, pushes to
+# master, and manual runs, so plain PR events never spend Modal quota. See
+# .github/workflows/TEST_SELECTION.md.
 
 on:
   workflow_dispatch:
@@ -73,7 +74,9 @@ jobs:
       - name: Checkout trusted workflow code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          # Trusted base revision for every event: the merge-group commit must
+          # never control the selector that runs on this GitHub runner.
+          ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
           fetch-depth: 1
           persist-credentials: false
           lfs: false
@@ -154,7 +157,9 @@ jobs:
       - name: Checkout trusted controller code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          # Trusted base revision for every event: the merge-group commit is
+          # only ever fetched by exact SHA inside the no-secret Sandbox.
+          ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
           fetch-depth: 1
           persist-credentials: false
           lfs: false

--- a/.github/workflows/modal-torch-latest.yml
+++ b/.github/workflows/modal-torch-latest.yml
@@ -3,7 +3,9 @@ name: modal-torch-latest
 # This Required workflow selects tests on a no-secret GitHub runner, then tests
 # the exact candidate SHA inside a no-secret Modal Sandbox. Under
 # pull_request_target, every GitHub-side checkout and Python entrypoint comes
-# from the trusted base commit. See .github/workflows/TEST_SELECTION.md.
+# from the trusted base commit. The Sandbox only runs for merge queue entries,
+# pushes to master, and manual runs, so plain PR events never spend Modal quota.
+# See .github/workflows/TEST_SELECTION.md.
 
 on:
   workflow_dispatch:
@@ -42,6 +44,14 @@ on:
     branches:
       - master
 
+  # Required checks must also trigger on merge queue entries, otherwise the
+  # merge fails waiting for a status that is never reported. This is the only
+  # PR-related event that spends Modal quota.
+  merge_group:
+    types: [checks_requested]
+    branches:
+      - master
+
 permissions:
   contents: read
 
@@ -70,12 +80,12 @@ jobs:
           submodules: false
 
       - name: Fetch candidate tree as data
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' || github.event_name == 'merge_group'
         env:
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           CANDIDATE_ROOT: ${{ runner.temp }}/deepspeed-candidate
         run: |
           python3 ci/torch_latest.py checkout-candidate \
@@ -94,7 +104,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           CANDIDATE_ROOT: ${{ runner.temp }}/deepspeed-candidate
         run: |
-          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+          if [ "$EVENT_NAME" = "pull_request_target" ] || [ "$EVENT_NAME" = "merge_group" ]; then
             python3 ci/tests_fetcher.py \
               --workflow modal-torch-latest \
               --repo-root "$CANDIDATE_ROOT" \
@@ -132,7 +142,10 @@ jobs:
 
     # Preserve the Required check on failures and no-test selections. A selector
     # failure enters this job and fails explicitly; mode=none skips the Sandbox.
-    if: ${{ !cancelled() && (needs.collect-tests.result != 'success' || needs.collect-tests.outputs.mode != 'none') }}
+    # pull_request_target runs skip the Sandbox entirely (a skipped dependent
+    # job still satisfies the Required check), so the tests gate the merge queue
+    # entry instead of every PR update.
+    if: ${{ !cancelled() && (needs.collect-tests.result != 'success' || (needs.collect-tests.outputs.mode != 'none' && github.event_name != 'pull_request_target')) }}
     steps:
       - name: Fail if test selection failed
         if: needs.collect-tests.result != 'success'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,12 @@ make test
 
 ### Diff-based CI test selection
 Some GPU CI workflows (currently `modal-torch-latest`, which runs `tests/unit/v1/`)
-don't run the whole suite on every PR. Instead, `ci/tests_fetcher.py` looks at the
-files your PR changes, builds an import graph over `deepspeed/` and the `unit` test
-helpers, and runs only the tests that could be affected. This keeps CI fast without
-losing coverage (`push` to `master` always runs everything). The full design — and
+run their modal tests on the merge queue entry instead of on every PR push, to
+conserve Modal GPU quota. `ci/tests_fetcher.py` looks at the files your PR
+changes, builds an import graph over `deepspeed/` and the `unit` test helpers,
+and selects only the tests that could be affected. The selection is previewed on
+the PR by a cheap no-secret job and executed once the PR enters the merge queue
+(`push` to `master` always runs everything). The full design — and
 how to drive and extend it — is in
 [`.github/workflows/TEST_SELECTION.md`](.github/workflows/TEST_SELECTION.md).
 
@@ -91,9 +93,10 @@ cat ci/.test_selection/test_list.txt
 python ci/tests_fetcher.py --base origin/master --explain
 ```
 
-> Note: under `pull_request_target` the `deploy` job runs the PR's `deepspeed/` and
-> `tests/` but restores `ci/` from the base branch (the CI scripts hold the modal/HF
-> secrets). So changes to `ci/*` only take effect once merged — validate them via a
+> Note: plain PR events never start the modal `deploy` job (it stays skipped to
+> conserve GPU quota), and under `pull_request_target` GitHub runs the base branch's
+> CI scripts anyway. So changes to `ci/*` are first exercised live by the merge
+> queue entry, which runs your merged tree — validate them before that via a
 > `pull_request`-triggered run or the `modal` CLI.
 
 ### Model Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,9 @@ python ci/tests_fetcher.py --base origin/master --explain
 
 > Note: plain PR events never start the modal `deploy` job (it stays skipped to
 > conserve GPU quota), and under `pull_request_target` GitHub runs the base branch's
-> CI scripts anyway. So changes to `ci/*` are first exercised live by the merge
-> queue entry, which runs your merged tree — validate them before that via a
+> CI scripts anyway. Merge queue runs also use trusted master for the CI scripts —
+> your merged tree is only fetched as the candidate under test — so changes to
+> `ci/*` take effect once **merged**; validate them before that via a
 > `pull_request`-triggered run or the `modal` CLI.
 
 ### Model Tests

--- a/ci/accelerate.py
+++ b/ci/accelerate.py
@@ -3,11 +3,18 @@
 
 # DeepSpeed Team
 
+import os
 from pathlib import Path
 
 import modal
 
 ROOT_PATH = Path(__file__).parents[1]
+
+# Tree under test. On merge queue runs this launcher is checked out from
+# trusted master, so the merged candidate is fetched separately and pointed at
+# here. Remotely the env var is unset and this module is materialized inside
+# the image at /root, where it must keep resolving to ROOT_PATH.
+CANDIDATE_PATH = Path(os.environ.get("DS_CI_CANDIDATE_ROOT") or ROOT_PATH)
 
 # yapf: disable
 image = (modal.Image
@@ -16,13 +23,13 @@ image = (modal.Image
          .pip_install("uv")
          # uv_pip_install already includes --compile-bytecode
          .uv_pip_install("datasets==3.6.0", extra_options="--system")
-         .pip_install_from_requirements(ROOT_PATH / "requirements/requirements.txt", gpu="any")
-         .pip_install_from_requirements(ROOT_PATH / "requirements/requirements-dev.txt", gpu="any")
-         .add_local_dir(ROOT_PATH , remote_path="/root/", copy=True)
+         .pip_install_from_requirements(CANDIDATE_PATH / "requirements/requirements.txt", gpu="any")
+         .pip_install_from_requirements(CANDIDATE_PATH / "requirements/requirements-dev.txt", gpu="any")
+         .add_local_dir(CANDIDATE_PATH, remote_path="/root/", copy=True)
          .run_commands("pip install /root")
-         .add_local_dir(ROOT_PATH / "accelerator", remote_path="/root/deepspeed/accelerator")
-         .add_local_dir(ROOT_PATH / "csrc", remote_path="/root/deepspeed/ops/csrc")
-         .add_local_dir(ROOT_PATH / "op_builder", remote_path="/root/deepspeed/ops/op_builder")
+         .add_local_dir(CANDIDATE_PATH / "accelerator", remote_path="/root/deepspeed/accelerator")
+         .add_local_dir(CANDIDATE_PATH / "csrc", remote_path="/root/deepspeed/ops/csrc")
+         .add_local_dir(CANDIDATE_PATH / "op_builder", remote_path="/root/deepspeed/ops/op_builder")
         )
 
 app = modal.App("deepspeedai-accelerate-ci", image=image)


### PR DESCRIPTION
## Motivation

Both modal workflows spend Modal GPU quota on every PR event (`review_requested` / `ready_for_review` / `synchronize`), while the merge queue entry — the commit that actually gates the merge — never runs them, because the workflows have no `merge_group` trigger. This PR moves the GPU spend to the merge queue only.

## Behavior change

| Event | Before | After |
|---|---|---|
| `pull_request_target` (review_requested / ready_for_review / synchronize) | collect + **Modal run** (when tests are selected) | collect only (no secrets, no Modal) — `deploy` reports *skipped*, which still satisfies Required checks |
| `merge_group` (checks_requested) | **nothing runs** | collect + Modal run on the merged tree, gating the merge |
| `push` to master / `workflow_dispatch` | collect + Modal run | unchanged |

## Changes

- `.github/workflows/modal-torch-latest.yml`
  - add a `merge_group` (`checks_requested`) trigger — required checks must be reported on queued entries or the merge fails;
  - the candidate-tree fetch and diff-based selection now also run for `merge_group` (the merge-group commit diffed against `merge_group.base_sha`), so queue runs keep subset selection instead of falling back to the full suite;
  - `deploy` gains `github.event_name != 'pull_request_target'`; the explicit failure-propagation path (a failing `collect-tests` still fails the check on every event) is preserved.
- `.github/workflows/modal-accelerate.yml`: same trigger and the same `deploy` gating. `dorny/paths-filter@v4` (≥ v4.0.1) supports `merge_group` natively, so path filtering is unchanged.
- Docs: `TEST_SELECTION.md` (job flow, deploy gating, a `merge_group` trust-context note in the security model) and `CONTRIBUTING.md`.

Net effect: one Modal run per queued (batched) merge instead of one per PR event. The repo's merge queue is active (recent merges went through it), so this takes effect immediately once merged.

## Verification

- YAML parse + trigger-structure check for both workflows.
- Simulated the GitHub-expression fallbacks for all four event contexts: fork head/base SHAs resolve as before; for `merge_group` the candidate resolves to the base-repo merge-group SHA and the queue's base SHA.
- Deploy-gating truth table (10 cases): PR events never create a Sandbox (even for `mode=all`); selector failures still fail the check on every event; queue entries run for `all`/`subset` and skip for `none`.
- `bash -n` on the modified inline script; `python ci/test_tests_fetcher.py` 16/16; `pre-commit run --files` passes on all four files.

## Notes for reviewers

- `merge_group` runs use the workflow/controller from the merged commit with access to secrets — inherent to GitHub's merge queue, documented in the security-model section of `TEST_SELECTION.md`; PRs touching `ci/*` should be reviewed with that in mind.
- If the modal check names are added to the required-checks list, queue entries become gated by the modal results (PR-side `skipped` counts as success). No settings change is needed for this PR itself.


## Security hardening (follow-up commit)

Follow-up `586a049a4` (from Codex review): on `merge_group` runs, every GitHub-side checkout now resolves to the **trusted base revision** (`github.event.merge_group.base_sha`) instead of the merge-group commit, so queued-PR code never runs next to the Modal/HF tokens:

- `modal-torch-latest`: the selector and the controller come from trusted master; the merged candidate is still only ever fetched by exact SHA inside the no-secret Modal Sandbox.
- `modal-accelerate`: the `modal run` launcher comes from trusted master; the merged candidate is fetched as validated git data (`ci/torch_latest.py checkout-candidate`) into `$RUNNER_TEMP/deepspeed-candidate`, and `ci/accelerate.py` uploads the tree under test from `DS_CI_CANDIDATE_ROOT` when set. Remotely the env var is unset and the module keeps resolving inside the image at `/root` as before.

The residual exposure is a queued PR rewriting the workflow YAML itself — inherent to GitHub's merge queue and documented in `TEST_SELECTION.md`. Bootstrap note: this PR's own queue entry runs the pre-change trusted launcher once; the new launcher/candidate split is live from the next merge on.
