### PR TITLE
Fix DSVAE's forward path and the arguments it drops

### DIFF
--- a/deepspeed/model_implementations/diffusers/vae.py
+++ b/deepspeed/model_implementations/diffusers/vae.py
@@ -32,7 +32,12 @@ class DSVAE(CUDAGraph, torch.nn.Module):
         return self.static_decoder_output
 
     def _decode(self, x, return_dict=True, generator=None):
-        return self.vae.decode(x, return_dict=return_dict)
+        # Every diffusers pipeline passes `generator` to `vae.decode`, and a stochastic decoder such as
+        # ConsistencyDecoderVAE samples with it. Only forward it when one was given, since not every
+        # VAE's `decode` accepts the argument.
+        if generator is None:
+            return self.vae.decode(x, return_dict=return_dict)
+        return self.vae.decode(x, return_dict=return_dict, generator=generator)
 
     def _create_cuda_graph_decoder(self, *inputs, **kwargs):
         # warmup to create the workspace and cublas handle
@@ -119,7 +124,7 @@ class DSVAE(CUDAGraph, torch.nn.Module):
 
     def forward(self, *inputs, **kwargs):
         if self.enable_cuda_graph:
-            if self.cuda_graph_created:
+            if self.all_cuda_graph_created:
                 outputs = self._graph_replay(*inputs, **kwargs)
             else:
                 self._create_cuda_graph(*inputs, **kwargs)
@@ -147,5 +152,5 @@ class DSVAE(CUDAGraph, torch.nn.Module):
 
         self.all_cuda_graph_created = True
 
-    def _forward(self, sample, timestamp, encoder_hidden_states, return_dict=True):
-        return self.vae(sample, timestamp, encoder_hidden_states, return_dict)
+    def _forward(self, sample, sample_posterior=False, return_dict=True, generator=None):
+        return self.vae(sample, sample_posterior=sample_posterior, return_dict=return_dict, generator=generator)

--- a/tests/unit/inference/test_ds_vae.py
+++ b/tests/unit/inference/test_ds_vae.py
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import torch
+
+from deepspeed.model_implementations.diffusers.vae import DSVAE
+
+
+class RecordingVAE(torch.nn.Module):
+    """Records what DSVAE hands over. Signatures copied from diffusers `AutoencoderKL`."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = None
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.seen = {}
+
+    def decode(self, z, return_dict=True, generator=None):
+        self.seen["decode"] = {"return_dict": return_dict, "generator": generator}
+        return "decoded"
+
+    def encode(self, x, return_dict=True):
+        self.seen["encode"] = {"return_dict": return_dict}
+        return "encoded"
+
+    def forward(self, sample, sample_posterior=False, return_dict=True, generator=None):
+        self.seen["forward"] = {
+            "sample_posterior": sample_posterior,
+            "return_dict": return_dict,
+            "generator": generator
+        }
+        return "forwarded"
+
+
+def test_ds_vae_forward_reads_the_graph_flag_it_sets():
+    # enable_cuda_graph defaults to True, and the flag DSVAE sets is `all_cuda_graph_created`
+    vae = RecordingVAE()
+    ds_vae = DSVAE(vae, enable_cuda_graph=True)
+    ds_vae.all_cuda_graph_created = True
+    ds_vae._graph_replay = lambda *inputs, **kwargs: "replayed"
+
+    assert ds_vae(torch.zeros(1)) == "replayed"
+
+
+def test_ds_vae_forwards_the_inputs_it_accepts():
+    vae = RecordingVAE()
+    ds_vae = DSVAE(vae, enable_cuda_graph=False)
+
+    assert ds_vae(torch.zeros(1), sample_posterior=True, return_dict=False) == "forwarded"
+    assert vae.seen["forward"] == {"sample_posterior": True, "return_dict": False, "generator": None}
+
+
+def test_ds_vae_decode_forwards_the_generator():
+    # every diffusers pipeline calls vae.decode(latents, return_dict=False, generator=generator)
+    vae = RecordingVAE()
+    ds_vae = DSVAE(vae, enable_cuda_graph=False)
+    generator = torch.Generator()
+
+    ds_vae.decode(torch.zeros(1), return_dict=False, generator=generator)
+
+    assert vae.seen["decode"] == {"return_dict": False, "generator": generator}


### PR DESCRIPTION
### What breaks

`DSVAE` is the wrapper `deepspeed.init_inference` swaps in for a diffusers VAE, so every Stable Diffusion encode/decode goes through it. Three things in it do not match what they wrap.

**1. `forward` reads a flag `DSVAE` never sets.**

```
AttributeError: 'DSVAE' object has no attribute 'cuda_graph_created'
```

`__init__` sets `decoder_cuda_graph_created`, `encoder_cuda_graph_created` and `all_cuda_graph_created`; `_create_cuda_graph` sets `all_cuda_graph_created`. `forward` tests `self.cuda_graph_created`, which only `DSUNet` has. `enable_cuda_graph` defaults to `True`, so that is the default path, and `all_cuda_graph_created` is written twice and read nowhere.

**2. `_forward` is a copy of `DSUNet._forward`.**

```python
def _forward(self, sample, timestamp, encoder_hidden_states, return_dict=True):
    return self.vae(sample, timestamp, encoder_hidden_states, return_dict)
```

A VAE has no timestep and no encoder hidden states. `AutoencoderKL.forward` is `(sample, sample_posterior=False, return_dict=True, generator=None)`, so `DSVAE(sample)` raises `TypeError: missing 2 required positional arguments`, and satisfying it lands `timestamp` on `sample_posterior`, `encoder_hidden_states` on `return_dict`, and `return_dict` on `generator`.

**3. `_decode` accepts `generator` and drops it.**

`StableDiffusionPipeline.__call__` calls `self.vae.decode(latents / scaling_factor, return_dict=False, generator=generator)`. `AutoencoderKL` ignores it, but `ConsistencyDecoderVAE` and `AutoencoderTiny` sample with it, so their decode is silently non-reproducible behind `init_inference`.

### What changed

- `forward` reads `all_cuda_graph_created`, the flag the class sets. That makes the dead flag live and the default path work.
- `_forward` takes `AutoencoderKL.forward`'s parameters and passes them by keyword.
- `_decode` forwards `generator` when one was given. Only when given, since `AutoencoderKLTemporalDecoder.decode` has no such argument.

### Test

New `tests/unit/inference/test_ds_vae.py`, three plain functions driving `DSVAE` with a recording stub whose signatures are copied from `AutoencoderKL`. No accelerator, no model download.

**3 failed before, 3 passed after** (`AttributeError`, `TypeError`, and `generator` arriving as `None`), run on torch 2.11.0 against deepspeed 0.19.6, whose `vae.py` is byte-identical to master.

`yapf --style .style.yapf --diff` clean on both files.
