### PR TITLE
Fix flop counts for the matmul family in the flops profiler

### DIFF
--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -523,7 +523,10 @@ def _prod(dims):
 def _linear_flops_compute(input, weight, bias=None):
     out_features = weight.shape[0]
     macs = input.numel() * out_features
-    return 2 * macs, macs
+    # A bias adds one flop per output element, the same way the convolution and addmm
+    # counters below charge for theirs.
+    bias_flops = 0 if bias is None else _prod(input.shape[:-1]) * out_features
+    return 2 * macs + bias_flops, macs
 
 
 def _relu_flops_compute(input, inplace=False):
@@ -770,7 +773,14 @@ def _matmul_flops_compute(input, other, *, out=None):
     """
     Count flops for the matmul operation.
     """
-    macs = _prod(input.shape) * other.shape[-1]
+    # One multiply-accumulate per output element per contracted element. A 1-D operand gets a
+    # singleton dimension prepended (left) or appended (right) that matmul drops again from the
+    # result, so counting over `input`'s own shape charges a dot product and a matrix-vector
+    # product for a dimension their outputs never have.
+    lhs = tuple(input.shape) if input.dim() > 1 else (1, ) + tuple(input.shape)
+    rhs = tuple(other.shape) if other.dim() > 1 else tuple(other.shape) + (1, )
+    output_shape = torch.broadcast_shapes(lhs[:-2], rhs[:-2]) + (lhs[-2], rhs[-1])
+    macs = _prod(output_shape) * lhs[-1]
     return 2 * macs, macs
 
 
@@ -779,7 +789,9 @@ def _addmm_flops_compute(input, mat1, mat2, *, beta=1, alpha=1, out=None):
     Count flops for the addmm operation.
     """
     macs = _prod(mat1.shape) * mat2.shape[-1]
-    return 2 * macs + _prod(input.shape), macs
+    # `input` is added to every output element, so a broadcast bias still costs one flop per
+    # output element, not one per element of its own shape.
+    return 2 * macs + mat1.shape[0] * mat2.shape[-1], macs
 
 
 def _einsum_flops_compute(equation, *operands):
@@ -832,7 +844,8 @@ def _tensor_addmm_flops_compute(self, mat1, mat2, *, beta=1, alpha=1, out=None):
     Count flops for the tensor addmm operation.
     """
     macs = _prod(mat1.shape) * mat2.shape[-1]
-    return 2 * macs + _prod(self.shape), macs
+    # Same as `_addmm_flops_compute`: the added tensor covers the whole output.
+    return 2 * macs + mat1.shape[0] * mat2.shape[-1], macs
 
 
 def _mul_flops_compute(input, other, *, out=None):

--- a/deepspeed/profiling/flops_profiler/profiler.py
+++ b/deepspeed/profiling/flops_profiler/profiler.py
@@ -791,7 +791,7 @@ def _addmm_flops_compute(input, mat1, mat2, *, beta=1, alpha=1, out=None):
     macs = _prod(mat1.shape) * mat2.shape[-1]
     # `input` is added to every output element, so a broadcast bias still costs one flop per
     # output element, not one per element of its own shape.
-    return 2 * macs + mat1.shape[0] * mat2.shape[-1], macs
+    return 2 * macs + _prod(mat1.shape[:-1]) * mat2.shape[-1], macs
 
 
 def _einsum_flops_compute(equation, *operands):
@@ -844,8 +844,10 @@ def _tensor_addmm_flops_compute(self, mat1, mat2, *, beta=1, alpha=1, out=None):
     Count flops for the tensor addmm operation.
     """
     macs = _prod(mat1.shape) * mat2.shape[-1]
-    # Same as `_addmm_flops_compute`: the added tensor covers the whole output.
-    return 2 * macs + mat1.shape[0] * mat2.shape[-1], macs
+    # Same as `_addmm_flops_compute`: the added tensor covers the whole output. This counter is
+    # also registered for `torch.baddbmm`, whose output carries a leading batch dimension, so
+    # take every dimension of `mat1` except the contracted one rather than just the first.
+    return 2 * macs + _prod(mat1.shape[:-1]) * mat2.shape[-1], macs
 
 
 def _mul_flops_compute(input, other, *, out=None):

--- a/tests/unit/profiling/flops_profiler/test_flops_profiler.py
+++ b/tests/unit/profiling/flops_profiler/test_flops_profiler.py
@@ -308,3 +308,81 @@ def test_flops_profiler_counts_shared_module_once(shared):
     assert flops == 60000
     assert macs == 30000
     assert params == (10000 if shared else 30000)
+
+
+@pytest.mark.sequential
+@pytest.mark.parametrize("bias", [True, False])
+def test_linear_bias_flops(bias):
+    """A bias is added once per output element, exactly as the convolution counter charges for
+    its own bias."""
+    model = torch.nn.Linear(8, 16, bias=bias)
+    inputs = torch.randn(4, 8)
+
+    prof = FlopsProfiler(model)
+    prof.start_profile()
+    result = model(inputs)
+    prof.stop_profile()
+    flops, macs = prof.get_total_flops(), prof.get_total_macs()
+    prof.end_profile()
+
+    assert macs == 4 * 8 * 16
+    assert flops == 2 * macs + (result.numel() if bias else 0)
+
+
+@pytest.mark.sequential
+@pytest.mark.parametrize("lhs_shape, rhs_shape", [
+    ((8, ), (8, )),
+    ((4, 8), (8, )),
+    ((8, ), (8, 5)),
+    ((4, 8), (8, 5)),
+    ((3, 4, 8), (3, 8, 5)),
+    ((2, 1, 4, 8), (3, 8, 5)),
+])
+def test_matmul_flops(lhs_shape, rhs_shape):
+    """matmul costs one multiply-accumulate per output element per contracted element. The
+    singleton dimension matmul adds for a 1-D operand is dropped from the result, so it must not
+    be counted."""
+
+    class Matmul(torch.nn.Module):
+
+        def forward(self, lhs, rhs):
+            return torch.matmul(lhs, rhs)
+
+    model = Matmul()
+    lhs, rhs = torch.randn(*lhs_shape), torch.randn(*rhs_shape)
+
+    prof = FlopsProfiler(model)
+    prof.start_profile()
+    result = model(lhs, rhs)
+    prof.stop_profile()
+    flops, macs = prof.get_total_flops(), prof.get_total_macs()
+    prof.end_profile()
+
+    expected_macs = max(result.numel(), 1) * lhs_shape[-1]
+    assert macs == expected_macs
+    assert flops == 2 * expected_macs
+
+
+@pytest.mark.sequential
+@pytest.mark.parametrize("bias_shape", [(4, 5), (5, ), (1, 5), (4, 1), (1, )])
+def test_addmm_broadcast_bias_flops(bias_shape):
+    """The added tensor reaches every output element, so a broadcast bias costs one flop per
+    output element rather than one per element of its own shape."""
+
+    class Addmm(torch.nn.Module):
+
+        def forward(self, bias, mat1, mat2):
+            return torch.addmm(bias, mat1, mat2)
+
+    model = Addmm()
+    bias, mat1, mat2 = torch.randn(*bias_shape), torch.randn(4, 8), torch.randn(8, 5)
+
+    prof = FlopsProfiler(model)
+    prof.start_profile()
+    result = model(bias, mat1, mat2)
+    prof.stop_profile()
+    flops, macs = prof.get_total_flops(), prof.get_total_macs()
+    prof.end_profile()
+
+    assert macs == 4 * 8 * 5
+    assert flops == 2 * macs + result.numel()

--- a/tests/unit/profiling/flops_profiler/test_flops_profiler.py
+++ b/tests/unit/profiling/flops_profiler/test_flops_profiler.py
@@ -386,3 +386,28 @@ def test_addmm_broadcast_bias_flops(bias_shape):
 
     assert macs == 4 * 8 * 5
     assert flops == 2 * macs + result.numel()
+
+
+@pytest.mark.parametrize("bias_shape", [(2, 4, 5), (5, ), (1, 1, 5), (4, 5)])
+def test_baddbmm_broadcast_bias_flops(bias_shape):
+    """baddbmm shares the addmm counter, and its output carries a batch dimension the
+    two-dimensional form does not, so the bias covers B * M * N elements and not B * N."""
+
+    class Baddbmm(torch.nn.Module):
+
+        def forward(self, bias, batch1, batch2):
+            return torch.baddbmm(bias, batch1, batch2)
+
+    model = Baddbmm()
+    bias = torch.randn(*bias_shape)
+    batch1, batch2 = torch.randn(2, 4, 8), torch.randn(2, 8, 5)
+
+    prof = FlopsProfiler(model)
+    prof.start_profile()
+    result = model(bias, batch1, batch2)
+    prof.stop_profile()
+    flops, macs = prof.get_total_flops(), prof.get_total_macs()
+    prof.end_profile()
+
+    assert macs == 2 * 4 * 8 * 5
+    assert flops == 2 * macs + result.numel()


### PR DESCRIPTION
## What is wrong

Four flop counters in `flops_profiler/profiler.py` count the wrong number of elements. The convolution counter in the same file is the control: it already charges one flop per output element for its bias.

| counter | on master | correct |
|---|---|---|
| `_linear_flops_compute` | bias never counted | one flop per output element, like `_conv_flops_compute` |
| `_matmul_flops_compute` | `prod(input.shape) * other.shape[-1]` | one MAC per output element per contracted element |
| `_addmm_flops_compute` | bias term is `prod(bias.shape)` | one flop per output element |
| `_tensor_addmm_flops_compute` | same as above | same as above |

Measured on master, `FlopsProfiler` against a hand-derived count:

```
linear n=4 k=8 m=16 bias=True   profiler flops=1024   exact=1088
matmul (8,) @ (8,)              profiler macs=64      exact=8      8x over
matmul (4,8) @ (8,)             profiler macs=256     exact=32     8x over
matmul (2,1,4,8) @ (3,8,5)      profiler macs=320     exact=960    3x under
addmm bias(5,) -> out(4,5)      profiler flops=325    exact=340
```

`nn.Linear` and `F.scaled_dot_product_attention` route through these, so the error reaches ordinary transformer profiles.

## Why

`F.linear(x, w, b)` is `addmm(b, x, wT)`, and `addmm` does count a bias, so the two paths disagreed on the same op. `matmul` prepends or appends the singleton dimension that a 1-D operand gets and then drops it from the result, so counting over `input.shape` charges a dimension the output never has; it also ignored broadcast batch dimensions. `addmm` adds `input` to every output element, so a broadcast bias still touches the whole output.

## Test

New `test_linear_bias_flops`, `test_matmul_flops` and `test_addmm_broadcast_bias_flops` in `tests/unit/profiling/flops_profiler/test_flops_profiler.py`.

```
pytest unit/profiling/flops_profiler/test_flops_profiler.py -m sequential
before: 8 failed, 22 passed
after: 30 passed
```
