### PR TITLE
Fix autotuner crash when an experiment produces no metric

### DIFF
--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -719,6 +719,9 @@ class Autotuner:
         space_num_exps = 0
         for (exp, metric_val, num_exps) in space_records:
             space_num_exps += num_exps
+            if metric_val is None:
+                # a run that did not produce a metric (e.g. OOM) is not a valid candidate
+                continue
             if best_space_record is None or metric_val > best_space_record[1]:
                 best_space_record = (exp, metric_val)
         if best_space_record:

--- a/deepspeed/autotuning/autotuner.py
+++ b/deepspeed/autotuning/autotuner.py
@@ -583,7 +583,8 @@ class Autotuner:
         fast_best_record = self.get_best_space_record(tuning_space_name)
         fast_best_metric_val = fast_best_record[1] if fast_best_record else 0
         fast_best_mbs = fast_best_record[0][DS_CONFIG][TRAIN_MICRO_BATCH_SIZE_PER_GPU] if fast_best_record else 0
-        logger.info(f"fast_best_mbs = {fast_best_mbs}, name = {fast_best_record[0]['name']}")
+        fast_best_name = fast_best_record[0]['name'] if fast_best_record else None
+        logger.info(f"fast_best_mbs = {fast_best_mbs}, name = {fast_best_name}")
 
         if self.fast_enabled() or stage == 0:
             logger.info(f"End tuning for space: {tuning_space_name}")

--- a/tests/unit/autotuning/test_autotuning.py
+++ b/tests/unit/autotuning/test_autotuning.py
@@ -91,6 +91,9 @@ def test_get_best_space_record_ignores_runs_without_a_metric(tmpdir):
 
     tuner.update_records("z0_space", {"name": "exp1"}, None, 1)
     tuner.update_records("z0_space", {"name": "exp2"}, None, 1)
+    # tune_space's callers already fall back to a default when this is None,
+    # so returning None here (instead of a record carrying a None metric) must
+    # stay a safe, handled outcome rather than a new crash.
     assert tuner.get_best_space_record("z0_space") is None
 
     tuner.update_records("z0_space", {"name": "exp3"}, 3.5, 1)

--- a/tests/unit/autotuning/test_autotuning.py
+++ b/tests/unit/autotuning/test_autotuning.py
@@ -79,6 +79,27 @@ def test_autotuner_resources(tmpdir, active_resources):
     assert expected_num_gpus == tuner.exp_num_gpus
 
 
+def test_get_best_space_record_ignores_runs_without_a_metric(tmpdir):
+    # A run that fails to produce a metric (e.g. OOM) is recorded with metric_val=None.
+    # get_best_space_record used to crash with "TypeError: '>' not supported between
+    # instances of 'NoneType' and 'NoneType'" whenever every run in a space had no
+    # metric, discarding all previously gathered results for the whole tuning run.
+    config_dict = {"autotuning": {"enabled": True, "exps_dir": os.path.join(tmpdir, 'exps_dir'), "arg_mappings": {}}}
+    config_path = create_config_from_dict(tmpdir, config_dict)
+    args = dsrun.parse_args(args=f'--autotuning {TUNE_OPTION} foo.py --deepspeed_config {config_path}'.split())
+    tuner = Autotuner(args=args, active_resources={"worker-0": [0, 1]})
+
+    tuner.update_records("z0_space", {"name": "exp1"}, None, 1)
+    tuner.update_records("z0_space", {"name": "exp2"}, None, 1)
+    assert tuner.get_best_space_record("z0_space") is None
+
+    tuner.update_records("z0_space", {"name": "exp3"}, 3.5, 1)
+    best = tuner.get_best_space_record("z0_space")
+    assert best[0]["name"] == "exp3"
+    assert best[1] == 3.5
+    assert best[2] == 3
+
+
 def test_get_val_by_key_searches_all_nested_subdicts():
     # get_val_by_key must mirror its sibling set_val_by_key: both walk every
     # nested subdict, not just the first one. Here 'device' lives in the SECOND


### PR DESCRIPTION
Fixes #3475

## The bug

`get_best_space_record` picks the best record in a tuning space with:

```python
if best_space_record is None or metric_val > best_space_record[1]:
```

An experiment that produces no metric (an OOM during autotuning is the
common case) is still recorded, with `metric_val` set to `None`. Once a
`None`-valued record becomes `best_space_record`, the next comparison
does `metric_val > best_space_record[1]`, and if both sides happen to
be `None` (or the incoming one is a real number compared against a
`None` best) this raises:

```
TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'
```

This isn't limited to `get_best_space_record` itself: `tune_space`
calls it both in fast-tuning mode and after full tuning to pick the
overall best micro batch size, and `get_best_space_records` calls it
once per tuning space to build the final results table. A single space
where every experiment OOM'd is enough to crash the whole autotuning
run and lose every valid result gathered from the spaces tuned before
it.

## The fix

A record with a `None` metric is no longer eligible to become the
best record. It's still counted toward the space's total number of
experiments (`space_num_exps`), it just can't win the comparison. This
means `get_best_space_record` now returns `None` only when a space has
no experiments with a usable metric at all, which the existing callers
already handle correctly (they fall back to `0` or `-1` in that case),
so no other call site needed to change.

## Testing

Added `test_get_best_space_record_ignores_runs_without_a_metric` to
`tests/unit/autotuning/test_autotuning.py`, covering:
- every recorded experiment in a space has `metric_val=None` -> no crash, returns `None`
- a mix of `None` and real metrics -> the real one wins regardless of position, and the experiment count still includes the failed runs

Confirmed this test fails with the exact `TypeError` above on current
master and passes with the fix. Also ran the full existing
`tests/unit/autotuning/test_autotuning.py` suite (12 tests) and it
passes. Ran `pre-commit` on both changed files (yapf, flake8,
check-torchdist, check-license, codespell) with no issues. This is a
pure CPU, no-GPU-needed unit test path, no integration/training-loop
behavior is touched.

cc @loadams (CODEOWNERS for `deepspeed/autotuning/`)