### PR TITLE
op_builder: use C++20 for nvcc on CUDA 13+

### DIFF
--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -896,7 +896,7 @@ class CUDAOpBuilder(OpBuilder):
 
             cuda_major, cuda_minor = installed_cuda_version()
             if cuda_major > 10:
-                if cuda_major == 12 and cuda_minor >= 5:
+                if (cuda_major == 12 and cuda_minor >= 5) or cuda_major >= 13:
                     std_lib = '-std=c++20'
                 else:
                     std_lib = '-std=c++17'


### PR DESCRIPTION
## Problem

`CUDAOpBuilder.nvcc_args()` only passes `-std=c++20` to nvcc when CUDA is 12.5+; on CUDA 13.x it falls back to `-std=c++17`. PyTorch >= 2.12 headers require C++20, so building DeepSpeed CUDA ops against CUDA 13 + torch >= 2.12 fails:

```
torch/include/torch/csrc/api/include/torch/all.h:5:2: error: #error C++20 or later compatible compiler is required to use PyTorch.
torch/include/ATen/ATen.h:5:2: error: #error C++20 or later compatible compiler is required to use ATen.
torch/include/c10/util/intrusive_ptr.h(775): error: namespace "std" has no member "strong_ordering"
...
error: command '/usr/bin/ccache' failed with exit code 255
```

Note that `cxx_args()` already selects `-std=c++20` for torch >= 2.12 (see #8238), so only the nvcc path is broken.

## Fix

Extend the C++20 condition in `nvcc_args()` to also cover CUDA 13+:

```python
if (cuda_major == 12 and cuda_minor >= 5) or cuda_major >= 13:
```

## Verification

Built DeepSpeed from source (`DS_BUILD_OPS=1 pip install .`) with CUDA 13.3, PyTorch 2.14.0, gcc-13: the build fails before this change with the errors above and completes successfully with it.
