### PR TITLE
Log a warning when ZeRO gradient overflow silently skips the optimizer step

### DIFF
--- a/deepspeed/runtime/zero/stage_1_and_2.py
+++ b/deepspeed/runtime/zero/stage_1_and_2.py
@@ -2294,6 +2294,10 @@ class DeepSpeedZeroOptimizer(ZeROOptimizer):
         prev_scale = self.loss_scale
         self._update_scale(self.overflow)
         if self.overflow:
+            logger.warning(
+                f"[ZeRO] Gradient overflow detected. Skipping optimizer step. "
+                f"Loss scale: {self.loss_scale}. "
+                f"Total skipped steps so far: {self.skipped_steps + 1}.")
             see_memory_usage('After overflow before clearing gradients')
             self.zero_grad(set_to_none=True)
             self._release_preflattened_grad_buffers()


### PR DESCRIPTION
When bf16 training hits a gradient overflow, `step()` returns early with no output at all. With fp16 you at least get something from `DynamicLossScaler` ("OVERFLOW! Skipping step"), but bf16 always uses the static `LossScaler` which logs nothing. There's a `skipped_steps` counter but it only surfaces through `_report_progress`, which is gated on `steps_per_print` — and that defaults to `None`, so it never fires.

In practice this means a bf16 run can look completely fine (normal loss curves, metrics being emitted) while no weights are actually being updated.

Added a `logger.warning` right at the top of the overflow branch so you always get a message, regardless of dtype or config.

Fixes #8415.