### PR TITLE
Validate max_out_tokens and min_out_tokens are positive at inference config parse time

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -302,6 +302,12 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
                                       "new_param": "moe.type"
                                   })
 
+    @field_validator("max_out_tokens", "min_out_tokens", mode="before")
+    def validate_token_limits(cls, field_value):
+        if isinstance(field_value, int) and field_value <= 0:
+            raise ValueError(f"Token limit must be a positive integer, got {field_value}")
+        return field_value
+
     @field_validator("dtype", mode="before")
     def validate_dtype(cls, field_value, values):
         if isinstance(field_value, str):


### PR DESCRIPTION
`deepspeed.init_inference(model, config={"max_out_tokens": -1})` goes through without any error. The first sign something's wrong is when generation actually runs and hits:

```
RuntimeError: Input with size 6 exceeds maximum length of -1. Please increase max_tokens in the DeepSpeed Inference Config.
```

Which is confusing — the user already set `max_tokens`, it's just set to a bad value. Added a `field_validator` that rejects `max_out_tokens` and `min_out_tokens` <= 0 at config parse time, before any model loading.

Fixes #8339.