### PR TITLE
Fix missing () on is_bf16_supported in ZeRO-3 dtype fallback (silent bf16 on non-bf16 hardware)

### DIFF
--- a/deepspeed/runtime/zero/partition_parameters.py
+++ b/deepspeed/runtime/zero/partition_parameters.py
@@ -401,7 +401,7 @@ class InsertPostInitMethodToModuleSubClasses(object):
                 self.dtype = torch.float
         else:
             self.dtype = dtype or torch.float16 if get_accelerator().is_fp16_supported(
-            ) else torch.bfloat16 if get_accelerator().is_bf16_supported else torch.float32
+            ) else torch.bfloat16 if get_accelerator().is_bf16_supported() else torch.float32
 
     def _enable_mem_efficient_linear(self):
         print_rank_0(


### PR DESCRIPTION
Spotted a missing `()` in the dtype fallback chain in `_set_dtype`:

```python
self.dtype = dtype or torch.float16 if get_accelerator().is_fp16_supported()
    else torch.bfloat16 if get_accelerator().is_bf16_supported   # <-- no call
    else torch.float32
```

`is_bf16_supported` is a method on every accelerator, so without the parens you're checking the method object itself, which is always truthy. The `torch.float32` branch can never be reached — hardware that doesn't support fp16 or bf16 silently ends up with bfloat16 instead of float32.