### PR TITLE
Guard steps_per_print() None check in PipelineEngine._exec_optimizer_step

### DIFF
--- a/deepspeed/runtime/pipe/engine.py
+++ b/deepspeed/runtime/pipe/engine.py
@@ -1260,7 +1260,7 @@ class PipelineEngine(DeepSpeedEngine):
         if self.wall_clock_breakdown():
             self.timers(STEP_MICRO_TIMER).stop()
             self.timers(STEP_GLOBAL_TIMER).stop()
-            if self.global_steps % self.steps_per_print() == 0:
+            if self.steps_per_print() is not None and self.global_steps % self.steps_per_print() == 0:
                 self.timers.log([
                     BATCH_INPUT_TIMER,
                     FORWARD_MICRO_TIMER,
@@ -1269,7 +1269,7 @@ class PipelineEngine(DeepSpeedEngine):
                     BACKWARD_REDUCE_MICRO_TIMER,
                     STEP_MICRO_TIMER,
                 ])
-            if self.global_steps % self.steps_per_print() == 0:
+            if self.steps_per_print() is not None and self.global_steps % self.steps_per_print() == 0:
                 self.timers.log([
                     FORWARD_GLOBAL_TIMER,
                     BACKWARD_GLOBAL_TIMER,


### PR DESCRIPTION
If `wall_clock_breakdown` is on and `steps_per_print` isn't set (which is the default), `_exec_optimizer_step` crashes with:

```
TypeError: unsupported operand type(s) for %: 'int' and 'NoneType'
```

because of these two lines:

```python
if self.global_steps % self.steps_per_print() == 0:  # steps_per_print() returns None
```

Worth noting: `wall_clock_breakdown` gets set to True not just when explicitly configured, but also when the flops profiler is enabled (`self.wall_clock_breakdown = ... | flops_profiler.enabled`), so this can bite you without touching that setting directly.

`train_batch()` already handles this correctly with `if self.steps_per_print() is not None and ...`. Applied the same guard to the two spots in `_exec_optimizer_step` that were missed.