### PR TITLE
Fix SequenceTiledCompute backward for empty trailing shards

### DIFF
--- a/deepspeed/runtime/sequence_parallel/ulysses_sp.py
+++ b/deepspeed/runtime/sequence_parallel/ulysses_sp.py
@@ -821,6 +821,7 @@ class SequenceTiledCompute(torch.autograd.Function):
 
         with torch.no_grad():
             shard_step = math.ceil(seqlen / shards)
+            ctx.shard_step = shard_step
             output_shards = []
 
             for i in range(shards):
@@ -877,8 +878,6 @@ class SequenceTiledCompute(torch.autograd.Function):
         else:
             grad_requiring_tensor_grad = torch.empty_like(grad_requiring_tensor)
 
-        kwargs_to_shard_shards = {k: list(torch.chunk(v, chunks=shards, dim=1)) for k, v in kwargs_to_shard.items()}
-
         for i in range(shards):
             # when fn involves one or more model weights deepspeed will normally push a grad to
             # reduce per sub-module call, so since we only want it to add a grad for the last
@@ -894,14 +893,18 @@ class SequenceTiledCompute(torch.autograd.Function):
                     for param in compute_params:
                         param.ds_grad_is_ready = True
 
-            kwargs_to_shard_shard = {k: v[i] for k, v in kwargs_to_shard_shards.items()}
+            # Match forward's empty trailing slices, with offsets that remain valid for narrow().
+            shard_offset = min(i * ctx.shard_step, ctx.seqlen)
+            kwargs_to_shard_shard = {
+                k: v[:, shard_offset:shard_offset + ctx.shard_step]
+                for k, v in kwargs_to_shard.items()
+            }
             grad_requiring_tensor_shard = kwargs_to_shard_shard[grad_requiring_tensor_key]
 
             grad_requiring_tensor_shard.requires_grad_(grad_requiring_tensor_requires_grad)
 
             # if seqlen is not exactly divisible by shards the last step will be shorter than shard_step
-            shard_step = kwargs_to_shard_shards[grad_requiring_tensor_key][i].shape[1]
-            shard_offset = i * kwargs_to_shard_shards[grad_requiring_tensor_key][0].shape[1]
+            shard_step = grad_requiring_tensor_shard.shape[1]
 
             if grad_requiring_tensor.shape[0] == 1:
                 # on narrow the shard's stride is unaffected with dim0==1 (bs) so we use the most efficient `narrow` alias:

--- a/tests/unit/ulysses_alst/test_tiled_compute.py
+++ b/tests/unit/ulysses_alst/test_tiled_compute.py
@@ -7,6 +7,7 @@ Arctic Long Sequence Training (ALST) Tiled compute component tests
 """
 
 from deepspeed.runtime.sequence_parallel.ulysses_sp import TiledMLP, sequence_tiled_compute, TiledFusedLogitsLoss
+from deepspeed.accelerator import get_accelerator
 from deepspeed.utils import safe_get_full_grad
 from torch.nn import Linear, Module
 from unit.common import DistributedTest, preferred_dtype
@@ -229,6 +230,66 @@ class TestTiledCompute(DistributedTest):
         torch_assert_close(param_grad_a1, param_grad_c1)  #, rtol=1e-03, atol=1e-04)
         torch_assert_close(param_grad_a2, param_grad_c2)  #, rtol=1e-03, atol=1e-04)
         torch_assert_close(x_grad_a, x_grad_c)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("seqlen,shards", [(5, 4), (2, 4), (7, 4), (8, 4)])
+@pytest.mark.parametrize("output_reduction", [None, "sum", "mean"])
+def test_sequence_tiled_compute_shard_boundaries(batch_size, seqlen, shards, output_reduction):
+    # Empty trailing tiles must preserve both gradients and updates relative to untiled computation.
+    device = get_accelerator().device_name()
+    dtype = torch.float32
+    hidden_dim = 8
+    torch.manual_seed(42)
+    tiled_model = SimpleMLP(hidden_dim).to(device=device, dtype=dtype)
+    reference_model = SimpleMLP(hidden_dim).to(device=device, dtype=dtype)
+    reference_model.load_state_dict(tiled_model.state_dict())
+    tiled_optimizer = torch.optim.SGD(tiled_model.parameters(), lr=0.01)
+    reference_optimizer = torch.optim.SGD(reference_model.parameters(), lr=0.01)
+
+    def compute(x, scale, model):
+        output = mlp_forward_orig(model, x) * scale
+        return output if output_reduction is None else output.sum()
+
+    for _ in range(2):
+        tiled_optimizer.zero_grad()
+        reference_optimizer.zero_grad()
+        x = torch.rand((batch_size, seqlen, hidden_dim), device=device, dtype=dtype, requires_grad=True)
+        x_reference = x.detach().clone().requires_grad_(True)
+        scale = torch.rand_like(x)
+
+        output = sequence_tiled_compute(
+            compute,
+            seqlen,
+            shards,
+            kwargs_to_shard={
+                "x": x,
+                "scale": scale
+            },
+            kwargs_to_pass={"model": tiled_model},
+            grad_requiring_tensor_key="x",
+            compute_params=list(tiled_model.parameters()),
+            output_unshard_dimension=1 if output_reduction is None else 0,
+            output_reduction=output_reduction,
+        )
+        expected = mlp_forward_orig(reference_model, x_reference) * scale
+        if output_reduction is not None:
+            expected = expected.sum()
+            if output_reduction == "mean":
+                # Averaging per-tile sums divides the full sum by the requested tile count.
+                expected = expected / shards
+
+        torch.testing.assert_close(output, expected)
+        output.sum().backward()
+        expected.sum().backward()
+        torch.testing.assert_close(x.grad, x_reference.grad)
+        for param, reference_param in zip(tiled_model.parameters(), reference_model.parameters()):
+            torch.testing.assert_close(param.grad, reference_param.grad)
+
+        tiled_optimizer.step()
+        reference_optimizer.step()
+        for param, reference_param in zip(tiled_model.parameters(), reference_model.parameters()):
+            torch.testing.assert_close(param, reference_param)
 
 
 @pytest.mark.parametrize("shards", [2, 4])


### PR DESCRIPTION
## Description

`sequence_tiled_compute` can finish forward and then raise `IndexError` in backward when `torch.chunk` returns fewer pieces than requested. For `seqlen=5, shards=4`, forward calls the function on slices of lengths `[2, 2, 1, 0]`, while backward creates only three chunks and still indexes four. This also occurs without ZeRO.

Save the forward slice step and reuse it to slice every sharded input during backward. Clamp trailing empty-slice offsets to the sequence length so the gradient `narrow()` calls remain valid. This preserves the existing forward calls, requested shard count, reduction behavior, and final-shard gradient signaling.

The regression test runs two SGD steps against an untiled PyTorch MLP and compares outputs, input gradients, parameter gradients, and updated weights. It covers batch sizes 1/2, `(seqlen, shards)` pairs `(5, 4)`, `(2, 4)`, `(7, 4)`, and `(8, 4)`, multiple sharded inputs, and tensor/sum/mean outputs. The callback supports empty inputs, as required by the existing forward behavior.

## Validation

Hardware: NVIDIA RTX A1000 Laptop GPU, 4 GiB, driver 595.84; Python 3.12.13, PyTorch 2.13.0+cu130, CUDA 13.0.

- Before the fix, the 12 empty-tail regression variants reproduced the backward `IndexError`; the 12 control variants passed.
- `DS_ACCELERATOR=cuda python -m pytest -q tests/unit/ulysses_alst/test_tiled_compute.py -k sequence_tiled_compute_shard_boundaries --tb=short`: **24 passed** in FP32, including both optimizer steps.
- Existing `TestTiledCompute` ZeRO-2 cases: **2 passed** on the GPU.
- Existing ZeRO-3 cases: default communication buffers exhausted this 4 GiB GPU while initializing the third model. Reran with a local-only `reduce_bucket_size=65536` override: **2 passed**. The override is not included in this PR.
- `pre-commit run --files deepspeed/runtime/sequence_parallel/ulysses_sp.py tests/unit/ulysses_alst/test_tiled_compute.py`: passed.
- `python ci/tests_fetcher.py --base origin/master`: no affected tests in its configured `tests/unit/v1` scope; the ALST tests above were run explicitly.
