### PR TITLE
fix(zenflow): restore assert and remove duplicated identical branch in gradient copy

### DIFF
--- a/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
+++ b/deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py
@@ -685,10 +685,8 @@ class ZenFlowZeroOptimizerParallel(ZenFlowZeroOptimizer):
             0, dest_offset, num_elements)
 
         grad_accum = self.get_param_gradient_attribute(param)
-        if grad_accum is None:
-            src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
-        else:
-            src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
+        assert grad_accum is not None
+        src_tensor = grad_accum.view(-1).narrow(0, source_offset, num_elements)
         if src_tensor.dtype != self.master_weights_and_grads_dtype:
             src_tensor = src_tensor.to(self.master_weights_and_grads_dtype)
 


### PR DESCRIPTION
In `deepspeed/runtime/zenflow/zenflow_stage_1_and_2.py` (ZenFlow overlap path), the fork of `async_inplace_copy_grad_to_fp32_buffer_from_gpu` mangled the original logic into two byte-identical if/else arms:

```python
grad_accum = self.get_param_gradient_attribute(param)
if grad_accum is None:
    src_tensor = grad_accum.view(-1).narrow(...)  # AttributeError on None!
else:
    src_tensor = grad_accum.view(-1).narrow(...)
```

If the condition were ever true, the None branch itself calls `.view()` on `None`. Restored the upstream shape from `runtime/zero/stage_1_and_2.py` (`assert grad_accum is not None` + single assignment). No test covers this method (`grep -rn async_inplace_copy tests/` is empty), which is why the mangle survived.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>