### PR TITLE
fix(checkpointing): remove identical if/else arms and leftover debug print in WriterFactory

### DIFF
--- a/deepspeed/runtime/model_checkpointing/writer_factory.py
+++ b/deepspeed/runtime/model_checkpointing/writer_factory.py
@@ -19,10 +19,7 @@ class CheckpointWriterFactory(object):
         self._io_buffer_double = writer_config[CHECKPOINT_IO_BUFFER_DOUBLE]
         self._data_parallel_writer = dp_writer_config
         self._io_multiplier = writer_config[CHECKPOINT_IO_MULTIPLIER]
-        if self._data_parallel_writer.pure_dp:
-            self._show_statistics = writer_config[CHECKPOINT_IO_STATISTICS] and self._data_parallel_writer is not None
-        else:
-            self._show_statistics = writer_config[CHECKPOINT_IO_STATISTICS] and self._data_parallel_writer is not None
+        self._show_statistics = writer_config[CHECKPOINT_IO_STATISTICS] and self._data_parallel_writer is not None
         self._io_buffer = None
         self._dnvme_handle = None
         self._writer = None
@@ -34,9 +31,6 @@ class CheckpointWriterFactory(object):
                 self._setup_for_gds(aio_config)
             else:
                 self._setup_for_aio(aio_config)
-        print(
-            f'WriterFactory: self._data_parallel_writer={self._data_parallel_writer} self._show_statistics={self._show_statistics}'
-        )
 
     def create_writer(self, file_path, optimize_dp_state):
         assert self._writer is None, \


### PR DESCRIPTION
In `deepspeed/runtime/model_checkpointing/writer_factory.py`:

1. The `pure_dp` if/else computed the byte-identical expression in both arms (AST-verified) — collapsed to a single assignment.
2. Removed an unconditional `print(f'WriterFactory: …')` debug line that was dumped to stdout of every user process constructing the fast checkpoint writer (`deepspeed/runtime/checkpoint_engine/fast_checkpoint_engine.py`).

### Checklist

- [x] `python -m py_compile` passes on the touched file
- [x] No behavior change beyond removing stdout noise

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>