### PR TITLE
docs(sparse_attention): fix copy-pasted BigBird return line in sliding-window layout

### DIFF
--- a/deepspeed/ops/sparse_attention/sparsity_config.py
+++ b/deepspeed/ops/sparse_attention/sparsity_config.py
@@ -715,7 +715,7 @@ class LocalSlidingWindowSparsityConfig(SparsityConfig):
         Arguments:
              seq_len: required: an integer determining number of attention heads of the layer.
         Return:
-             layout: a tensor of dimension (num_heads, num_blocks, num_blocks) containing `BigBird` sparsity layout of all head
+             layout: a tensor of dimension (num_heads, num_blocks, num_blocks) containing `Local Sliding Window` sparsity layout of all head
         """
 
         layout = self.setup_layout(seq_len)


### PR DESCRIPTION
`LocalSlidingWindowSparsityConfig.make_layout` builds a sliding-window sparsity layout (via `set_sliding_window_layout`), but its `Return:` line was copied verbatim from `BigBirdSparsityConfig.make_layout` and claims to return a `BigBird` layout. The line now names the layout this class actually produces. Docs-only.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>