### PR TITLE
docs: point CONTRIBUTING's installation link at the README section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ python ci/tests_fetcher.py --base origin/master --explain
 > `pull_request`-triggered run or the `modal` CLI.
 
 ### Model Tests
-To execute model tests, first [install DeepSpeed](#installation). The
+To execute model tests, first [install DeepSpeed](README.md#installation). The
 [DeepSpeedExamples](https://github.com/deepspeedai/DeepSpeedExamples/) repository is cloned
 as part of this process. Next, execute the model test driver:
 ```bash


### PR DESCRIPTION
The 'Model Tests' section links `[install DeepSpeed](#installation)`, but CONTRIBUTING.md has no Installation heading — the section lives in README.md. The link now targets `README.md#installation`.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>