### PR TITLE
Sort checkpoint shard files by numeric rank

### DIFF
--- a/deepspeed/checkpoint/ds_to_universal.py
+++ b/deepspeed/checkpoint/ds_to_universal.py
@@ -61,6 +61,7 @@ from deepspeed.checkpoint.autoep_zero3_metadata import (
     validate_autoep_zero3_partitioned_metadata,
 )
 from deepspeed.checkpoint.affine import ParamAffineMap, AFFINE_MAP_FORMAT_VERSION
+from deepspeed.checkpoint.utils import natural_keys
 
 
 def parse_arguments():
@@ -91,19 +92,6 @@ def parse_arguments():
     args = parser.parse_args()
     print(f'args = {args}')
     return args
-
-
-def atoi(text):
-    return int(text) if text.isdigit() else text
-
-
-def natural_keys(text):
-    '''
-    alist.sort(key=natural_keys) sorts in human order
-    http://nedbatchelder.com/blog/200712/human_sorting.html
-    (See Toothy's implementation in the comments)
-    '''
-    return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
 def _create_checkpoint_paths(base_folder, iteration, tp_degree, pp_degree):

--- a/deepspeed/checkpoint/utils.py
+++ b/deepspeed/checkpoint/utils.py
@@ -4,8 +4,22 @@
 # DeepSpeed Team
 
 import os
+import re
 import torch
 from .constants import (MODEL_FILE_PREFIX, MODEL_FILE_SUFFIX, OPTIM_FILE_SUFFIX, ZERO_FILE_PREFIX)
+
+
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+
+def natural_keys(text):
+    '''
+    alist.sort(key=natural_keys) sorts in human order
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    (See Toothy's implementation in the comments)
+    '''
+    return [atoi(c) for c in re.split(r'(\d+)', text)]
 
 
 def get_model_ckpt_name_for_rank(base_folder, mp_rank_str):

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -85,7 +85,7 @@ from deepspeed.checkpoint.autoep_zero3_metadata import (
     is_autoep_zero3_partitioned_entry,
     validate_autoep_zero3_partitioned_metadata,
 )
-from deepspeed.checkpoint.utils import clone_tensors_for_torch_save
+from deepspeed.checkpoint.utils import clone_tensors_for_torch_save, natural_keys
 from deepspeed.checkpoint.ds_to_universal import dp_index_to_str
 from deepspeed.runtime.sparse_tensor import SparseTensor
 
@@ -4432,7 +4432,8 @@ class DeepSpeedEngine(Module):
         import glob
 
         ckpt_files = glob.glob(ckpt_file_pattern)
-        ckpt_files.sort()
+        # Callers index this list by model-parallel rank, so it must be ordered numerically.
+        ckpt_files.sort(key=natural_keys)
         return ckpt_files
 
     def load_checkpoint(self,

--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -20,7 +20,7 @@ from ..activation_checkpointing import checkpointing
 from .topology import PipeDataParallelTopology, PipelineParallelGrid
 from deepspeed.runtime.state_dict_factory import SDLoaderFactory
 from deepspeed.accelerator import get_accelerator
-from deepspeed.checkpoint.utils import clone_tensors_for_torch_save
+from deepspeed.checkpoint.utils import clone_tensors_for_torch_save, natural_keys
 
 
 class PipelineError(Exception):
@@ -601,7 +601,8 @@ class PipelineModule(nn.Module):
         layer_ckpt_path = os.path.join(ckpt_dir, f'layer_{idx:02d}-')
         layer_ckpt_path += "*model_states.pt"
         ckpt_files = glob.glob(layer_ckpt_path)
-        ckpt_files.sort()
+        # Callers index this list by model-parallel rank, so it must be ordered numerically.
+        ckpt_files.sort(key=natural_keys)
         return ckpt_files
 
     def save_state_dict(self, save_dir, checkpoint_engine, exclude_frozen_params=False):

--- a/tests/unit/checkpoint/test_ckpt_file_ordering.py
+++ b/tests/unit/checkpoint/test_ckpt_file_ordering.py
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import os
+from types import SimpleNamespace
+
+import torch
+
+from deepspeed.runtime.engine import DeepSpeedEngine
+from deepspeed.runtime.pipe.module import PipelineModule
+from deepspeed.runtime.pipe.topology import PipeModelDataParallelTopology
+from deepspeed.runtime.state_dict_factory import SDLoaderFactory
+
+# The rank field in a checkpoint file name is padded to two digits, so this is the
+# smallest interesting degree: the field overflows and lexicographic order diverges
+# from rank order.
+MP_DEGREE_OVER_PAD = 128
+MP_DEGREE_UNDER_PAD = 8
+
+
+class PipelineModuleStub:
+    """Supplies only the attributes the two checkpoint path methods read off ``self``."""
+
+    ckpt_layer_path = PipelineModule.ckpt_layer_path
+    ckpt_layer_path_list = PipelineModule.ckpt_layer_path_list
+
+    def __init__(self, topo, global_rank=0):
+        self._local_start = 0
+        self.global_rank = global_rank
+        self._grid = SimpleNamespace(_topo=topo)
+
+
+class EngineStub:
+    """Supplies only the attributes the two checkpoint name methods read off ``self``."""
+
+    _get_ckpt_name = DeepSpeedEngine._get_ckpt_name
+    _get_all_ckpt_names = DeepSpeedEngine._get_all_ckpt_names
+
+    def __init__(self, checkpoint_mp_rank=0):
+        self.checkpoint_mp_rank = checkpoint_mp_rank
+
+    def zero_optimization_partition_weights(self):
+        return False
+
+    def load_universal_checkpoint(self):
+        return False
+
+
+def write_pipeline_layer_shards(ckpt_dir, mp_degree):
+    topo = PipeModelDataParallelTopology(num_pp=1, num_mp=mp_degree, num_dp=1)
+    for rank in range(mp_degree):
+        torch.save({'rank': rank}, PipelineModuleStub(topo, rank).ckpt_layer_path(ckpt_dir, 0))
+    return topo
+
+
+def test_pipeline_layer_shards_load_by_numeric_rank(tmpdir):
+    ckpt_dir = str(tmpdir)
+    topo = write_pipeline_layer_shards(ckpt_dir, MP_DEGREE_OVER_PAD)
+
+    ckpt_list = PipelineModuleStub(topo).ckpt_layer_path_list(ckpt_dir, 0)
+    assert len(ckpt_list) == MP_DEGREE_OVER_PAD
+
+    sd_loader = SDLoaderFactory.get_sd_loader(ckpt_list, version=2.0, checkpoint_engine=None)
+    for mp_rank in range(MP_DEGREE_OVER_PAD):
+        _, sd, _ = sd_loader.load(MP_DEGREE_OVER_PAD, mp_rank, module_key=None, is_pipe_parallel=True)
+        assert sd['rank'] == mp_rank
+
+
+def test_engine_checkpoint_names_ordered_by_numeric_rank(tmpdir):
+    ckpt_dir, tag = str(tmpdir), 'global_step100'
+    os.makedirs(os.path.join(ckpt_dir, tag))
+    for rank in range(MP_DEGREE_OVER_PAD):
+        torch.save({'rank': rank}, EngineStub(rank)._get_ckpt_name(ckpt_dir, tag))
+
+    ckpt_files = EngineStub()._get_all_ckpt_names(ckpt_dir, tag)
+    assert len(ckpt_files) == MP_DEGREE_OVER_PAD
+
+    loaded = [torch.load(f, weights_only=True)['rank'] for f in ckpt_files]
+    assert loaded == list(range(MP_DEGREE_OVER_PAD))
+
+
+def test_shard_order_below_pad_width_matches_lexicographic(tmpdir):
+    # Every checkpoint written before this change has a rank field of at most two
+    # digits, where the two orderings agree, so none of them is reordered.
+    ckpt_dir = str(tmpdir)
+    topo = write_pipeline_layer_shards(ckpt_dir, MP_DEGREE_UNDER_PAD)
+
+    ckpt_list = PipelineModuleStub(topo).ckpt_layer_path_list(ckpt_dir, 0)
+    loaded = [torch.load(p, weights_only=True)['rank'] for p in ckpt_list]
+    assert loaded == list(range(MP_DEGREE_UNDER_PAD))
+    assert ckpt_list == sorted(ckpt_list)


### PR DESCRIPTION
`get_rank_repr` pads the rank field in a shard file name to two digits, and the readers that glob those names sort them as plain strings before indexing the result by model-parallel rank. Past a parallel degree of 100 the pad overflows and the order stops matching the index: `model_100` sorts between `model_10` and `model_11`, so rank 11 loads rank 100's shard. Nothing raises and the shapes still match; the weights are just wrong. That is the failure this issue predicted.

A globbed shard list has to be ordered by numeric rank, because `MegatronSDLoader` indexes it positionally and `get_merge_state_dicts`/`get_split_state_dict` slice contiguous rank ranges out of it. Two call sites feed that loader, `PipelineModule.ckpt_layer_path_list` and `DeepSpeedEngine._get_all_ckpt_names`, both added in the same commit and both affected. They now sort with `natural_keys`, which `get_checkpoint_files` in `zero_to_fp32.py` and `_get_checkpoint_files` in `ds_to_universal.py` already use for globbed checkpoint files; it moves to `checkpoint/utils.py` so `ds_to_universal.py` can drop its copy, while `zero_to_fp32.py` keeps its own because it ships standalone.

Widening the pad would rename shards on disk and break existing checkpoints. Sorting on the read side leaves the format alone: the two orders agree whenever every rank field is two digits or fewer, so nothing written so far is reordered. I left out the pad-overflow assert suggested in the issue, since the read path no longer depends on the pad width.

This only bites at a tensor or model parallel degree of 100 or more, which is rare and is probably why it has sat since 2021. The failure is silent, though, and the fix is a sort key.

Verified in a CPU container:

- Three tests in `tests/unit/checkpoint/test_ckpt_file_ordering.py`. Reverting the `module.py` sort key on its own fails the pipeline test (`assert 100 == 11`), and reverting the `engine.py` one on its own fails the engine test. The third pins the sub-100 order and is green either way, so I reordered the list in place to confirm it can fail.
- `unit/checkpoint/` and `unit/runtime/pipe/`: the same 10 failures and 154 errors as unmodified master, plus the three new passes. Those are the GPU and multi-process tests this box cannot run.
- `pre-commit` on the changed files: clean.

I have not run a real 100-way parallel job. The repro drives the actual naming, listing and loader index over 128 shards in a single process.

Fixes #1381
