### PR TITLE
[Phase 2] Add NEON SIMD path for CPU Adam on AArch64

### DIFF
--- a/csrc/adam/cpu_adam_impl.cpp
+++ b/csrc/adam/cpu_adam_impl.cpp
@@ -41,7 +41,7 @@ void Adam_Optimizer::Step_1(ds_params_precision_t* _params,
                             bool parallel)
 {
     size_t rounded_size = 0;
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
     Step_AVX<1>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size, parallel);
 #elif defined(__SVE__) && defined(__ARM_FEATURE_SVE)
     Step_SVE<1>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size, parallel);
@@ -93,7 +93,7 @@ void Adam_Optimizer::Step_4(ds_params_precision_t* _params,
                             bool parallel)
 {
     size_t rounded_size = 0;
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
     Step_AVX<4>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size, parallel);
 #elif defined(__SVE__) && defined(__ARM_FEATURE_SVE)
     Step_SVE<4>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size, parallel);
@@ -156,7 +156,7 @@ void Adam_Optimizer::Step_8(ds_params_precision_t* _params,
                             bool parallel)
 {
     size_t rounded_size = 0;
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
     Step_AVX<8>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size, parallel);
 #elif defined(__SVE__) && defined(__ARM_FEATURE_SVE)
     Step_SVE<8>(&rounded_size, _params, grads, _exp_avg, _exp_avg_sq, _param_size, parallel);
@@ -476,7 +476,7 @@ private:
 
 // SIMD block the Adam AVX kernel rounds to (Step_8 => span 8). Slicing on multiples of
 // this keeps each slice's AVX/scalar boundary identical to the whole-tensor kernel.
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
 static constexpr size_t kZenAdamAlign = SIMD_WIDTH * 8;
 #else
 static constexpr size_t kZenAdamAlign = 1;

--- a/csrc/includes/cpu_adam.h
+++ b/csrc/includes/cpu_adam.h
@@ -45,7 +45,7 @@ public:
     }
     ~Adam_Optimizer() {}
 
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
     template <int span, typename ds_params_precision_t, typename ds_state_precision_t>
     void Step_AVX(size_t* rounded_size,
                   ds_params_precision_t* _params,
@@ -122,7 +122,7 @@ private:
     bool _adamw_mode;
 };
 
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
 template <int span, typename ds_params_precision_t, typename ds_state_precision_t>
 void Adam_Optimizer::Step_AVX(size_t* rounded_size,
                               ds_params_precision_t* _params,
@@ -132,7 +132,7 @@ void Adam_Optimizer::Step_AVX(size_t* rounded_size,
                               size_t _param_size,
                               bool parallel)
 {
-#if !defined(__AVX512__)
+#if !defined(__AVX512__) && !defined(__NEON__)
     if (std::is_same_v<ds_params_precision_t, c10::BFloat16> ||
         std::is_same_v<ds_state_precision_t, c10::BFloat16>) {
         return;

--- a/csrc/includes/simd.h
+++ b/csrc/includes/simd.h
@@ -11,8 +11,12 @@
 #endif
 
 #define TILE (128 * 1024 * 1024)
-#if defined(__AVX512__) or defined(__AVX256__)
+#if defined(__AVX512__) or defined(__AVX256__) or defined(__NEON__)
+#if defined(__NEON__)
+#include <arm_neon.h>
+#else
 #include <immintrin.h>
+#endif
 
 template <typename T>
 inline T readAs(const void* src)
@@ -114,6 +118,60 @@ static void store_16_f32_as_bf16_nearest(__m512 v, void* data)
     _mm_store_ps(x, _mm_castsi128_ps(_mm256_cvtps_ph(d, _MM_FROUND_TO_NEAREST_INT)))
 
 #define INTV __m128i
+#elif defined(__NEON__)
+#define SIMD_STORE(a, d) vst1q_f32(a, d)
+#define SIMD_LOAD(x) vld1q_f32(x)
+#define SIMD_SET(x) vdupq_n_f32(x)
+#define SIMD_ADD(x, y) vaddq_f32(x, y)
+#define SIMD_MUL(x, y) vmulq_f32(x, y)
+// vfmaq accumulates into its first operand, while the x86 macros take the addend last.
+#define SIMD_FMA(x, y, c) vfmaq_f32(c, x, y)
+#define SIMD_SQRT(x) vsqrtq_f32(x)
+#define SIMD_DIV(x, y) vdivq_f32(x, y)
+#define SIMD_AND(x, y) \
+    vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(x), vreinterpretq_u32_f32(y)))
+// x86 andnot(x, y) computes ~x & y; NEON bic(a, b) computes a & ~b, so the operands swap.
+#define SIMD_ANDNOT(x, y) \
+    vreinterpretq_f32_u32(vbicq_u32(vreinterpretq_u32_f32(y), vreinterpretq_u32_f32(x)))
+#define SIMD_OR(x, y) \
+    vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(x), vreinterpretq_u32_f32(y)))
+#define SIMD_XOR(x, y) \
+    vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(x), vreinterpretq_u32_f32(y)))
+#define SIMD_WIDTH 4
+
+static inline float32x4_t load_4_bf16_as_f32(const void* data)
+{
+    // bf16 is the high half of an fp32 pattern, so widen and shift into place.
+    uint16x4_t a = vld1_u16((const uint16_t*)data);
+    uint32x4_t b = vshlq_n_u32(vmovl_u16(a), 16);
+    return vreinterpretq_f32_u32(b);
+}
+
+static inline void store_4_f32_as_bf16_nearest(float32x4_t v, void* data)
+{
+    // Same round-to-nearest-even-with-nan-quieting flow as the AVX512 version above.
+    uint32x4_t u32 = vreinterpretq_u32_f32(v);
+
+    // uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
+    uint32x4_t lsb = vandq_u32(vshrq_n_u32(u32, 16), vdupq_n_u32(1));
+    uint32x4_t rounding_bias = vaddq_u32(lsb, vdupq_n_u32(0x7fff));
+    // vaddhn keeps the high halves of the sums, which is exactly (u32 + bias) >> 16 narrowed.
+    uint16x4_t non_nan_res = vaddhn_u32(u32, rounding_bias);
+
+    // if ((x & 0x7fffffffU) > 0x7f800000U) the result is a quiet nan
+    uint32x4_t non_sign_bits = vandq_u32(u32, vdupq_n_u32(0x7fffffff));
+    uint16x4_t nan_mask = vmovn_u32(vcgtq_u32(non_sign_bits, vdupq_n_u32(0x7f800000)));
+    uint16x4_t res = vbsl_u16(nan_mask, vdup_n_u16(0x7fc0), non_nan_res);
+
+    vst1_u16((uint16_t*)data, res);
+}
+#define SIMD_LOAD_BF16(x) load_4_bf16_as_f32(x)
+#define SIMD_STORE_BF16(x, d) store_4_f32_as_bf16_nearest(d, x)
+
+#define SIMD_LOAD_FP16(x) vcvt_f32_f16(vld1_f16((const float16_t*)(x)))
+#define SIMD_STORE_FP16(x, d) vst1_f16((float16_t*)(x), vcvt_f16_f32(d))
+
+#define INTV uint16x4_t
 #endif
 
 union AVX_Data {
@@ -121,6 +179,8 @@ union AVX_Data {
     __m512 data;
 #elif defined(__AVX256__)
     __m256 data;
+#elif defined(__NEON__)
+    float32x4_t data;
 #endif
     // float data_f[16];
 };
@@ -138,7 +198,7 @@ template <int span, typename T>
 inline typename std::enable_if_t<std::is_same_v<T, c10::BFloat16>, void> simd_store(T* dst,
                                                                                     AVX_Data* src)
 {
-#ifdef __AVX512__
+#if defined(__AVX512__) or defined(__NEON__)
     size_t width = SIMD_WIDTH;
 #pragma unroll
     for (size_t i = 0; i < span; ++i) { SIMD_STORE_BF16((float*)(dst + width * i), src[i].data); }
@@ -168,7 +228,7 @@ template <int span, typename T>
 inline typename std::enable_if_t<std::is_same_v<T, c10::BFloat16>, void> simd_load(AVX_Data* dst,
                                                                                    T* src)
 {
-#ifdef __AVX512__
+#if defined(__AVX512__) or defined(__NEON__)
     size_t width = SIMD_WIDTH;
 #pragma unroll
     for (size_t i = 0; i < span; ++i) { dst[i].data = SIMD_LOAD_BF16((float*)(src + width * i)); }

--- a/op_builder/builder.py
+++ b/op_builder/builder.py
@@ -512,6 +512,10 @@ class OpBuilder(ABC):
                 return '-D__AVX256__'
         elif (cpu_info['arch'] or '').startswith('ARM') and 'sve' in cpu_info['flags']:
             return '-D__SVE__'
+        elif cpu_info['arch'] == 'ARM_8':
+            # NEON is baseline on AArch64; vdivq/vsqrtq used by simd.h are A64-only,
+            # so do not advertise it for 32-bit ARM.
+            return '-D__NEON__'
         return '-D__SCALAR__'
 
     def command_exists(self, cmd):

--- a/op_builder/mps/cpu_adam.py
+++ b/op_builder/mps/cpu_adam.py
@@ -46,7 +46,7 @@ class CPUAdamBuilder(MPSOpBuilder):
             return None
 
     def cxx_args(self):
-        args = ['-O3', '-std=c++17', '-g', '-Wno-reorder', '-D__SCALAR__']
+        args = ['-O3', '-std=c++17', '-g', '-Wno-reorder', '-D__NEON__']
         libomp = self._libomp_prefix()
         if libomp is not None:
             args += ['-Xpreprocessor', '-fopenmp', f'-I{libomp}/include']

--- a/op_builder/mps/cpu_adam.py
+++ b/op_builder/mps/cpu_adam.py
@@ -46,7 +46,9 @@ class CPUAdamBuilder(MPSOpBuilder):
             return None
 
     def cxx_args(self):
-        args = ['-O3', '-std=c++17', '-g', '-Wno-reorder', '-D__NEON__']
+        # No -std flag: torch.utils.cpp_extension supplies the standard its own headers need
+        # (c++20 on current torch), and a hardcoded value here would override it.
+        args = ['-O3', '-g', '-Wno-reorder', '-D__NEON__']
         libomp = self._libomp_prefix()
         if libomp is not None:
             args += ['-Xpreprocessor', '-fopenmp', f'-I{libomp}/include']


### PR DESCRIPTION
## Summary

Phase 2 of Apple Silicon support (follow-up to #8293/#8300/#8335): the CPU Adam kernel — the ZeRO-Offload optimizer path — ran scalar on AArch64 machines without SVE, which includes every Apple Silicon Mac. This adds a 4-lane NEON implementation of the existing SIMD macro layer.

### Changes

- **`csrc/includes/simd.h`** — a `__NEON__` branch defining the full macro set (`SIMD_LOAD/STORE/SET/ADD/MUL/FMA/SQRT/DIV/AND/ANDNOT/OR/XOR`, width 4):
  - fp16 via the hardware converters (`vcvt_f32_f16` / `vcvt_f16_f32`).
  - bf16 via the same round-to-nearest-even + NaN-quieting flow as the AVX512 `store_16_f32_as_bf16_nearest` (using `vaddhn_u32` for the add-and-take-high-half step); loads are widen+shift.
  - x86 `andnot(x, y) = ~x & y` maps to `vbicq(y, x)` — operand order preserved (documented in a comment).
  - The bf16 `simd_load`/`simd_store` guards widen from AVX512-only to AVX512-or-NEON.
- **`csrc/includes/cpu_adam.h`** — `Step_AVX`'s non-AVX512 bf16 bailout is lifted for NEON (this was silently sending bf16 back to the scalar tail); the two Adam gates widen to include `__NEON__`.
- **`csrc/adam/cpu_adam_impl.cpp`** — same gate widening (4 sites, including `kZenAdamAlign`). The NEON branch sits before the existing `__SVE__` alternative and they remain mutually exclusive builder-emitted defines.
- **`op_builder/builder.py`** — `simd_width()` advertises `-D__NEON__` for `ARM_8` without SVE. 32-bit ARM keeps `__SCALAR__`: the `vdivq_f32`/`vsqrtq_f32` intrinsics used are A64-only.
- **`op_builder/mps/cpu_adam.py`** — switches from `-D__SCALAR__` to `-D__NEON__`.
- Lion/Adagrad/AIO gates are untouched and keep their current scalar behavior on ARM (candidate follow-ups).

### Measured on Apple M5 Max (macOS 26.3, Apple clang, Homebrew libomp)

`DeepSpeedCPUAdam` step, 50M params, 10-step average, vs the `-D__SCALAR__` build of the same tree:

| dtype | scalar | NEON | speedup |
|---|---|---|---|
| fp32 | 11.5 ms | 3.8 ms | 3.0× |
| fp16 | 11.5 ms | 3.3 ms | 3.5× |
| bf16 | 12.7 ms | 4.9 ms | 2.6× |

### Correctness

- NEON and scalar builds produce **bit-identical** fp16 results on identical inputs (5 steps, 1M params).
- All dtypes (fp32/fp16/bf16 params; fp32 and bf16 moments) match an fp32 `torch.optim.Adam/AdamW` oracle within storage rounding, at sizes exercising pure-SIMD, SIMD+scalar-tail (1000003), and sub-width (3) paths.
- Existing suites on the M5 Max: `test_cpu_adam.py` + `test_hybrid_adam.py` + `test_adamw.py` — 122 passed, 7 skipped. The `mps-torch-latest` CI workflow JIT-builds this kernel in its offload configs, so the NEON path is exercised upstream on every touching PR.
