### PR TITLE
fix(inference): reject non-positive max_out_tokens at config validation

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -310,6 +310,12 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
             return field_value
         raise TypeError(f"Invalid type for dtype: {type(field_value)}")
 
+    @field_validator("max_out_tokens")
+    def validate_max_out_tokens(cls, field_value, values):
+        if field_value <= 0:
+            raise ValueError(f"max_out_tokens must be a positive integer, got {field_value}")
+        return field_value
+
     @field_validator("moe")
     def moe_backward_compat(cls, field_value, values):
         if isinstance(field_value, bool):

--- a/tests/unit/inference/test_inference_config.py
+++ b/tests/unit/inference/test_inference_config.py
@@ -82,3 +82,27 @@ class TestInferenceConfig(DistributedTest):
             config = DeepSpeedInferenceConfig(moe=value)
             assert isinstance(config.moe, DeepSpeedMoEConfig)
             assert config.moe.enabled == value
+
+
+@pytest.mark.inference
+class TestInferenceConfigValidation:
+    """CPU-only validation tests for DeepSpeedInferenceConfig."""
+
+    def test_negative_max_out_tokens_rejected(self):
+        # Regression test for https://github.com/deepspeedai/DeepSpeed/issues/8339
+        from deepspeed.inference.config import DeepSpeedInferenceConfig
+
+        with pytest.raises(ValueError, match="max_out_tokens must be a positive integer"):
+            DeepSpeedInferenceConfig(max_out_tokens=-1)
+
+    def test_zero_max_out_tokens_rejected(self):
+        from deepspeed.inference.config import DeepSpeedInferenceConfig
+
+        with pytest.raises(ValueError, match="max_out_tokens must be a positive integer"):
+            DeepSpeedInferenceConfig(max_out_tokens=0)
+
+    def test_positive_max_out_tokens_accepted(self):
+        from deepspeed.inference.config import DeepSpeedInferenceConfig
+
+        config = DeepSpeedInferenceConfig(max_out_tokens=128)
+        assert config.max_out_tokens == 128


### PR DESCRIPTION
Fixes #8339

DeepSpeed currently accepts a negative (or zero) value for `max_out_tokens` during inference config parsing. The failure only surfaces later at generation time with a confusing "Input with size N exceeds maximum length of -1" message.

This PR adds a small pydantic field validator on `max_out_tokens` so that non-positive values raise a clear `ValueError` when the config is constructed.

Changes:
- `deepspeed/inference/config.py`: add `validate_max_out_tokens` field validator.
- `tests/unit/inference/test_inference_config.py`: add CPU-only regression tests for -1, 0, and positive values.

Verified:
- `CUDA_VISIBLE_DEVICES="" python -m pytest tests/unit/inference/test_inference_config.py -m inference -k TestInferenceConfigValidation -v` passes (3/3).
- `pre-commit run --files deepspeed/inference/config.py tests/unit/inference/test_inference_config.py` passes (yapf, flake8, license, codespell, check-torchdist, etc.).