### PR TITLE
Rebuild the full argument list when partitioning activations

### DIFF
--- a/deepspeed/runtime/activation_checkpointing/checkpointing.py
+++ b/deepspeed/runtime/activation_checkpointing/checkpointing.py
@@ -350,16 +350,13 @@ def merge_tensors(tensor_objects, non_tensor_objects, tensor_flags):
 
     real_tensor_flags = None
 
-    # remove the flags that are assigned to the size of the flattened tensors
+    # get_partitioned_activations_for_backward() saved a (value, size) pair for every argument, so
+    # the flags and the non-tensors both hold one extra entry per argument. A tensor argument pairs
+    # with a tensor size and a non-tensor argument pairs with None, so every argument owns an even
+    # index in each list and dropping the odd ones restores one entry per original argument.
     if PARTITION_ACTIVATIONS:
-        real_tensor_flags = []
-        previous_flag = False
-        for flag in tensor_flags:
-            if previous_flag:
-                previous_flag = False
-                continue
-            previous_flag = flag
-            real_tensor_flags.append(flag)
+        real_tensor_flags = tensor_flags[::2]
+        non_tensor_objects = non_tensor_objects[::2]
     else:
         real_tensor_flags = tensor_flags
 

--- a/tests/unit/runtime/activation_checkpointing/test_activation_checkpointing.py
+++ b/tests/unit/runtime/activation_checkpointing/test_activation_checkpointing.py
@@ -496,3 +496,61 @@ def test_configure_with_contiguous_checkpointing_requires_num_checkpoints():
             cp.mpu,
             cp.deepspeed_checkpointing_enabled,
         ) = saved
+
+
+def _partitioned_backward_args(args):
+    """Run an argument list through the save and restore path `partition_activations` uses.
+
+    This mirrors `CheckpointFunction.forward`/`backward` without an accelerator, so it runs on CPU.
+    """
+    cp = deepspeed.checkpointing
+    saved = _snapshot_ckpt_config()
+    saved_mp = (cp.mp_group, cp.mp_size)
+    try:
+        cp.PARTITION_ACTIVATIONS = True
+        cp.CONTIGUOUS_CHECKPOINTING = False
+        cp.mp_group, cp.mp_size = None, 1
+
+        inputs = tuple(a.clone() if torch.is_tensor(a) else a for a in args)
+        new_args = cp.get_partitioned_activations_for_backward(list(args), inputs, False)
+        tensor_args, non_tensor_args, tensor_flags = cp.extract_tensors(all_objects=tuple(new_args))
+
+        for tensor in tensor_args:
+            if tensor is not None and getattr(tensor, 'saved_data', None) is not None:
+                tensor.data = tensor.saved_data.to(tensor.device)
+                tensor.saved_data = None
+
+        gathered = cp.gather_partitioned_activations(tensor_args)
+        return cp.merge_tensors(tensor_objects=gathered, non_tensor_objects=non_tensor_args, tensor_flags=tensor_flags)
+    finally:
+        _restore_ckpt_config(saved)
+        cp.mp_group, cp.mp_size = saved_mp
+
+
+@pytest.mark.parametrize('non_tensor', [None, 2, True, 2.5, (None, 2.5)])
+def test_partitioned_non_tensor_args_survive_the_round_trip(non_tensor):
+    """The recompute must be handed the arguments the forward pass received, not extra `None`s."""
+    tensor = torch.rand(HIDDEN_DIM, requires_grad=True)
+    args = (tensor, non_tensor)
+
+    merged = _partitioned_backward_args(args)
+
+    assert len(merged) == len(args)
+    assert torch.is_tensor(merged[0])
+    if non_tensor is None:
+        assert merged[1] is None
+    else:
+        assert merged[1] == non_tensor
+
+
+def test_partitioned_args_keep_their_order_around_a_non_tensor():
+    """A non-tensor argument must not shift the arguments that follow it."""
+    first = torch.rand(HIDDEN_DIM, requires_grad=True)
+    second = torch.rand(HIDDEN_DIM, requires_grad=True)
+    args = (first, None, True, second)
+
+    merged = _partitioned_backward_args(args)
+
+    assert [torch.is_tensor(item) for item in merged] == [True, False, False, True]
+    assert merged[1] is None
+    assert merged[2] is True


### PR DESCRIPTION
With `partition_activations` on, a checkpointed function that takes any non-tensor argument gets a corrupted argument list on the recompute.

**Cause:** `get_partitioned_activations_for_backward` saves a `(value, size)` pair for *every* argument, so `tensor_flags` and `non_tensor_objects` both hold two entries per argument. `merge_tensors` collapsed the flags by skipping the one after a `True`, which drops nothing for a non-tensor argument, whose value and its `None` size are both non-tensors. It never collapsed the non-tensor values at all.

Driving the real save and restore helpers on CPU:

| forward was called with | recompute received |
| --- | --- |
| `(tensor, tensor)` | `(tensor, tensor)` |
| `(tensor, 2)` | `(tensor, 2, None)` |
| `(tensor, None)` | `(tensor, None, None)` |
| `(tensor, None, 2.5)` | `(tensor, None, None, 2.5, None)` |
| `(tensor, None, True, tensor)` | `(tensor, None, None, True, None, tensor)` |

So a stray `None` lands after every non-tensor argument and shifts everything after it. `TestCheckpointNonTensor` already covers these exact argument shapes, but never with `partition_activations`.

**Fix:** every argument owns an even index in both lists, so drop the odd ones.

```python
real_tensor_flags = tensor_flags[::2]
non_tensor_objects = non_tensor_objects[::2]
```

All-tensor arguments are unaffected, which is why this went unnoticed.

**Test:** two tests in `tests/unit/runtime/activation_checkpointing/test_activation_checkpointing.py` drive the real `get_partitioned_activations_for_backward`, `extract_tensors`, `gather_partitioned_activations` and `merge_tensors`, so they run on CPU without an accelerator.

```
pytest tests/unit/runtime/activation_checkpointing/test_activation_checkpointing.py -k partitioned
  on master:  6 failed  (assert 3 == 2)
  with this:  6 passed
```

The end-to-end path cannot run here: `_test_activation_checkpoint` skips on the CPU accelerator, and `CheckpointFunction.forward` needs a real `Stream`. Flagging that rather than implying otherwise. `yapf` and `flake8 --config=.flake8` are clean on both files.
