### PR TITLE
fix(inference): break circular import in ops.transformer.inference

### DIFF
--- a/deepspeed/ops/transformer/inference/__init__.py
+++ b/deepspeed/ops/transformer/inference/__init__.py
@@ -4,5 +4,23 @@
 # DeepSpeed Team
 
 from .config import DeepSpeedInferenceConfig
-from ....model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference
 from .moe_inference import DeepSpeedMoEInferenceConfig, DeepSpeedMoEInference
+
+__all__ = [
+    "DeepSpeedInferenceConfig",
+    "DeepSpeedMoEInferenceConfig",
+    "DeepSpeedMoEInference",
+    "DeepSpeedTransformerInference",
+]
+
+
+def __getattr__(name: str):
+    # Lazy import breaks the circular dependency between this package and
+    # `deepspeed.model_implementations.transformers.ds_transformer`, which
+    # imports `deepspeed.ops.transformer.inference.triton.*` at module load
+    # time when Triton is installed. Accessing the symbol on demand keeps the
+    # package import path acyclic.
+    if name == "DeepSpeedTransformerInference":
+        from ....model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference
+        return DeepSpeedTransformerInference
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/inference/test_inference_import.py
+++ b/tests/unit/inference/test_inference_import.py
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import pytest
+
+
+@pytest.mark.inference
+class TestInferenceImport:
+    """CPU-only tests for the public inference package import surface."""
+
+    def test_transformer_inference_is_lazy_imported(self):
+        # Regression test for https://github.com/deepspeedai/DeepSpeed/issues/7159
+        # Importing the inference package must not trigger a circular import even
+        # when Triton is installed, and the legacy public symbol must stay reachable.
+        from deepspeed.model_implementations.transformers.ds_transformer import (
+            DeepSpeedTransformerInference as DirectTransformerInference, )
+        from deepspeed.ops.transformer.inference import (
+            DeepSpeedTransformerInference as OpsTransformerInference, )
+
+        assert OpsTransformerInference is DirectTransformerInference


### PR DESCRIPTION
Closes #7159

Importing `deepspeed.ops.transformer.inference` eagerly loaded `DeepSpeedTransformerInference` from `model_implementations.transformers.ds_transformer`. That module imports Triton kernels at load time, and importing any submodule under `deepspeed.ops.transformer.inference.triton` while the parent `inference` package was still initializing caused a circular-import error on systems where Triton is installed.

Changes:
- Replace the eager import with a PEP-562 `__getattr__` and an explicit `__all__`, so `DeepSpeedTransformerInference` is resolved only when accessed.
- Add a CPU-only regression test asserting the symbol stays reachable.

Verified:
- `python -c "import deepspeed; from deepspeed.ops.transformer.inference import DeepSpeedTransformerInference"` passes with `deepspeed.HAS_TRITON=True`.
- `pytest tests/unit/inference/test_inference_import.py -m inference -xvs` passes.
- `pre-commit run --files deepspeed/ops/transformer/inference/__init__.py tests/unit/inference/test_inference_import.py` passes.
