### PR TITLE
[MPS] Update C++ Standard in CPUAdamBuilder 

### DIFF
--- a/op_builder/mps/cpu_adam.py
+++ b/op_builder/mps/cpu_adam.py
@@ -46,7 +46,10 @@ class CPUAdamBuilder(MPSOpBuilder):
             return None
 
     def cxx_args(self):
-        args = ['-O3', '-std=c++17', '-g', '-Wno-reorder', '-D__SCALAR__']
+        import torch
+        torch_major, torch_minor = (int(x) for x in torch.__version__.split('.')[:2])
+        cpp_standard = '-std=c++20' if (torch_major, torch_minor) >= (2, 12) else '-std=c++17'
+        args = ['-O3', cpp_standard, '-g', '-Wno-reorder', '-D__SCALAR__']
         libomp = self._libomp_prefix()
         if libomp is not None:
             args += ['-Xpreprocessor', '-fopenmp', f'-I{libomp}/include']


### PR DESCRIPTION
## Motivation
Fix #8267 CI failure in MPS CPU, which block the pr ci.

## Changes
This pull request updates the `cxx_args` method in `op_builder/mps/cpu_adam.py` to improve compatibility with newer versions of PyTorch. The main change is to select the appropriate C++ standard based on the detected PyTorch version.

Build compatibility improvement:

* [`op_builder/mps/cpu_adam.py`](diffhunk://#diff-2d1ae59bc654f8a04c10e13f7ab5b28e58964628234c3834450a4c8f97a399f1L49-R52): The C++ standard used in compilation is now set to `-std=c++20` for PyTorch versions 2.12 and above, and remains `-std=c++17` for earlier versions. This ensures compatibility with recent PyTorch releases.