### PR TITLE
Support dynamic parameter offload for ZeRO-3 inference

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -5954,10 +5954,6 @@ class DeepSpeedEngine(Module):
         param_offload_config = self.zero_offload_param()
         assert param_offload_config is None or param_offload_config.device == OffloadDeviceEnum.none, "Moving states across devices is not supported for offloaded parameters."
 
-        assert not isinstance(
-            self.optimizer,
-            DeepSpeedZeRoOffload), "Moving states across devices is not supported without an optimizer."
-
         if device == OffloadDeviceEnum.none:
             logger.warning("No device specified for offloading states.")
             return
@@ -5973,8 +5969,4 @@ class DeepSpeedEngine(Module):
         Arguments:
             non_blocking: Optional. Whether to offload the states asynchronously.
         """
-        assert not isinstance(
-            self.optimizer,
-            DeepSpeedZeRoOffload), "Moving states across devices is not supported without an optimizer."
-
         self.optimizer.reload_states(non_blocking=non_blocking)

--- a/deepspeed/runtime/zero/parameter_offload.py
+++ b/deepspeed/runtime/zero/parameter_offload.py
@@ -6,10 +6,11 @@
 import sys
 import torch
 from collections import OrderedDict
+from typing import Container
 from deepspeed.utils import z3_leaf_module, set_z3_leaf_module
 from deepspeed.runtime.utils import see_memory_usage
 from deepspeed.runtime.zero.utils import apply_to_tensors_only, is_zero_param
-from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum
+from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum, OffloadStateTypeEnum
 from deepspeed.runtime.zero.partition_parameters import _init_external_params
 from deepspeed.runtime.zero.partition_parameters import *
 from deepspeed.runtime.zero.partitioned_param_coordinator import PartitionedParameterCoordinator, InflightParamRegistry, iter_params
@@ -168,6 +169,7 @@ class DeepSpeedZeRoOffload(object):
         self.dp_process_group = dp_process_group
         self.offload_device = None
         self.offload_param_pin_memory = False
+        self._offloaded_param_partitions = []
         self.zero_param_parallel_group = zero_param_parallel_group
         self.zero_quantized_weights = zero_quantized_weights
         self.zero_quantized_nontrainable_weights = zero_quantized_nontrainable_weights
@@ -255,6 +257,70 @@ class DeepSpeedZeRoOffload(object):
     def empty_partition_cache(self):
         self.partition_all_parameters()
 
+    @torch.no_grad()
+    def offload_states(self,
+                       include: Container[OffloadStateTypeEnum] = None,
+                       device: OffloadDeviceEnum = OffloadDeviceEnum.cpu,
+                       pin_memory: bool = True,
+                       non_blocking: bool = False):
+        if self._offloaded_param_partitions or (include is not None and OffloadStateTypeEnum.lp_params not in include):
+            return
+
+        params = list(dict.fromkeys(iter_params(self.module, recurse=True)))
+        for param in params:
+            if param.ds_zero_param_process_group is not None or param.ds_secondary_tensor is not None:
+                raise NotImplementedError("Dynamic inference offload does not support hpZeRO parameter partitions.")
+            if hasattr(param.ds_tensor, "ds_quant_scale"):
+                raise NotImplementedError("Dynamic inference offload does not support stored quantized parameters.")
+
+        # Persistent parameters and prefetches can retain full copies in addition to the local shards.
+        self.partition_all_parameters()
+        accelerator = get_accelerator()
+        accelerator.synchronize()
+        partitions = list(dict.fromkeys(param.ds_tensor for param in params if param.ds_tensor.device.type != "cpu"))
+        records = []
+        try:
+            for partition in partitions:
+                cpu_buffer = torch.empty_like(partition, device=device.value)
+                if pin_memory:
+                    cpu_buffer = accelerator.pin_memory(cpu_buffer)
+                records.append((partition, partition.device, cpu_buffer))
+                cpu_buffer.copy_(partition, non_blocking=non_blocking)
+        finally:
+            # Keep both the source storage and native pinned roots alive until all copies complete.
+            if non_blocking:
+                accelerator.synchronize()
+
+        for partition, _, cpu_buffer in records:
+            partition.data = cpu_buffer
+        self._offloaded_param_partitions = records
+        accelerator.empty_cache()
+
+    @torch.no_grad()
+    def reload_states(self, non_blocking: bool = False):
+        if not self._offloaded_param_partitions:
+            return
+
+        accelerator = get_accelerator()
+        restored = []
+        try:
+            for _, device, cpu_buffer in self._offloaded_param_partitions:
+                restored.append(cpu_buffer.to(device, non_blocking=non_blocking))
+        finally:
+            if non_blocking:
+                accelerator.synchronize()
+
+        for (partition, _, _), tensor in zip(self._offloaded_param_partitions, restored):
+            partition.data = tensor
+        self._release_offload_buffers()
+
+    def _release_offload_buffers(self):
+        records = self._offloaded_param_partitions
+        self._offloaded_param_partitions = []
+        for _, _, cpu_buffer in records:
+            if get_accelerator().is_pinned(cpu_buffer):
+                get_accelerator().unpin_memory(cpu_buffer)
+
     def _convert_to_zero_parameters(self, ds_config, module, mpu):
         non_zero_params = [p for p in module.parameters() if not is_zero_param(p)]
         if non_zero_params:
@@ -279,6 +345,13 @@ class DeepSpeedZeRoOffload(object):
                      zero_quantized_nontrainable_weights=self.zero_quantized_nontrainable_weights)
 
     def destroy(self):
+        if self._offloaded_param_partitions:
+            get_accelerator().synchronize()
+            for partition, _, cpu_buffer in self._offloaded_param_partitions:
+                if get_accelerator().is_pinned(cpu_buffer):
+                    # The module can outlive the engine; its CPU shards must not alias freed native pins.
+                    partition.data = cpu_buffer.clone()
+            self._release_offload_buffers()
         self._remove_module_hooks()
 
     def _remove_module_hooks(self):

--- a/docs/code-docs/source/zero3.rst
+++ b/docs/code-docs/source/zero3.rst
@@ -547,6 +547,39 @@ Below is an example code snippet demonstrating how to offload FP32 parameters an
     # Load states back to device memory
     ds_engine.reload_states()
 
+ZeRO-3 inference engines initialized without an optimizer also support dynamic parameter
+offload. For these engines, ``lp_params`` selects the model's parameter partitions,
+including FP32 parameters when mixed precision is disabled. The default ``include=None``
+offloads these partitions; optimizer and gradient state selections have no effect.
+An empty selection (``include=[]``) is a no-op.
+
+Use the API between inference calls to release parameter memory while another model
+runs, then reload before the next forward. Parameters cached by ZeRO-3 are released
+when offloading, including persistent parameters. Module buffers are not moved.
+Repeated offload or reload calls are no-ops until the state changes.
+
+.. code-block:: python
+
+    ds_engine, _, _, _ = deepspeed.initialize(model=model, config={
+        "train_micro_batch_size_per_gpu": 1,
+        "zero_optimization": {"stage": 3},
+        "bf16": {"enabled": True},
+    })
+    ds_engine.eval()
+    with torch.no_grad():
+        output = ds_engine(inputs)
+        ds_engine.offload_states(pin_memory=True, non_blocking=True)
+        # Run another model while the parameter partitions reside in CPU memory.
+        ds_engine.reload_states(non_blocking=True)
+        output = ds_engine(inputs)
+
+Dynamic inference offload currently requires GPU-resident parameters without static
+CPU/NVMe parameter offload, hpZeRO secondary partitions, or stored quantized weights.
+``pin_memory`` uses the configured DeepSpeed pinning backend. With ``non_blocking=True``,
+copies are submitted without per-copy synchronization, but the inference offload and
+reload calls wait for completion before returning so storage can be safely released
+and reused. Reload restores each partition to its original device.
+
 ``deepspeed.runtime.zero.offload_states.get_state_devices`` returns devices of the specified state.
 
 .. code-block:: python

--- a/tests/unit/v1/zero/test_offload_states.py
+++ b/tests/unit/v1/zero/test_offload_states.py
@@ -403,3 +403,229 @@ class TestDynamicOffloadStatesZero3(DistributedTest):
         offloaded_states = None if included_state is None else [included_state]
         run_model_zero3(model, param_groups, config_dict, hidden_dim, torch.bfloat16, offloaded_states, pin_memory,
                         non_blocking)
+
+
+class _InferenceOffloadModel(torch.nn.Module):
+
+    def __init__(self, hidden_dim=1025):
+        super().__init__()
+        self.first = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.middle = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.last = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.last.weight = self.first.weight
+
+    def forward(self, inputs):
+        return self.last(torch.relu(self.middle(torch.relu(self.first(inputs)))))
+
+
+def _init_inference_offload_model(dtype, persistent_parameters, zero_config=None):
+    accelerator = get_accelerator()
+    if accelerator.device_name() == "cpu":
+        pytest.skip("Dynamic offload needs a separate accelerator and CPU device")
+    if dtype == torch.bfloat16 and not accelerator.is_bf16_supported():
+        pytest.skip("bf16 is not supported on this accelerator")
+    if dtype == torch.float16 and not accelerator.is_fp16_supported():
+        pytest.skip("fp16 is not supported on this accelerator")
+
+    torch.manual_seed(1234)
+    model = _InferenceOffloadModel().requires_grad_(False).eval()
+    model = model.to(device=accelerator.current_device_name(), dtype=dtype)
+    inputs = torch.linspace(-1, 1, 2050, device=accelerator.current_device_name(), dtype=dtype).reshape(2, 1025)
+    parameter_snapshots = {name: param.detach().cpu().clone() for name, param in model.named_parameters()}
+    with torch.no_grad():
+        reference_output = model(inputs).cpu()
+
+    config = {
+        "train_micro_batch_size_per_gpu": 2,
+        "zero_optimization": {
+            "stage": 3,
+            "stage3_param_persistence_threshold": 10_000_000 if persistent_parameters else 0,
+        },
+    }
+    if zero_config is not None:
+        config["zero_optimization"].update(zero_config)
+    if dtype == torch.bfloat16:
+        config["bf16"] = {"enabled": True}
+    elif dtype == torch.float16:
+        config["fp16"] = {"enabled": True}
+
+    if config["zero_optimization"].get("zero_hpz_partition_size", 1) > 1:
+        deepspeed.zero.Init(module=model, config_dict_or_path=config)
+
+    engine, _, _, _ = deepspeed.initialize(model=model, config=config)
+    engine.eval()
+    return engine, inputs, reference_output, parameter_snapshots
+
+
+def _assert_inference_offload_parameters(engine, parameter_snapshots):
+    # The public gather context also covers a shared parameter used by two different modules.
+    with deepspeed.zero.GatheredParameters(list(engine.module.parameters())):
+        for name, param in engine.module.named_parameters():
+            torch.testing.assert_close(param.detach().cpu(), parameter_snapshots[name], rtol=0, atol=0)
+
+
+class TestDynamicOffloadStatesZero3Inference(DistributedTest):
+    world_size = [1, 2]
+
+    @pytest.mark.parametrize("dtype,pin_memory,non_blocking,persistent_parameters,included_state", [
+        pytest.param(torch.bfloat16, False, False, False, None, id="bf16-pageable-sync-partitioned-all"),
+        pytest.param(torch.bfloat16,
+                     False,
+                     True,
+                     False,
+                     OffloadStateTypeEnum.lp_params,
+                     id="bf16-pageable-async-partitioned-lp"),
+        pytest.param(
+            torch.bfloat16, True, False, False, OffloadStateTypeEnum.lp_params, id="bf16-pinned-sync-partitioned-lp"),
+        pytest.param(torch.bfloat16, True, True, False, None, id="bf16-pinned-async-partitioned-all"),
+        pytest.param(
+            torch.bfloat16, False, False, True, OffloadStateTypeEnum.lp_params, id="bf16-pageable-sync-persistent-lp"),
+        pytest.param(torch.bfloat16, False, True, True, None, id="bf16-pageable-async-persistent-all"),
+        pytest.param(torch.bfloat16, True, False, True, None, id="bf16-pinned-sync-persistent-all"),
+        pytest.param(
+            torch.bfloat16, True, True, True, OffloadStateTypeEnum.lp_params, id="bf16-pinned-async-persistent-lp"),
+        pytest.param(torch.float32, True, True, True, None, id="fp32-pinned-async-persistent-all"),
+        pytest.param(
+            torch.float16, True, True, False, OffloadStateTypeEnum.lp_params, id="fp16-pinned-async-partitioned-lp"),
+    ])
+    def test_inference_offload_reload(self, dtype, pin_memory, non_blocking, persistent_parameters, included_state):
+        """Frozen, optimizer-free inference must free accelerator memory and resume without changing the model."""
+        engine, inputs, reference_output, parameter_snapshots = _init_inference_offload_model(
+            dtype, persistent_parameters)
+        accelerator = get_accelerator()
+        accelerator_device = torch.device(accelerator.current_device_name())
+        include = None if included_state is None else [included_state]
+        try:
+            with torch.no_grad():
+                initial_output = engine(inputs).cpu()
+                torch.testing.assert_close(initial_output, reference_output)
+
+                for _ in range(3):
+                    accelerator.synchronize()
+                    allocated_before = accelerator.memory_allocated()
+                    engine.offload_states(include=include,
+                                          device=OffloadDeviceEnum.cpu,
+                                          pin_memory=pin_memory,
+                                          non_blocking=non_blocking)
+                    accelerator.synchronize()
+                    allocated_offloaded = accelerator.memory_allocated()
+                    assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {torch.device("cpu")}
+                    assert allocated_offloaded < allocated_before, "Inference parameters must release accelerator memory"
+
+                    engine.offload_states(include=include,
+                                          device=OffloadDeviceEnum.cpu,
+                                          pin_memory=pin_memory,
+                                          non_blocking=non_blocking)
+                    accelerator.synchronize()
+                    assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {torch.device("cpu")}
+                    assert accelerator.memory_allocated() == allocated_offloaded
+
+                    engine.reload_states(non_blocking=non_blocking)
+                    accelerator.synchronize()
+                    allocated_reloaded = accelerator.memory_allocated()
+                    assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {accelerator_device}
+                    assert allocated_reloaded > allocated_offloaded, "Reload must restore accelerator parameter storage"
+
+                    engine.reload_states(non_blocking=non_blocking)
+                    accelerator.synchronize()
+                    assert accelerator.memory_allocated() == allocated_reloaded
+                    torch.testing.assert_close(engine(inputs).cpu(), initial_output, rtol=0, atol=0)
+                    _assert_inference_offload_parameters(engine, parameter_snapshots)
+        finally:
+            engine.destroy()
+
+    @pytest.mark.parametrize("included_states", [
+        pytest.param([], id="empty"),
+        pytest.param([OffloadStateTypeEnum.hp_params], id="hp-params"),
+        pytest.param([OffloadStateTypeEnum.optim_states], id="optimizer-states"),
+        pytest.param([OffloadStateTypeEnum.lp_grads], id="lp-grads"),
+    ])
+    def test_unselected_inference_states_are_noop(self, included_states):
+        """Absent training states and an empty selection must leave inference parameters available."""
+        engine, inputs, reference_output, parameter_snapshots = _init_inference_offload_model(torch.bfloat16, True)
+        accelerator = get_accelerator()
+        accelerator_device = torch.device(accelerator.current_device_name())
+        try:
+            with torch.no_grad():
+                initial_output = engine(inputs).cpu()
+                torch.testing.assert_close(initial_output, reference_output)
+                accelerator.synchronize()
+                allocated_before = accelerator.memory_allocated()
+                # Reloading before the first offload must also leave the inference model untouched.
+                engine.reload_states(non_blocking=True)
+                accelerator.synchronize()
+                assert accelerator.memory_allocated() == allocated_before
+                engine.offload_states(include=included_states, pin_memory=True, non_blocking=True)
+                accelerator.synchronize()
+                assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {accelerator_device}
+                assert accelerator.memory_allocated() == allocated_before
+                engine.reload_states(non_blocking=True)
+                accelerator.synchronize()
+                assert accelerator.memory_allocated() == allocated_before
+                torch.testing.assert_close(engine(inputs).cpu(), initial_output, rtol=0, atol=0)
+                _assert_inference_offload_parameters(engine, parameter_snapshots)
+        finally:
+            engine.destroy()
+
+
+class TestDynamicInferenceOffloadLifecycle(DistributedTest):
+    world_size = 1
+
+    def test_destroy_while_offloaded_preserves_module_weights(self):
+        """Destroying the engine must not leave retained module weights pointing to freed native host memory."""
+        engine, inputs, reference_output, _ = _init_inference_offload_model(torch.bfloat16, True)
+        module = engine.module
+        destroyed = False
+        try:
+            with torch.no_grad():
+                torch.testing.assert_close(engine(inputs).cpu(), reference_output)
+            engine.offload_states(pin_memory=True, non_blocking=True)
+            get_accelerator().synchronize()
+            assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {torch.device("cpu")}
+            # Parameter views are empty while sharded. Their local weight tensors must remain readable
+            # after destroy, even when a native pinned allocation previously owned their storage.
+            expected_shards = {name: param.ds_tensor.detach().clone() for name, param in module.named_parameters()}
+            engine.destroy()
+            destroyed = True
+            for name, param in module.named_parameters():
+                assert param.ds_tensor.device == torch.device("cpu")
+                torch.testing.assert_close(param.ds_tensor.detach().clone(), expected_shards[name], rtol=0, atol=0)
+        finally:
+            if not destroyed:
+                engine.destroy()
+
+    def test_static_parameter_offload_rejects_dynamic_offload(self):
+        """Static parameter offload remains a separate mode and must reject dynamic offload without mutation."""
+        engine, inputs, reference_output, _ = _init_inference_offload_model(
+            torch.bfloat16, False, zero_config={"offload_param": {
+                "device": "cpu",
+                "pin_memory": False
+            }})
+        try:
+            with torch.no_grad():
+                initial_output = engine(inputs).cpu()
+                torch.testing.assert_close(initial_output, reference_output)
+                with pytest.raises(AssertionError, match="offloaded parameters"):
+                    engine.offload_states()
+                assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {torch.device("cpu")}
+                torch.testing.assert_close(engine(inputs).cpu(), initial_output, rtol=0, atol=0)
+        finally:
+            engine.destroy()
+
+    @pytest.mark.world_size(2)
+    def test_hpzero_rejects_dynamic_offload(self):
+        """An unsupported secondary partition layout must fail before offloading any weights."""
+        engine, inputs, reference_output, parameter_snapshots = _init_inference_offload_model(
+            torch.bfloat16, False, zero_config={"zero_hpz_partition_size": 2})
+        accelerator_device = torch.device(get_accelerator().current_device_name())
+        try:
+            with torch.no_grad():
+                initial_output = engine(inputs).cpu()
+                torch.testing.assert_close(initial_output, reference_output)
+                with pytest.raises(NotImplementedError, match="hpZeRO"):
+                    engine.offload_states()
+                assert get_state_devices(engine, OffloadStateTypeEnum.lp_params) == {accelerator_device}
+                torch.testing.assert_close(engine(inputs).cpu(), initial_output, rtol=0, atol=0)
+                _assert_inference_offload_parameters(engine, parameter_snapshots)
+        finally:
+            engine.destroy()


### PR DESCRIPTION
ZeRO-3 engines initialized without an optimizer currently reject `offload_states()` and `reload_states()`, preventing an idle inference model from releasing its GPU weights between calls. This change extends the existing APIs to move its parameter partitions to CPU and restore them to their original devices. Related to #6595.

The parameter manager releases cached full parameters before migration, preserves shard metadata and shared parameter identity, and retains pinned allocation roots until copies finish. Repeated calls and selections containing no parameter state are no-ops. Destroying an offloaded engine leaves retained module shards readable.

The supported scope is ordinary GPU-resident ZeRO-3 inference, including FP16/BF16/FP32 and persistent/shared parameters. Static CPU/NVMe parameter offload, hpZeRO secondary partitions, and stored quantized weights remain unsupported. Module buffers are not moved. With `non_blocking=True`, transfers are enqueued without per-copy synchronization, but the inference APIs wait before returning. Reload is required before the next forward.

Validation on 2 × RTX 3090 24 GiB, driver 580.65.06, PyTorch 2.13.0+cu130:

- The unchanged base fails the new roundtrip regression at the optimizer-free guard.
- Ten inference combinations run at world sizes 1 and 2, each with three cycles, checking memory release, original Torch outputs, exact post-reload outputs, and CPU parameter snapshots.
- State-selection no-ops, destroy while offloaded, and static/hpZeRO rejection tests pass.
- Native pinned memory passes BF16/FP32 nonblocking roundtrips and destroy while offloaded.
- Four existing two-rank ZeRO-3 training offload regressions pass, including CPU optimizer offload.
- Changed-file pre-commit hooks and `pip check` pass.

A 64 MiB BF16 model releases 64 MiB at world size 1 and 96 MiB per rank at world size 2, including persistent full-parameter replicas. Three cycles retain exact outputs. This is bounded memory/correctness evidence, not a throughput or large-model convergence claim.

Wheel builds fail identically on the unchanged base and patch in the installed PyTorch `BuildExtension`, with `Command.__init__() got an unexpected keyword argument 'use_ninja'`. Editable installation and native runtime validation succeed. Stored-quantized configuration, combined parallel modes, and multi-node behavior were not tested.
