### PR TITLE
Fix AutoEP global L2 clipping for sharded expert ownership

### DIFF
--- a/deepspeed/module_inject/auto_ep_layer.py
+++ b/deepspeed/module_inject/auto_ep_layer.py
@@ -518,6 +518,7 @@ class AutoEPMoELayer(nn.Module):
             param.allreduce = False
             param.group_name = self.ep_group_name
             param.ds_zero_placement_family = "autoep_expert"
+            param.ds_autoep_ep_size = ep_size
             param.ds_zero_partition_group_name = self.ep_group_name
 
         # Mark shared expert and router params for global DP reduction.

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -387,10 +387,31 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
     """
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]
-    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    parameters = list(parameters)
     norm_type = float(norm_type)
+    # Inspect ownership before filtering gradients: an unused expert on one rank
+    # must not make that rank choose a different collective from the others.
+    autoep_global_l2 = (norm_type == 2.0 and mpu is None
+                        and any(getattr(p, "ds_zero_placement_family", None) == "autoep_expert" for p in parameters))
+    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    pg = groups._get_data_parallel_group()
     all_norms = []
-    if norm_type == inf:
+    if autoep_global_l2:
+        dp_world_size = dist.get_world_size(group=pg)
+        total_norm = torch.zeros((), device=get_accelerator().current_device_name(), dtype=torch.float32)
+        for p in parameters:
+            weight = 1.0 / dp_world_size
+            if getattr(p, "ds_zero_placement_family", None) == "autoep_expert":
+                ep_size = getattr(p, "ds_autoep_ep_size", None)
+                if not isinstance(ep_size, int) or ep_size <= 0 or dp_world_size % ep_size != 0:
+                    raise RuntimeError("AutoEP expert parameter has invalid EP ownership metadata")
+                weight = ep_size / dp_world_size
+            total_norm += p.grad.detach().float().square().sum() * weight
+        # Sum ownership-weighted squares before taking the root. Averaging
+        # rank-local norms does not recover the norm of the unique parameters.
+        dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=pg)
+        total_norm = total_norm.sqrt()
+    elif norm_type == inf:
         for p in parameters:
             all_norms.append(p.grad.data.abs().max().float())
         total_norm = torch.stack(all_norms).max()
@@ -421,14 +442,13 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
             dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=mpu.get_model_parallel_group())
         total_norm = total_norm.pow(1. / norm_type)
 
-    # Need to average total_norm across different GPUs due to the presence of moe params
-    pg = groups._get_data_parallel_group()
-    scaled_norm = total_norm * 1.0 / float(dist.get_world_size(group=pg))
-    scaled_norm_tensor = scaled_norm
-
-    dist.all_reduce(scaled_norm_tensor, group=pg)
-    total_norm = scaled_norm_tensor
-    total_norm = total_norm.to(parameters[0].device)
+    if not autoep_global_l2:
+        # Legacy reduction for other parameter layouts and norm modes.
+        scaled_norm_tensor = total_norm * 1.0 / float(dist.get_world_size(group=pg))
+        dist.all_reduce(scaled_norm_tensor, group=pg)
+        total_norm = scaled_norm_tensor
+    if parameters:
+        total_norm = total_norm.to(parameters[0].device)
 
     max_norm = torch.tensor([float(max_norm)], device=total_norm.device)
     clip_coef = max_norm / (total_norm + 1e-6)

--- a/tests/unit/v1/moe/test_autoep_grad_parity.py
+++ b/tests/unit/v1/moe/test_autoep_grad_parity.py
@@ -151,6 +151,62 @@ def _assert_grad_maps_close(actual, expected, *, lhs_name, rhs_name):
                                         f"expected_norm={expected[name].norm().item()}"))
 
 
+class TestAutoEPFP32Clipping(DistributedTest):
+    world_size = 2
+
+    def test_clipping_counts_each_unique_parameter_once(self):
+
+        class Model(torch.nn.Module):
+
+            def __init__(self, local_experts):
+                super().__init__()
+                self.expert = torch.nn.Parameter(torch.zeros(local_experts))
+                self.dense = torch.nn.Parameter(torch.zeros(1))
+
+        for ep_size in (1, 2):
+            for dense_gradient in (0.0, 12.0):
+                for unused_expert in (False, True):
+                    model = Model(4 // ep_size)
+                    model.expert.ds_zero_placement_family = "autoep_expert"
+                    model.expert.ds_autoep_ep_size = ep_size
+                    engine, _, _, _ = deepspeed.initialize(model=model,
+                                                           config={
+                                                               "train_micro_batch_size_per_gpu": 1,
+                                                               "gradient_accumulation_steps": 1,
+                                                               "gradient_clipping": 1.0,
+                                                               "optimizer": {
+                                                                   "type": "SGD",
+                                                                   "params": {
+                                                                       "lr": 0.05
+                                                                   }
+                                                               },
+                                                               "zero_optimization": {
+                                                                   "stage": 0
+                                                               },
+                                                           })
+                    # The same four unique expert gradients are replicated or owner-sharded.
+                    full = torch.tensor([0.0, 0.0, 3.0, 4.0], device=engine.device)
+                    start = (dist.get_rank() % ep_size) * (4 // ep_size)
+                    local = full[start:start + 4 // ep_size]
+                    skip_expert = unused_expert and ep_size == 2 and dist.get_rank() == 0
+                    if not skip_expert:
+                        model.expert.grad = local.clone()
+                    if dense_gradient:
+                        model.dense.grad = torch.tensor([dense_gradient], device=engine.device)
+
+                    # Direct norm of the unique gradient vector, independent of rank placement.
+                    unique = torch.cat((full, full.new_tensor([dense_gradient])))
+                    coefficient = 1.0 / (torch.linalg.vector_norm(unique) + 1e-6)
+                    engine.clip_fp32_gradients()
+                    if not skip_expert:
+                        torch.testing.assert_close(model.expert.grad, local * coefficient)
+                    if dense_gradient:
+                        torch.testing.assert_close(model.dense.grad, dense_gradient * coefficient.reshape(1))
+                    engine.optimizer.step()
+                    torch.testing.assert_close(model.expert, -0.05 * local * coefficient)
+                    torch.testing.assert_close(model.dense, -0.05 * dense_gradient * coefficient.reshape(1))
+
+
 class TestAutoEPGradParity(DistributedTest):
     world_size = 4
 

--- a/tests/unit/v1/moe/test_autoep_unit.py
+++ b/tests/unit/v1/moe/test_autoep_unit.py
@@ -534,6 +534,7 @@ class TestAutoEPConfig:
 
         for param in autoep_layer.experts.parameters():
             assert param.ds_zero_placement_family == "autoep_expert"
+            assert param.ds_autoep_ep_size == autoep_layer.ep_size
             assert param.ds_zero_partition_group_name == autoep_layer.ep_group_name
 
         for param in autoep_layer.router.parameters():


### PR DESCRIPTION
## Summary

Record AutoEP's expert-parallel size on expert parameters and use each parameter's replica count when summing squared gradients. Reduce those sums across the data-parallel group before taking the square root, so clipping counts each logical parameter once.

The ownership check runs before filtering absent gradients, keeping ranks on the same collective path when an expert is unused.

Fixes #8469. The change is limited to the AutoEP FP32 L2 path with `mpu=None`; the integration checks use ZeRO-0.

## Validation

- Eight clipping/update cases passed through `DeepSpeedEngine` on two CPU/Gloo processes, using an Intel Xeon Cascadelake host and PyTorch 2.13.0+cpu. They cover replicated and sharded experts, mixed dense/expert gradients, and an unused expert on one rank.
- The same test body fails with unmodified `0166cc87`: an owner-sharded gradient is clipped to roughly twice the reference value.
- The AutoEP parameter-metadata test passes. All pre-commit checks applicable to the four changed files pass.

The standard distributed pytest harness skips the two-process test on this single-socket CPU host. The test body was run directly with two Gloo processes using the command below. CUDA validation of this branch is still pending; the pinned-version CUDA results are in the issue.

<details>
<summary>CPU validation command</summary>

From the repository root in an environment with DeepSpeed and its test dependencies:

```bash
cat > /tmp/autoep_clip_check.py <<'PY'
import deepspeed
import deepspeed.comm as dist
from unit.v1.moe.test_autoep_grad_parity import TestAutoEPFP32Clipping

deepspeed.init_distributed(dist_backend="gloo", auto_mpi_discovery=False)
try:
    TestAutoEPFP32Clipping().test_clipping_counts_each_unique_parameter_once()
finally:
    dist.destroy_process_group()
PY
DS_ACCELERATOR=cpu PYTHONPATH="$PWD:$PWD/tests" \
python -m torch.distributed.run --standalone --nproc-per-node=2 /tmp/autoep_clip_check.py
```

</details>
