### PR TITLE
fix: track FusedAdam bias correction per parameter

### DIFF
--- a/deepspeed/ops/adam/fused_adam.py
+++ b/deepspeed/ops/adam/fused_adam.py
@@ -127,15 +127,11 @@ class FusedAdam(torch.optim.Optimizer):
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 
-            # assume same step across group now to simplify things
-            # per parameter step can be easily support by making it tensor, or pass list into kernel
+            # Group-level counters are retained for loading older checkpoints.
             if 'step' not in group:
                 group['step'] = 0
 
-            # create lists for multi-tensor apply
-            g_16, p_16, m_16, v_16 = [], [], [], []
-            g_bf, p_bf, m_bf, v_bf = [], [], [], []
-            g_32, p_32, m_32, v_32 = [], [], [], []
+            buckets = {}
 
             for p in group['params']:
                 if p.grad is None:
@@ -156,40 +152,20 @@ class FusedAdam(torch.optim.Optimizer):
                     # Exponential moving average of squared gradient values
                     state['exp_avg_sq'] = torch.zeros_like(p.data)
 
-                if p.dtype == torch.float16:
-                    g_16.append(p.grad.data)
-                    p_16.append(p.data)
-                    m_16.append(state['exp_avg'])
-                    v_16.append(state['exp_avg_sq'])
-                elif p.dtype == torch.bfloat16:
-                    g_bf.append(p.grad)
-                    p_bf.append(p)
-                    m_bf.append(state['exp_avg'])
-                    v_bf.append(state['exp_avg_sq'])
-                elif p.dtype == torch.float32:
-                    g_32.append(p.grad.data)
-                    p_32.append(p.data)
-                    m_32.append(state['exp_avg'])
-                    v_32.append(state['exp_avg_sq'])
-                else:
+                if p.dtype not in (torch.float16, torch.bfloat16, torch.float32):
                     raise RuntimeError('FusedAdam only support fp16, bf16 and fp32.')
 
-            if len(g_16) > 0:
                 state['step'] += 1
-                multi_tensor_applier(self.multi_tensor_adam, self._dummy_overflow_buf, [g_16, p_16, m_16, v_16],
-                                     group['lr'], beta1, beta2, group['eps'], state['step'], self.adam_w_mode,
-                                     bias_correction, group['weight_decay'])
+                # Parameters with missing gradients can have different bias-correction steps.
+                bucket = buckets.setdefault((p.dtype, state['step']), ([], [], [], []))
+                bucket[0].append(p.grad.data)
+                bucket[1].append(p.data)
+                bucket[2].append(state['exp_avg'])
+                bucket[3].append(state['exp_avg_sq'])
 
-            if len(g_bf) > 0:
-                state['step'] += 1
-                multi_tensor_applier(self.multi_tensor_adam, self._dummy_overflow_buf, [g_bf, p_bf, m_bf, v_bf],
-                                     group['lr'], beta1, beta2, group['eps'], state['step'], self.adam_w_mode,
-                                     bias_correction, group['weight_decay'])
-
-            if len(g_32) > 0:
-                state['step'] += 1
-                multi_tensor_applier(self.multi_tensor_adam, self._dummy_overflow_buf, [g_32, p_32, m_32, v_32],
-                                     group['lr'], beta1, beta2, group['eps'], state['step'], self.adam_w_mode,
-                                     bias_correction, group['weight_decay'])
+            for (_, step), tensor_lists in buckets.items():
+                multi_tensor_applier(self.multi_tensor_adam, self._dummy_overflow_buf, list(tensor_lists), group['lr'],
+                                     beta1, beta2, group['eps'], step, self.adam_w_mode, bias_correction,
+                                     group['weight_decay'])
 
         return loss

--- a/tests/unit/ops/adam/test_adamw.py
+++ b/tests/unit/ops/adam/test_adamw.py
@@ -3,6 +3,7 @@
 
 # DeepSpeed Team
 
+import copy
 import deepspeed
 import torch
 import pytest
@@ -131,3 +132,68 @@ def test_fused_adam_matches_reference(adam_w_mode, dtype):
     for ds_param, ref_param in zip(ds_params, ref_params):
         atol = 8 * torch.finfo(dtype).eps * ref_param.abs().max().item()
         torch.testing.assert_close(ds_param.float(), ref_param.float(), rtol=0, atol=atol)
+
+
+@pytest.mark.parametrize('adam_w_mode', [True, False], ids=['adamw', 'adam'])
+@pytest.mark.parametrize('mixed_dtype', [False, True], ids=['fp32', 'mixed'])
+@pytest.mark.parametrize('intermittent_grad', [False, True], ids=['all_grads', 'intermittent'])
+def test_fused_adam_parameter_steps(adam_w_mode, mixed_dtype, intermittent_grad):
+    dtypes = [torch.float16, torch.bfloat16, torch.float32] if mixed_dtype else [torch.float32] * 3
+    if not all(dtype in get_accelerator().supported_dtypes() for dtype in dtypes):
+        pytest.skip('Required dtypes are not supported')
+    if not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME]:
+        pytest.skip('FusedAdam is not compatible')
+    torch.manual_seed(123)
+    params = [torch.nn.Parameter(torch.randn(128, device=get_accelerator().device_name(), dtype=dtype) * 0.1)
+              for dtype in dtypes]
+    references = [p.detach().clone() for p in params]
+    moments = [(torch.zeros_like(p), torch.zeros_like(p)) for p in params]
+    steps = [0] * len(params)
+    options = dict(lr=0.03, betas=(0.8, 0.95), eps=1e-6, weight_decay=0.1, adam_w_mode=adam_w_mode)
+    optimizer = FusedAdam(params, **options)
+    for iteration in range(6):
+        optimizer.zero_grad()
+        for i, (param, reference, (first, second)) in enumerate(zip(params, references, moments)):
+            if intermittent_grad and iteration % 3 == i:
+                continue
+            param.grad = torch.randn_like(param) * 0.1
+            steps[i] += 1
+            reference_adam_step(reference, param.grad, first, second, steps[i], options['lr'],
+                                *options['betas'], options['eps'], options['weight_decay'], adam_w_mode)
+        optimizer.step()
+        for i, (param, reference) in enumerate(zip(params, references)):
+            atol = {torch.float32: 2e-6, torch.float16: 1e-4, torch.bfloat16: 1e-3}[param.dtype]
+            torch.testing.assert_close(param.detach(), reference, rtol=0, atol=atol)
+            if steps[i]:
+                assert optimizer.state[param]['step'] == steps[i]
+        if iteration == 2:
+            state_dict = copy.deepcopy(optimizer.state_dict())
+            optimizer = FusedAdam(params, **options)
+            optimizer.load_state_dict(state_dict)
+
+
+def test_fused_adam_intermittent_training():
+    if not deepspeed.ops.__compatible_ops__[FusedAdamBuilder.NAME]:
+        pytest.skip('FusedAdam is not compatible')
+    torch.manual_seed(123)
+    model = SimpleModel(16).to(get_accelerator().device_name())
+    reference = copy.deepcopy(model)
+    options = dict(lr=0.02, betas=(0.8, 0.95), eps=1e-6, weight_decay=0.1)
+    optimizer = FusedAdam(model.parameters(), **options)
+    reference_optimizer = torch.optim.AdamW(reference.parameters(), **options)
+    for iteration in range(6):
+        bias_grad = iteration % 3 != 1
+        model.linears[0].bias.requires_grad_(bias_grad)
+        reference.linears[0].bias.requires_grad_(bias_grad)
+        optimizer.zero_grad()
+        reference_optimizer.zero_grad(set_to_none=True)
+        inputs = torch.randn(8, 16, device=get_accelerator().device_name())
+        labels = torch.randint(0, 16, (8,), device=get_accelerator().device_name())
+        actual, expected = model(inputs, labels), reference(inputs, labels)
+        torch.testing.assert_close(actual, expected)
+        actual.backward()
+        expected.backward()
+        optimizer.step()
+        reference_optimizer.step()
+        for param, ref_param in zip(model.parameters(), reference.parameters()):
+            torch.testing.assert_close(param, ref_param, rtol=1e-5, atol=2e-6)


### PR DESCRIPTION
FusedAdam increments only the last active parameter's step counter and uses it for every tensor of a given dtype. When a parameter has no gradient on some iterations, the counter used for the other parameters can switch, producing incorrect bias correction. A group with multiple dtypes also advances that same counter once per dtype.

Increment each active parameter's counter once and batch tensors by dtype and step. Parameters that advance together still share a fused kernel call; parameters with different update histories get the appropriate bias correction. The optimizer state format is unchanged.

The added tests cover Adam/AdamW, uniform and mixed FP32/FP16/BF16 groups, intermittent gradients, and a state-dict round trip. A small training regression also compares against PyTorch AdamW when a layer bias is intermittently frozen. On H800, the original code fails all nine new cases; the fix passes those and the six existing reference cases.

```bash
python -m pytest tests/unit/ops/adam/test_adamw.py -k 'fused_adam_matches_reference or fused_adam_parameter_steps or fused_adam_intermittent_training' -v
```

An additional two-GPU FP32 check compares three accumulated updates against a full-model AdamW reference for ZeRO stages 0 and 3, including two ZeRO-3 subgroup sizes. All configurations pass, including saving a full DeepSpeed checkpoint after the first update, reconstructing the engine, restoring model/optimizer state and continuing. Changed-file pre-commit checks pass.

This does not reconstruct counters already written incorrectly by older versions. CPU/NVMe offload, multi-node training, checkpoint recovery with a changed world size, and performance were not tested.
