### PR TITLE
Make add_tuning_arguments' 1Cycle flags reach OneCycle

### DIFF
--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -41,6 +41,7 @@ CYCLE_MIN_LR = 'cycle_min_lr'
 CYCLE_MAX_LR = 'cycle_max_lr'
 DECAY_LR_RATE = 'decay_lr_rate'
 
+CYCLE_MOMENTUM = 'cycle_momentum'
 CYCLE_MIN_MOM = 'cycle_min_mom'
 CYCLE_MAX_MOM = 'cycle_max_mom'
 DECAY_MOM_RATE = 'decay_mom_rate'
@@ -80,16 +81,16 @@ def add_tuning_arguments(parser):
                        help='size of first step of 1Cycle schedule (training steps).')
     group.add_argument("--cycle_first_stair_count",
                        type=int,
-                       default=-1,
+                       default=None,
                        help='first stair count for 1Cycle schedule.')
     group.add_argument("--cycle_second_step_size",
                        type=int,
-                       default=-1,
+                       default=None,
                        help='size of second step of 1Cycle schedule (default first_step_size).')
     group.add_argument("--cycle_second_stair_count",
                        type=int,
-                       default=-1,
-                       help='second stair count for 1Cycle schedule.')
+                       default=None,
+                       help='second stair count for 1Cycle schedule (default first stair count).')
     group.add_argument("--decay_step_size",
                        type=int,
                        default=1000,
@@ -171,6 +172,9 @@ def override_1cycle_params(args, params):
         params[DECAY_LR_RATE] = args.decay_lr_rate
 
     # 1Cycle MOM params
+    if hasattr(args, CYCLE_MOMENTUM):
+        params[CYCLE_MOMENTUM] = args.cycle_momentum
+
     if hasattr(args, CYCLE_MIN_MOM) and args.cycle_min_mom is not None:
         params[CYCLE_MIN_MOM] = args.cycle_min_mom
 

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -15,6 +15,7 @@ from deepspeed.runtime.lr_schedules import LR_RANGE_TEST, LR_RANGE_TEST_MIN_LR, 
 from deepspeed.runtime.lr_schedules import WARMUP_LR, WARMUP_MIN_LR, WARMUP_MAX_LR, WARMUP_NUM_STEPS, WARMUP_TYPE, WARMUP_LOG_RATE, WARMUP_LINEAR_RATE
 from deepspeed.runtime.lr_schedules import ONE_CYCLE, CYCLE_MIN_LR, CYCLE_MAX_LR, CYCLE_FIRST_STEP_SIZE, DECAY_LR_RATE, DECAY_STEP_SIZE
 from deepspeed.runtime.lr_schedules import CYCLE_MIN_MOM, CYCLE_MAX_MOM, DECAY_MOM_RATE
+from deepspeed.runtime.lr_schedules import CYCLE_MOMENTUM, CYCLE_FIRST_STAIR_COUNT, CYCLE_SECOND_STEP_SIZE, CYCLE_SECOND_STAIR_COUNT
 from deepspeed.runtime.lr_schedules import WARMUP_DECAY_LR, TOTAL_NUM_STEPS
 from deepspeed.runtime.lr_schedules import WARMUP_COSINE_LR, WARMUP_MIN_RATIO, COS_MIN_RATIO, WarmupCosineLR
 from deepspeed.runtime.lr_schedules import WarmupLR, WarmupDecayLR, LRRangeTest, OneCycle
@@ -949,3 +950,91 @@ def test_other_schedules_keep_their_config_params():
         assert err is None
         assert expected in config["params"]
         assert lrs.get_lr_from_config(config)[0] == config["params"][expected]
+
+
+def test_one_cycle_config_from_args_builds_a_scheduler():
+    # The three "unset" flags defaulted to -1 and override_1cycle_params copied them
+    # through, since -1 is not None. OneCycle rejects a negative second step size, so
+    # the plain CLI invocation for this schedule raised before it ever ran:
+    #   ValueError: cycle_second_step_size must be non-negative, got -1.0
+    parser = lrs.add_tuning_arguments(argparse.ArgumentParser())
+    args = parser.parse_args([
+        "--lr_schedule", ONE_CYCLE, "--cycle_min_lr", "1e-4", "--cycle_max_lr", "1e-3",
+        "--cycle_first_step_size", "4"
+    ])
+
+    config, err = lrs.get_config_from_args(args)
+    assert err is None
+    params = config["params"]
+    # Left out entirely, so OneCycle's own defaults apply rather than a sentinel.
+    assert CYCLE_SECOND_STEP_SIZE not in params
+    assert CYCLE_FIRST_STAIR_COUNT not in params
+    assert CYCLE_SECOND_STAIR_COUNT not in params
+
+    optimizer = torch.optim.Adam([torch.nn.Parameter(torch.zeros(1))], lr=1e-3)
+    scheduler = OneCycle(optimizer, **params)
+    # The help text says the second step defaults to the first.
+    assert scheduler.second_step_size == scheduler.first_step_size == 4
+
+
+def test_one_cycle_second_stair_count_falls_back_to_the_first():
+    # cycle_second_stair_count=None means "same as the first"; the -1 default reached
+    # OneCycle as a real value, so the second half of the cycle lost its stairs while
+    # the first half kept them.
+    parser = lrs.add_tuning_arguments(argparse.ArgumentParser())
+    args = parser.parse_args([
+        "--lr_schedule", ONE_CYCLE, "--cycle_min_lr", "1e-4", "--cycle_max_lr", "1e-3",
+        "--cycle_first_step_size", "4", "--cycle_first_stair_count", "5"
+    ])
+
+    config, _ = lrs.get_config_from_args(args)
+    optimizer = torch.optim.Adam([torch.nn.Parameter(torch.zeros(1))], lr=1e-3)
+    scheduler = OneCycle(optimizer, **config["params"])
+
+    assert scheduler.first_stair_count == 5
+    assert scheduler.second_stair_count == 5
+
+    direct = OneCycle(torch.optim.Adam([torch.nn.Parameter(torch.zeros(1))], lr=1e-3),
+                      cycle_min_lr=1e-4,
+                      cycle_max_lr=1e-3,
+                      cycle_first_step_size=4,
+                      cycle_first_stair_count=5)
+    assert scheduler.second_stair_count == direct.second_stair_count
+
+
+@pytest.mark.parametrize("argv, expected", [([], False), (["--cycle_momentum"], True)])
+def test_cycle_momentum_reaches_scheduler_params(argv, expected):
+    # --cycle_momentum was declared but never copied into the config, so OneCycle fell
+    # back to its own cycle_momentum=True either way: the flag could not turn momentum
+    # cycling on (it was already on) or off (its documented default).
+    args = lrs.add_tuning_arguments(argparse.ArgumentParser()).parse_args(argv)
+    params = {}
+    lrs.override_1cycle_params(args, params)
+
+    assert params[CYCLE_MOMENTUM] is expected
+
+
+@pytest.mark.parametrize("argv, cycles", [([], False), (["--cycle_momentum"], True)])
+def test_cycle_momentum_flag_decides_whether_betas_move(argv, cycles):
+    # The observable half: OneCycle rewrites param_groups["betas"][0] on every step when
+    # momentum cycling is on. Without the flag the optimizer's own beta1 must survive.
+    parser = lrs.add_tuning_arguments(argparse.ArgumentParser())
+    args = parser.parse_args([
+        "--lr_schedule", ONE_CYCLE, "--cycle_min_lr", "1e-4", "--cycle_max_lr", "1e-3",
+        "--cycle_first_step_size", "4", "--cycle_min_mom", "0.80", "--cycle_max_mom", "0.99"
+    ] + argv)
+
+    config, _ = lrs.get_config_from_args(args)
+    optimizer = torch.optim.Adam([torch.nn.Parameter(torch.zeros(1))], lr=1e-3, betas=(0.9, 0.999))
+    scheduler = OneCycle(optimizer, **config["params"])
+    assert scheduler.cycle_momentum is cycles
+
+    seen = {optimizer.param_groups[0]["betas"][0]}
+    for _ in range(4):
+        scheduler.step()
+        seen.add(optimizer.param_groups[0]["betas"][0])
+
+    if cycles:
+        assert len(seen) > 1
+    else:
+        assert seen == {0.9}


### PR DESCRIPTION
`add_tuning_arguments` declares the 1Cycle flags and `override_1cycle_params` copies them into the scheduler config. Three of them do not survive the trip.

## The plain CLI invocation does not build

Three flags use `-1` as an "unset" sentinel, and the copy guard is `is not None`, so `-1` is forwarded as a real value:

```python
>>> parser = add_tuning_arguments(argparse.ArgumentParser())
>>> args = parser.parse_args(["--lr_schedule", "OneCycle", "--cycle_min_lr", "1e-4",
...                           "--cycle_max_lr", "1e-3", "--cycle_first_step_size", "4"])
>>> get_config_from_args(args)[0]["params"]
{'cycle_first_step_size': 4, 'cycle_first_stair_count': -1, 'cycle_second_step_size': -1,
 'cycle_second_stair_count': -1, 'decay_step_size': 1000, ...}
>>> OneCycle(optimizer, **_)
ValueError: cycle_second_step_size must be non-negative, got -1.0
```

`-1` was survivable before #8166 added the step-size guards; it produced `total_size = first + (-1)` instead. It is now an error, and this path has no way around it short of passing the flag explicitly.

`cycle_second_stair_count` has the same shape without the error. `None` means "same as the first half", and `-1` is a real value that simply is not `> 0`, so `--cycle_first_stair_count 5` gives the first half stairs and the second half none:

| | via the CLI helper | built directly |
| --- | --- | --- |
| `first_stair_count` | 5 | 5 |
| `second_stair_count` | **-1** | 5 |

## `--cycle_momentum` was never copied

It is declared, parsed, and dropped. `OneCycle` defaults `cycle_momentum=True`, so the flag could neither turn momentum cycling on (already on) nor off (what its own `default=False` asks for).

On an Adam-like optimizer the schedule rewrites `param_groups["betas"][0]` every step. Measured with `--cycle_min_mom 0.80 --cycle_max_mom 0.99`:

```
--cycle_momentum omitted   args=False  reached config: False  scheduler.cycle_momentum=True  beta1: [0.8, 0.9425, 0.895, 0.8475, 0.8]
--cycle_momentum passed    args=True   reached config: False  scheduler.cycle_momentum=True  beta1: [0.8, 0.9425, 0.895, 0.8475, 0.8]
```

Identical, and beta1 goes 0.9 -> 0.8 on the first step for a caller who never asked for it.

## The fix

- the three sentinels default to `None`, so the existing `is not None` guard leaves them out and `OneCycle`'s own defaults apply — which is what the help text already promises ("default first_step_size")
- `CYCLE_MOMENTUM` constant added next to the other 1Cycle momentum keys, and `override_1cycle_params` copies the flag

**Behaviour change worth naming:** a CLI-built `OneCycle` no longer cycles momentum unless `--cycle_momentum` is passed. That is what the flag documents; the old default was unreachable rather than chosen. `store_true` cannot distinguish "omitted" from "given as False", so the flag is copied unconditionally — there is no third state to preserve.

Scope: only this helper. `engine._configure_lr_scheduler` passes a JSON config straight to the scheduler, so `"params": {"cycle_momentum": false}` has always worked, and the other four schedules are untouched.

## Testing

`tests/unit/runtime/test_lr_schedulers.py`, H20:

```
master   88 passed, 0 failed
branch   94 passed, 0 failed
only failing on branch (regressions) -> none
only failing on master               -> none
```

Six new cases. Verified they fail on `master` for the right reason, rather than only that they pass here — run against master's source with just the new constant added so the import resolves:

```
test_one_cycle_config_from_args_builds_a_scheduler        AssertionError: 'cycle_second_step_size' not in {... 'cycle_second_step_size': -1 ...}
test_one_cycle_second_stair_count_falls_back_to_the_first ValueError: cycle_second_step_size must be non-negative, got -1.0
test_cycle_momentum_reaches_scheduler_params[False]       KeyError: 'cycle_momentum'
test_cycle_momentum_reaches_scheduler_params[True]        KeyError: 'cycle_momentum'
test_cycle_momentum_flag_decides_whether_betas_move[False] ValueError: cycle_second_step_size must be non-negative, got -1.0
test_cycle_momentum_flag_decides_whether_betas_move[True]  ValueError: cycle_second_step_size must be non-negative, got -1.0
```

The last two report the sentinel rather than the momentum assertion because on `master` they cannot get far enough to reach it — the beta1 table above is from a probe that supplies `--cycle_second_step_size` explicitly to step over the first defect.

## Related

This is the third of the same shape in this helper. #8268 fixed `--warmup_min_ratio`/`--cos_min_ratio` being dropped for `WarmupCosineLR`; #8337 fixed `--lr_range_test_staircase` being un-turn-off-able. The flag-parsing test #8337 added even cites `--cycle_momentum` as the correct `store_true` shape — but nothing checked that it reaches the scheduler, which is the half that was broken.