### PR TITLE
Reject a non-positive out-token limit at config time

### DIFF
--- a/deepspeed/inference/config.py
+++ b/deepspeed/inference/config.py
@@ -258,14 +258,14 @@ class DeepSpeedInferenceConfig(DeepSpeedConfigModel):
 
     config: Optional[Dict] = Field(None, alias="args")  # todo: really no need for this field if we can refactor
 
-    max_out_tokens: int = Field(1024, alias="max_tokens")
+    max_out_tokens: int = Field(1024, gt=0, alias="max_tokens")
     """
     This argument shows the maximum number of tokens inference-engine can work
     with, including the input and output tokens. Please consider increasing it
     to the required token-length required for your use-case.
     """
 
-    min_out_tokens: int = Field(1, alias="min_tokens")
+    min_out_tokens: int = Field(1, gt=0, alias="min_tokens")
     """
     This argument communicates to the runtime the minimum number of tokens you
     expect you will need to generate. This will cause the runtime to error

--- a/deepspeed/runtime/config.py
+++ b/deepspeed/runtime/config.py
@@ -9,6 +9,7 @@ from enum import Enum
 
 import torch
 import json
+from pydantic import Field
 import hjson
 import copy
 import base64
@@ -514,7 +515,9 @@ def get_memory_breakdown(param_dict):
 
 class HybridEngineConfig(DeepSpeedConfigModel):
     enabled: bool = False
-    max_out_tokens: int = 512
+    # Reaches the same `allocate_workspace` binding as the inference config's
+    # `max_out_tokens`, whose C++ parameter is `unsigned`.
+    max_out_tokens: int = Field(512, gt=0)
     inference_tp_size: int = 1
     release_inference_cache: bool = False
     pin_parameters: bool = True

--- a/tests/unit/inference/test_inference_config.py
+++ b/tests/unit/inference/test_inference_config.py
@@ -82,3 +82,62 @@ class TestInferenceConfig(DistributedTest):
             config = DeepSpeedInferenceConfig(moe=value)
             assert isinstance(config.moe, DeepSpeedMoEConfig)
             assert config.moe.enabled == value
+
+
+@pytest.mark.inference
+class TestInferenceOutTokenBounds:
+    """Config-only checks: no engine, no distributed state."""
+
+    def test_out_token_limits_reject_non_positive(self):
+        # Regression test for https://github.com/deepspeedai/DeepSpeed/issues/8339
+        #
+        # `max_out_tokens` was unbounded, so a negative survived config parsing and
+        # inverted the guard in `InferenceEngine._generate`, where
+        # `tensor_length > max_out_tokens` is true for every input:
+        #     RuntimeError: Input with size 6 exceeds maximum length of -1.
+        # Both limits are also handed to `allocate_workspace`, whose C++ parameters
+        # are `unsigned`, so the value that arrives there is not the one that was set.
+        from pydantic import ValidationError
+
+        from deepspeed.inference.config import DeepSpeedInferenceConfig
+
+        for field in ("max_out_tokens", "min_out_tokens"):
+            for value in (-1, 0):
+                with pytest.raises(ValidationError):
+                    DeepSpeedInferenceConfig(**{field: value})
+
+        # The aliases are the documented spelling and take the same path.
+        for alias in ("max_tokens", "min_tokens"):
+            with pytest.raises(ValidationError):
+                DeepSpeedInferenceConfig(**{alias: -1})
+
+    def test_out_token_limits_accept_positive(self):
+        from deepspeed.inference.config import DeepSpeedInferenceConfig
+
+        config = DeepSpeedInferenceConfig(max_out_tokens=2048, min_out_tokens=8)
+        assert config.max_out_tokens == 2048
+        assert config.min_out_tokens == 8
+
+        defaults = DeepSpeedInferenceConfig()
+        assert defaults.max_out_tokens == 1024
+        assert defaults.min_out_tokens == 1
+
+
+@pytest.mark.inference
+class TestHybridEngineOutTokens:
+
+    def test_max_out_tokens_rejects_non_positive(self):
+        # The same setting's other face: `HybridEngineConfig.max_out_tokens` reaches
+        # the same `allocate_workspace` binding through `hybrid_engine.py`, and was
+        # unbounded while the inference config's copy is now not.
+        from pydantic import ValidationError
+
+        from deepspeed.runtime.config import HybridEngineConfig
+
+        for value in (-1, 0):
+            with pytest.raises(ValidationError):
+                HybridEngineConfig(max_out_tokens=value)
+
+        assert HybridEngineConfig().max_out_tokens == 512
+        assert HybridEngineConfig(max_out_tokens=4096).max_out_tokens == 4096
+


### PR DESCRIPTION
Fixes #8339.

## The config accepts values that cannot work

`init_inference(model, config={"max_out_tokens": -1})` is accepted today. Measured on `master` (`bb7ad0d8`):

```
max_out_tokens=      -1 -> ACCEPTED (config.max_out_tokens=-1)
max_out_tokens=       0 -> ACCEPTED
max_out_tokens=  -99999 -> ACCEPTED
min_out_tokens=      -1 -> ACCEPTED
min_out_tokens=       0 -> ACCEPTED
```

## What a negative then does

`InferenceEngine._generate` guards the input length against it (`deepspeed/inference/engine.py:635`):

```python
if tensor_length > self._config.max_out_tokens:
    raise RuntimeError(f"Input with size {tensor_length} exceeds maximum length of {self._config.max_out_tokens}. ...")
```

A negative limit makes that true for **every** input, so this is not "long requests fail" — nothing generates at all, and the message blames the input:

```
RuntimeError: Input with size 6 exceeds maximum length of -1.
Please increase max_tokens in the DeepSpeed Inference Config.
```

Both limits are also handed straight to `allocate_workspace`, whose C++ parameters are `unsigned` (`csrc/transformer/inference/csrc/pt_binding.cpp:107-116`), so the value that arrives there is not the one that was set. `max_out_tokens` is a factor of the requested allocation (`inference_context.h:129-140`):

```cpp
size_t temp_size = batch_size * (num_heads / mp_size) * max_out_tokens;
size_t minimal_requirements = temp_size + (...) * MEGABYTE;
if (_free_memory_size < minimal_requirements) {
    throw std::runtime_error("Workspace can't be allocated, no enough memory.");
}
```

On that path a bad token limit is reported as an out-of-memory condition.

## Change

`gt=0` on `max_out_tokens` and `min_out_tokens`, the way `deepspeed/runtime/zero/config.py` already bounds its size parameters (`reduce_bucket_size: int = Field(pp_int(5e8), gt=0)` and friends).

`HybridEngineConfig.max_out_tokens` (`deepspeed/runtime/config.py:517`) gets the same bound. It is the same setting's other face — `hybrid_engine.py:105-106` passes it into the same `DeepSpeedTransformerInference` config, so it reaches the same binding — and it was the only one of the pair still unbounded.

## Deliberately not included

`min_out_tokens > max_out_tokens` is also accepted, and the workspace path always throws on it: `_max_seq_len` is clamped to `max_out_tokens` and then compared against `min_out_tokens` (`inference_context.h:144-150`), so the comparison cannot pass.

I left it alone because the two limits are unused entirely when the workspace path does not run, so rejecting the combination would refuse a configuration that runs today. Say the word and I will add it.

## Testing

`tests/unit/inference/test_inference_config.py`, three cases: the two limits and their `max_tokens` / `min_tokens` aliases reject `-1` and `0`; positive values and the documented defaults still build; `HybridEngineConfig` likewise.

Verified they fail on `master` for the right reason, not merely that they pass here — branch's test file against master's source:

```
FAILED ...::TestInferenceOutTokenBounds::test_out_token_limits_reject_non_positive - Failed: DID NOT RAISE ValidationError
FAILED ...::TestHybridEngineOutTokens::test_max_out_tokens_rejects_non_positive    - Failed: DID NOT RAISE ValidationError
2 failed, 1 passed
```

The one that passes on both is `test_out_token_limits_accept_positive` — it pins that this does not narrow anything that already worked.

A/B over `test_inference_config.py` + `test_ds_config_dict.py` + `test_ds_config_model.py`, comparing failure *sets*:

```
master   7 failed, 40 passed
branch   7 failed, 43 passed        (+3 new)

only failing on branch (regressions) -> none
only failing on master               -> none
failing on both                      -> 7
```

The 7 are pre-existing on this box: `DistributedTest` cases dying at `ImportError: libcudart.so.13`, unrelated to this change.

One note on placement: these are config-only checks, so they live in plain classes rather than in `TestInferenceConfig(DistributedTest)`. A failing assertion inside that class's worker hangs the run instead of reporting, which I hit while writing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
