### PR TITLE
Count each expert once in the fp32 gradient-clipping norm

### DIFF
--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -389,9 +389,28 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
         parameters = [parameters]
     parameters = list(filter(lambda p: p.grad is not None, parameters))
     norm_type = float(norm_type)
+
+    # Expert parameters are not replicated across the data parallel group, so the
+    # rank-averaging below cannot reconstruct a global norm from them: each rank's
+    # norm covers a different set of experts. Combine those the way the bf16 and
+    # fp16 optimizers already do, over the expert parallel group.
+    expert_tensors: Dict[str, List[torch.Tensor]] = {}
+    for p in parameters:
+        if not is_moe_param(p):
+            continue
+        # An expert parameter built by hand may carry no group name, and without one
+        # there is no expert parallel group to reduce over. Leave every such call on
+        # the original path rather than guessing which group it belongs to.
+        group_name = getattr(p, "group_name", None)
+        if group_name is None:
+            expert_tensors = {}
+            break
+        expert_tensors.setdefault(group_name, []).append(p.grad.data)
+    norm_parameters = [p for p in parameters if not is_moe_param(p)] if expert_tensors else parameters
+
     all_norms = []
     if norm_type == inf:
-        for p in parameters:
+        for p in norm_parameters:
             all_norms.append(p.grad.data.abs().max().float())
         total_norm = torch.stack(all_norms).max()
         total_norm = total_norm.to(get_accelerator().current_device_name())
@@ -400,7 +419,7 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
             dist.all_reduce(total_norm, op=dist.ReduceOp.MAX, group=mpu.get_model_parallel_group())
     else:
         total_norm = 0
-        for p in parameters:
+        for p in norm_parameters:
             if mpu is not None:
                 if (mpu.get_model_parallel_rank() == 0) or is_model_parallel_parameter(p):
                     param_norm = p.grad.data.detach().float().norm(norm_type)
@@ -421,14 +440,29 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
             dist.all_reduce(total_norm, op=dist.ReduceOp.SUM, group=mpu.get_model_parallel_group())
         total_norm = total_norm.pow(1. / norm_type)
 
-    # Need to average total_norm across different GPUs due to the presence of moe params
-    pg = groups._get_data_parallel_group()
-    scaled_norm = total_norm * 1.0 / float(dist.get_world_size(group=pg))
-    scaled_norm_tensor = scaled_norm
+    if expert_tensors:
+        # `total_norm` now covers only the replicated parameters, so it is already the
+        # same on every rank. Fold the experts in over their own group, counting each
+        # expert once, rather than averaging norms that describe different parameters.
+        moe_norm = get_norm_with_moe_layers(total_norm,
+                                            mpu=mpu,
+                                            expert_tensors=expert_tensors,
+                                            norm_type=norm_type)
+        # That helper reports a non-finite norm as -1. Left as-is it would make
+        # `clip_coef` negative and flip the sign of every gradient; inf keeps the
+        # behaviour the averaging path already had, which is to scale them to zero.
+        if moe_norm == -1:
+            moe_norm = float('inf')
+        total_norm = torch.tensor([float(moe_norm)], device=parameters[0].device, dtype=torch.float)
+    else:
+        # Need to average total_norm across different GPUs due to the presence of moe params
+        pg = groups._get_data_parallel_group()
+        scaled_norm = total_norm * 1.0 / float(dist.get_world_size(group=pg))
+        scaled_norm_tensor = scaled_norm
 
-    dist.all_reduce(scaled_norm_tensor, group=pg)
-    total_norm = scaled_norm_tensor
-    total_norm = total_norm.to(parameters[0].device)
+        dist.all_reduce(scaled_norm_tensor, group=pg)
+        total_norm = scaled_norm_tensor
+        total_norm = total_norm.to(parameters[0].device)
 
     max_norm = torch.tensor([float(max_norm)], device=total_norm.device)
     clip_coef = max_norm / (total_norm + 1e-6)

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -399,25 +399,33 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
     # The two branches below issue different collectives, so this decision has to
     # come out the same on every rank -- and a rank whose experts received no tokens
     # this step has expert parameters but no expert gradients.
-    # A rank can legitimately own no expert at all -- under pipeline parallelism, say --
-    # so reading ownership locally is not enough to guarantee the same choice everywhere.
-    # One scalar settles it. The second slot carries "an expert here has no group name",
-    # which has no expert parallel group to reduce over, so such a call stays on the
-    # original path rather than guessing which group the parameter belongs to.
-    vote = torch.tensor(
-        [
-            float(any(is_moe_param(p) and getattr(p, "group_name", None) is not None for p in parameters)),
-            float(any(is_moe_param(p) and getattr(p, "group_name", None) is None for p in parameters)),
-        ],
-        device=get_accelerator().current_device_name(),
-        dtype=torch.float)
-    dist.all_reduce(vote, group=groups._get_data_parallel_group())
-    if vote[0].item() > 0 and vote[1].item() == 0:
-        # The registry is built identically on every rank, so these names agree without
-        # a second collective even where the local parameters do not.
-        expert_group_names = sorted(getattr(groups, "_EXPERT_PARALLEL_GROUP", None) or {})
-    else:
-        expert_group_names = []
+    # The registry of expert groups is built identically on every rank, so an empty one
+    # means no MoE is configured anywhere and the choice is already made: take the
+    # original path, with no collective and no host sync. This is a per-step call from
+    # `_take_model_step`, so the common case must not pay for the MoE one.
+    registry = sorted(getattr(groups, "_EXPERT_PARALLEL_GROUP", None) or {})
+    expert_group_names = []
+    if registry:
+        # A rank can legitimately own no expert at all -- under pipeline parallelism, a
+        # stage holding only dense layers -- so reading ownership locally cannot guarantee
+        # the same choice everywhere. One scalar settles it, and it has to be reduced over
+        # the world rather than the data parallel group: under pipeline parallelism that
+        # group is one stage wide (`PipelineParallelGrid.get_data_parallel_group`), while
+        # the expert norm below reduces over the pipeline group, which spans stages. A
+        # per-stage vote let an expert stage and a dense stage issue different collectives
+        # on that group. The second slot carries "an expert here has no group name", which
+        # has no expert parallel group to reduce over, so such a call stays on the
+        # original path rather than guessing which group the parameter belongs to.
+        vote = torch.tensor(
+            [
+                float(any(is_moe_param(p) and getattr(p, "group_name", None) is not None for p in parameters)),
+                float(any(is_moe_param(p) and getattr(p, "group_name", None) is None for p in parameters)),
+            ],
+            device=get_accelerator().current_device_name(),
+            dtype=torch.float)
+        dist.all_reduce(vote, group=groups._clone_world_group())
+        if vote[0].item() > 0 and vote[1].item() == 0:
+            expert_group_names = registry
 
     parameters = list(filter(lambda p: p.grad is not None, parameters))
 

--- a/deepspeed/runtime/utils.py
+++ b/deepspeed/runtime/utils.py
@@ -387,32 +387,62 @@ def clip_grad_norm_(parameters, max_norm, norm_type=2, mpu=None):
     """
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]
-    parameters = list(filter(lambda p: p.grad is not None, parameters))
+    parameters = list(parameters)
     norm_type = float(norm_type)
 
     # Expert parameters are not replicated across the data parallel group, so the
     # rank-averaging below cannot reconstruct a global norm from them: each rank's
     # norm covers a different set of experts. Combine those the way the bf16 and
     # fp16 optimizers already do, over the expert parallel group.
+    #
+    # Read ownership from the parameters, before dropping the ones with no gradient.
+    # The two branches below issue different collectives, so this decision has to
+    # come out the same on every rank -- and a rank whose experts received no tokens
+    # this step has expert parameters but no expert gradients.
+    # A rank can legitimately own no expert at all -- under pipeline parallelism, say --
+    # so reading ownership locally is not enough to guarantee the same choice everywhere.
+    # One scalar settles it. The second slot carries "an expert here has no group name",
+    # which has no expert parallel group to reduce over, so such a call stays on the
+    # original path rather than guessing which group the parameter belongs to.
+    vote = torch.tensor(
+        [
+            float(any(is_moe_param(p) and getattr(p, "group_name", None) is not None for p in parameters)),
+            float(any(is_moe_param(p) and getattr(p, "group_name", None) is None for p in parameters)),
+        ],
+        device=get_accelerator().current_device_name(),
+        dtype=torch.float)
+    dist.all_reduce(vote, group=groups._get_data_parallel_group())
+    if vote[0].item() > 0 and vote[1].item() == 0:
+        # The registry is built identically on every rank, so these names agree without
+        # a second collective even where the local parameters do not.
+        expert_group_names = sorted(getattr(groups, "_EXPERT_PARALLEL_GROUP", None) or {})
+    else:
+        expert_group_names = []
+
+    parameters = list(filter(lambda p: p.grad is not None, parameters))
+
     expert_tensors: Dict[str, List[torch.Tensor]] = {}
-    for p in parameters:
-        if not is_moe_param(p):
-            continue
-        # An expert parameter built by hand may carry no group name, and without one
-        # there is no expert parallel group to reduce over. Leave every such call on
-        # the original path rather than guessing which group it belongs to.
-        group_name = getattr(p, "group_name", None)
-        if group_name is None:
-            expert_tensors = {}
-            break
-        expert_tensors.setdefault(group_name, []).append(p.grad.data)
+    if expert_group_names:
+        for p in parameters:
+            if is_moe_param(p):
+                expert_tensors.setdefault(p.group_name, []).append(p.grad.data)
+        # Every rank has to reduce over every group, whether or not its own experts
+        # were used this step; a zero contributes nothing to the sum of p-th powers
+        # and nothing to a max over absolute values.
+        zero = torch.zeros(1, device=get_accelerator().current_device_name())
+        for group_name in expert_group_names:
+            expert_tensors.setdefault(group_name, [zero])
+
     norm_parameters = [p for p in parameters if not is_moe_param(p)] if expert_tensors else parameters
 
     all_norms = []
     if norm_type == inf:
         for p in norm_parameters:
             all_norms.append(p.grad.data.abs().max().float())
-        total_norm = torch.stack(all_norms).max()
+        # Everything may be an expert, leaving nothing replicated to take a max over.
+        # Zero is the identity here: these are absolute values.
+        total_norm = torch.stack(all_norms).max() if all_norms \
+            else torch.zeros((), device=get_accelerator().current_device_name())
         total_norm = total_norm.to(get_accelerator().current_device_name())
         # Take max across all GPUs.
         if mpu is not None:

--- a/tests/unit/runtime/test_runtime_utils.py
+++ b/tests/unit/runtime/test_runtime_utils.py
@@ -82,6 +82,67 @@ class TestClipGradNorm(DistributedTest):
         assert abs(float(norm) - expected) < 1e-4, (
             f"global norm {float(norm)} should be {expected} regardless of expert placement")
 
+    def _expert(self, value, device, with_grad=True):
+        param = torch.nn.Parameter(torch.zeros(4, device=device))
+        if with_grad:
+            param.grad = torch.full((4, ), value, device=device)
+        param.allreduce = False
+        param.group_name = "ep_size_2"
+        return param
+
+    def _plain(self, value, device):
+        param = torch.nn.Parameter(torch.zeros(4, device=device))
+        param.grad = torch.full((4, ), value, device=device)
+        return param
+
+    def test_experts_idle_on_one_rank_do_not_deadlock(self):
+        """A rank whose experts got no tokens must take the same collectives (#8469).
+
+        Ownership has to be read from the parameters, not the gradients: `p.grad is
+        not None` filtering drops an unused expert, and branching on what is left made
+        one rank reduce over the expert group while its peer reduced over the data
+        parallel group. They then waited on each other.
+        """
+        groups._create_expert_and_data_parallel(2)
+        rank = dist.get_rank()
+        device = get_accelerator().device_name(rank)
+
+        expert = self._expert(2.0, device, with_grad=(rank == 0))
+        norm = ds_utils.clip_grad_norm_([self._plain(1.0, device), expert], max_norm=1e9)
+
+        # non-expert 2.0 replicated, one expert of norm 4.0 owned by rank 0:
+        # sqrt(2**2 + 4**2).
+        assert abs(float(norm) - 20**0.5) < 1e-4
+
+    def test_a_rank_owning_no_expert_does_not_deadlock(self):
+        """Under pipeline parallelism a rank can hold no expert at all.
+
+        Local ownership then differs in kind rather than in degree, so the branch is
+        settled by one all-reduced flag instead of by what this rank happens to hold.
+        """
+        groups._create_expert_and_data_parallel(2)
+        rank = dist.get_rank()
+        device = get_accelerator().device_name(rank)
+
+        params = [self._plain(1.0, device)]
+        if rank == 0:
+            params.append(self._expert(2.0, device))
+
+        norm = ds_utils.clip_grad_norm_(params, max_norm=1e9)
+        assert abs(float(norm) - 20**0.5) < 1e-4
+
+    def test_expert_only_inf_norm(self):
+        """Nothing replicated leaves no tensor to take a max over; zero is the identity."""
+        groups._create_expert_and_data_parallel(2)
+        rank = dist.get_rank()
+        device = get_accelerator().device_name(rank)
+
+        norm = ds_utils.clip_grad_norm_([self._expert(float(rank + 1), device)],
+                                        max_norm=1e9,
+                                        norm_type=float('inf'))
+
+        assert abs(float(norm) - 2.0) < 1e-4
+
     def test_clipped_val(self):
         max_norm = 0.1
 

--- a/tests/unit/runtime/test_runtime_utils.py
+++ b/tests/unit/runtime/test_runtime_utils.py
@@ -51,6 +51,37 @@ class TestClipGradNorm(DistributedTest):
 
         assert gathered_norm[0] == gathered_norm[1], "norm at rank 0 does not match the norm at rank 1"
 
+    def test_sharded_experts_count_once(self):
+        """The global norm must not depend on how experts are spread over ranks.
+
+        Rank-averaging the per-rank norms only reconstructs a global norm when every
+        rank holds the same parameters. Under expert parallelism they do not, so the
+        four experts below gave sqrt(20) and sqrt(100) averaged to 7.236 instead of
+        the sqrt(120) = 10.954 that counting each expert once produces (#8469).
+        """
+        groups._create_expert_and_data_parallel(2)
+        rank = dist.get_rank()
+        device = get_accelerator().device_name(rank)
+
+        experts = [torch.full((4, ), float(v)) for v in (1.0, 2.0, 3.0, 4.0)]
+        expected = torch.cat(experts).norm(2).item()
+
+        owned = experts[:2] if rank == 0 else experts[2:]
+        params = []
+        for grad in owned:
+            param = torch.nn.Parameter(torch.zeros(4, device=device))
+            param.grad = grad.clone().to(device)
+            param.allreduce = False
+            param.group_name = "ep_size_2"
+            params.append(param)
+
+        # A max_norm far above the norm leaves the gradients alone, so this reads the
+        # computed norm rather than the clipped result.
+        norm = ds_utils.clip_grad_norm_(params, max_norm=1e9)
+
+        assert abs(float(norm) - expected) < 1e-4, (
+            f"global norm {float(norm)} should be {expected} regardless of expert placement")
+
     def test_clipped_val(self):
         max_norm = 0.1
 


### PR DESCRIPTION
Fixes #8475.

(Originally opened against #8469, which @gss10282023 withdrew and resubmitted as #8475 while this was being written. The discussion about how this and #8476 relate is on #8469 and continues on #8475.)

## The measurement

`clip_grad_norm_` ends by averaging the per-rank norms over the data parallel group:

```python
pg = groups._get_data_parallel_group()
scaled_norm = total_norm * 1.0 / float(dist.get_world_size(group=pg))
dist.all_reduce(scaled_norm_tensor, group=pg)
```

That reconstructs a global norm only while every rank holds the same parameters. Expert parameters are not replicated, so each rank's norm describes a different set of experts. Four expert gradients across two ranks, measured on 2×H20:

| layout | global norm |
| --- | ---: |
| reference — each expert counted once | **10.954452** (`sqrt(120)`) |
| replicated on both ranks | 10.954452 |
| one half per rank | **7.236068** |

`sqrt(20)` and `sqrt(100)` averaged to 7.236 instead of `sqrt(20 + 100)`. The same gradients, 34% apart, decided only by where the experts happen to live. `clip_coef` is `max_norm / total_norm`, so wherever clipping is active this changes the update.

@gss10282023 reported this (#8475) and measured a 0.2 shift in the clipping coefficient on their setup; the numbers above are an independent reproduction from a different direction.

## Why the fix is the repo's own

`get_norm_with_moe_layers` already does it correctly — it takes the non-expert norm plus the expert gradients keyed by group, reduces each expert group over its own `moe_ep_group`, and combines as `(Σ norm_i ** p) ** (1/p)`. **Both the bf16 and the fp16 optimizer already call it.**

The fp32 path instead inlines the approximation. That approximation also exists under its own name, `get_norm_with_moe_layers_fast`, carrying this comment:

> This implementation standardizes the grad_norm across ranks. A more precise implementation can be found in 'get_norm_with_moe_layers'.

and that named copy has **no callers at all** — so the warning never reaches the one place still doing it. This PR keeps expert gradients out of the replicated norm and folds them in through the precise helper, leaving fp32 the same shape as the other two optimizers.

## Scope

**Unchanged when no expert parameter is present** — that branch is the original code, not touched. Every non-MoE fp32 run behaves exactly as before, which the existing suite confirms (below).

Two guards worth naming:

- An expert parameter carrying no `group_name` has no expert parallel group to reduce over. `TestClipGradNorm::test_gather` builds one by hand exactly like that, so such a call stays on the original path rather than guessing a group.
- `get_norm_with_moe_layers` reports a non-finite norm as `-1`. Used as-is that would make `clip_coef` negative and flip the sign of every gradient, so it is mapped to `inf` — which keeps what the averaging path already did, scale to zero.

## Testing

2×H20. New case `test_sharded_experts_count_once` asserts the **norm value**, not that a code path was reached:

```
branch                        10 passed          (9 existing + 1 new)
master + this branch's test    1 failed
    AssertionError: global norm 7.236067771911621 should be 10.954451560974121
                    regardless of expert placement
```

It fails on `master` for the defect itself, not because it is new.

`tests/unit/runtime/test_runtime_utils.py` + `tests/unit/v1/moe/test_moe.py`, comparing failure *sets*:

```
master   7 failed, 29 passed, 14 skipped
branch   6 failed, 30 passed, 14 skipped

only failing on branch (regressions) -> none
only failing on master               -> test_sharded_experts_count_once   (the new one)
failing on both                      -> 6
```

The 6 are pre-existing on this box — `ImportError: libcudart.so.13`, unrelated to this change.

## Note

#8470 proposed a fix for the same issue and was closed by its author without discussion. This takes a different route: rather than repairing the averaging, it routes the fp32 path through the combiner the other two optimizers already use, so there is one implementation of the correct thing instead of two.