### PR TITLE
Recognize a norm by its shape, not by whether its class name was listed

### DIFF
--- a/deepspeed/module_inject/auto_tp.py
+++ b/deepspeed/module_inject/auto_tp.py
@@ -146,7 +146,28 @@ class Loading():
             "Qwen3_5MoeRMSNormGated", "DeepseekV2RMSNorm", "DeepseekV3RMSNorm", "DeepseekV2YarnRotaryEmbedding",
             "DeepseekV3YarnRotaryEmbedding", "MoEGate"
         ]
-        return module.__class__ in load_layers or module._get_name() in load_layer_names
+        if module.__class__ in load_layers or module._get_name() in load_layer_names:
+            return True
+        # Every norm above is on the list by class name, and transformers defines one
+        # norm class per architecture -- 233 of them in 5.16.1, of which this list names
+        # 14. The rest reach `_replace_module` and are skipped, so on the meta-device
+        # path their weights are never materialized and stay on meta.
+        #
+        # Recognise them by shape instead: a leaf module whose sole parameter is a 1-D
+        # `weight` is elementwise-affine, which is what `Loading.load` already knows how
+        # to copy. `nn.Linear` and `nn.Embedding` carry 2-D weights and are matched
+        # above, so this admits norms and nothing that wants a different load path.
+        return Loading._is_elementwise_affine_leaf(module)
+
+    def _is_elementwise_affine_leaf(module):
+        if next(module.children(), None) is not None:
+            return False
+        weight = getattr(module, "weight", None)
+        if not isinstance(weight, torch.nn.Parameter) or weight.dim() != 1:
+            return False
+        # A bias, if any, has to match; anything else means this is not a plain norm.
+        extra = {name for name, _ in module.named_parameters(recurse=False)} - {"weight", "bias"}
+        return not extra
 
     def load_buffer(module, state_dict, prefix):
         for name in module._buffers.keys():

--- a/tests/unit/v1/autotp/test_autotp_custom_patterns.py
+++ b/tests/unit/v1/autotp/test_autotp_custom_patterns.py
@@ -989,3 +989,64 @@ class TestAutoTPFusedWeights(DistributedTest):
 
 # Multi-model (teacher + student in one process) and multimodal-config regressions live in
 # tests/unit/v1/autotp/test_autotp_multiple_models.py so they run on the GPU workflow too.
+
+
+class _WeightOnlyNorm(nn.Module):
+    """A norm with the shape every transformers RMSNorm has: one 1-D `weight`."""
+
+    def __init__(self, size=8):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(size))
+
+    def forward(self, hidden_states):
+        return hidden_states * self.weight
+
+
+def test_is_load_module_recognizes_a_norm_it_has_never_heard_of():
+    """Two norms with identical structure, differing only in class name (#8447).
+
+    `Loading.is_load_module` gated on a hardcoded list of 26 class names, so a norm
+    whose architecture was not on it returned False, `_replace_module` skipped it,
+    and on the meta-device path its weight was never materialized. transformers
+    defines one norm class per architecture, so the list named a small fraction of
+    them and the rest were silently left uninitialized.
+    """
+    from deepspeed.module_inject.auto_tp import Loading
+
+    on_the_list = type("LlamaRMSNorm", (_WeightOnlyNorm, ), {})()
+    not_on_the_list = type("GemmaRMSNorm", (_WeightOnlyNorm, ), {})()
+
+    assert Loading.is_load_module(on_the_list)
+    assert Loading.is_load_module(not_on_the_list), (
+        "a norm must be recognized by its shape, not by whether its class name was listed")
+
+
+def test_is_load_module_still_refuses_what_it_refused_before():
+    """The shape test must admit norms and nothing that wants a different load path."""
+    from deepspeed.module_inject.auto_tp import Loading
+
+    # 2-D weights: these are matched by class above and must not start matching by shape.
+    assert Loading.is_load_module(nn.Linear(4, 4))
+    assert Loading.is_load_module(nn.Embedding(4, 4))
+    assert Loading.is_load_module(nn.LayerNorm(4))
+
+    class _TwoDimLeaf(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.ones(4, 4))
+
+    assert not Loading.is_load_module(_TwoDimLeaf())
+    assert not Loading.is_load_module(nn.Conv1d(2, 2, 3))
+    assert not Loading.is_load_module(nn.MultiheadAttention(4, 2))
+    # A container owns its children's parameters but none of its own.
+    assert not Loading.is_load_module(nn.Sequential(nn.Linear(4, 4)))
+
+    class _NormWithExtraParam(_WeightOnlyNorm):
+
+        def __init__(self):
+            super().__init__()
+            self.scale = nn.Parameter(torch.ones(8))
+
+    assert not Loading.is_load_module(_NormWithExtraParam())
+


### PR DESCRIPTION
Fixes #8447.

## The gate

`Loading.is_load_module` decides whether AutoTP loads a module's weights from the checkpoint:

```python
def is_load_module(module):
    load_layers = [nn.Linear, nn.Embedding, nn.LayerNorm]
    load_layer_names = ["LPLayerNorm", "SharedEmbedding", ..., "MoEGate"]   # 26 names
    return module.__class__ in load_layers or module._get_name() in load_layer_names
```

A norm whose class is not on that list returns `False`, `_replace_module` skips it, and on the meta-device path its weight is never materialized. It stays on meta, and nothing is logged.

transformers defines one norm class per architecture, so a list of names can only ever cover a fraction of them. Measured by scanning every `modeling_*.py` in transformers 5.12.1 for norm classes and asking the gate about each — using **one shared RMSNorm body so only the class name differs**, which is the whole point:

| | `master` | this branch |
| --- | ---: | ---: |
| norm class names found | 336 | 336 |
| recognized | **14** | **336** |
| silently skipped | **322** | **0** |

The skipped set includes every Gemma generation, every GLM, Granite, Olmo, MiniMax, Nemotron and Zamba.

## The change

Recognize a norm by shape rather than by name: a **leaf module whose only parameter is a 1-D `weight`** (plus an optional bias) is elementwise-affine, which is exactly what `Loading.load` already knows how to copy.

The name list is left in place, so nothing that matched before stops matching.

## It admits norms and nothing else

This is the half that needed checking, and it is identical on both sides:

| | `master` | this branch |
| --- | --- | --- |
| `nn.Linear` | True | True |
| `nn.Embedding` | True | True |
| `nn.LayerNorm` | True | True |
| `nn.Conv1d` | False | False |
| `nn.MultiheadAttention` | False | False |
| `nn.Sequential` (container) | False | False |
| leaf with a 2-D `weight` | False | False |

`nn.Linear` and `nn.Embedding` carry 2-D weights and are matched by class above, so they cannot start matching by shape; a container owns no parameters of its own; and a leaf carrying anything besides `weight`/`bias` is not a plain norm.

## Testing

2×H20, `tests/unit/v1/autotp/`. Two new cases, both asserting **which modules the gate accepts**, not that a code path ran:

```
branch                         2 passed
master + this branch's tests   1 failed
    AssertionError: a norm must be recognized by its shape,
                    not by whether its class name was listed
```

The second test passes on `master` too — deliberately: it pins the refusals so a future widening of the rule has to break something.

Full file, comparing failure *sets*:

```
master   17 failed, 12 passed
branch   16 failed, 13 passed

only failing on branch (regressions) -> none
only failing on master               -> test_is_load_module_recognizes_a_norm_it_has_never_heard_of
failing on both                      -> 16
```

The 16 are pre-existing on this box — `ImportError: libcudart.so.13`, unrelated to this change.