### PR TITLE
docs: fix precompiled ops install command

### DIFF
--- a/docs/_tutorials/advanced-install.md
+++ b/docs/_tutorials/advanced-install.md
@@ -40,7 +40,7 @@ want to attempt to install all of our ops by setting the `DS_BUILD_OPS`
 environment variable to `1`, for example:
 
 ```bash
-DS_BUILD_OPS=1 pip install deepspeed
+DS_BUILD_OPS=1 pip install --no-build-isolation deepspeed
 ```
 
 DeepSpeed will only install any ops that are compatible with your machine.
@@ -52,7 +52,7 @@ with `DS_BUILD` environment variables at installation time. For example, to
 install DeepSpeed with only the `FusedLamb` op use:
 
 ```bash
-DS_BUILD_FUSED_LAMB=1 pip install deepspeed
+DS_BUILD_FUSED_LAMB=1 pip install --no-build-isolation deepspeed
 ```
 
 Available `DS_BUILD` options include:

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,8 @@ BUILD_OP_DEFAULT = int(get_env_if_set('DS_BUILD_OPS', BUILD_OP_PLATFORM))
 print(f"DS_BUILD_OPS={BUILD_OP_DEFAULT}")
 
 if BUILD_OP_DEFAULT:
-    assert torch_available, "Unable to pre-compile ops without torch installed. Please install torch before attempting to pre-compile ops."
+    assert torch_available, ("Unable to pre-compile ops because torch is not available in the build environment. "
+                             "Install torch first, then run pip install --no-build-isolation deepspeed.")
 
 
 def command_exists(cmd):


### PR DESCRIPTION
## Summary

- disable pip build isolation in the documented precompiled-op install commands
- explain how to expose an existing PyTorch install to the build

Fixes #8480.

## Test

- `pre-commit run --files setup.py docs/_tutorials/advanced-install.md`
- reproduced the setup error in a clean build environment without PyTorch and confirmed it points to `--no-build-isolation`