### PR TITLE
tests: allow testing an installed DeepSpeed package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,13 @@ tests. Note that [pytest-forked](https://github.com/pytest-dev/pytest-forked) an
 `--forked` is safe because `import deepspeed` no longer initializes a CUDA context;
 earlier versions probed CUDA at import time, which poisoned `fork()`.
 
+To test an installed DeepSpeed package and its precompiled ops instead of the source
+checkout, run PyTest from the `tests` directory:
+```bash
+cd tests
+DS_TEST_USE_INSTALLED_DEEPSPEED=1 pytest --forked unit/
+```
+
 You can also run:
 ```
 make test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
 # allow having multiple repository checkouts and not needing to remember to rerun
 # 'pip install -e .[dev]' when switching between checkouts and running tests.
 git_repo_path = abspath(dirname(dirname(__file__)))
-sys.path.insert(1, git_repo_path)
+if os.environ.get('DS_TEST_USE_INSTALLED_DEEPSPEED', '0') != '1':
+    sys.path.insert(1, git_repo_path)
 
 
 def pytest_configure(config):

--- a/tests/unit/test_conftest.py
+++ b/tests/unit/test_conftest.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("use_installed_package", [False, True])
+def test_deepspeed_import_source(use_installed_package, tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    conftest = repo_root / "tests" / "conftest.py"
+    installed_package = tmp_path / "deepspeed"
+    installed_package.mkdir()
+    (installed_package / "__init__.py").write_text("")
+    program = f"""
+import importlib.util
+import runpy
+
+runpy.run_path({str(conftest)!r})
+print(importlib.util.find_spec('deepspeed').origin)
+"""
+    env = os.environ.copy()
+    env["DS_TEST_USE_INSTALLED_DEEPSPEED"] = "1" if use_installed_package else "0"
+    env["PYTHONPATH"] = str(tmp_path)
+
+    result = subprocess.run([sys.executable, "-c", program],
+                            cwd=repo_root / "tests",
+                            capture_output=True,
+                            text=True,
+                            env=env,
+                            check=True)
+
+    expected_package = installed_package if use_installed_package else repo_root / "deepspeed"
+    assert Path(result.stdout.strip()).resolve() == expected_package / "__init__.py"


### PR DESCRIPTION
## Summary

- keep source-checkout imports as the default test behavior
- add `DS_TEST_USE_INSTALLED_DEEPSPEED=1` for validating installed packages and precompiled ops
- document the installed-package test command

Fixes #7909.

## Test

- `pytest tests/unit/test_conftest.py -q`
- `pre-commit run --files CONTRIBUTING.md tests/conftest.py tests/unit/test_conftest.py`