### PR TITLE
Refresh the whole captured input before a CUDA graph replay

### DIFF
--- a/deepspeed/inference/engine.py
+++ b/deepspeed/inference/engine.py
@@ -34,6 +34,7 @@ from ..module_inject.auto_tp_model_utils import (build_bloom_alibi_tensor, build
                                                  install_head_sharded_helper)
 from ..ops.transformer.inference.ds_attention import DeepSpeedSelfAttention
 from ..model_implementations.transformers.ds_transformer import DeepSpeedTransformerInference
+from ..model_implementations.features.cuda_graph import refresh_static_tensors
 
 DS_INFERENCE_ENABLED = False
 from torch import nn
@@ -545,12 +546,11 @@ class InferenceEngine(Module):
         self.cuda_graph_created = True
 
     def _graph_replay(self, *inputs, **kwargs):
-        for i in range(len(inputs)):
-            if torch.is_tensor(inputs[i]):
-                self.static_inputs[i].copy_(inputs[i])
-        for k in kwargs:
-            if torch.is_tensor(kwargs[k]):
-                self.static_kwargs[k].copy_(kwargs[k])
+        for captured, latest in zip(self.static_inputs, inputs):
+            refresh_static_tensors(captured, latest)
+        for key, captured in self.static_kwargs.items():
+            if key in kwargs:
+                refresh_static_tensors(captured, kwargs[key])
         get_accelerator().replay_graph(self._cuda_graphs)
         return self.static_output
 

--- a/deepspeed/model_implementations/diffusers/unet.py
+++ b/deepspeed/model_implementations/diffusers/unet.py
@@ -5,7 +5,7 @@
 
 import torch
 from deepspeed.accelerator import get_accelerator
-from ..features.cuda_graph import CUDAGraph
+from ..features.cuda_graph import CUDAGraph, refresh_static_tensors
 
 
 class DSUNet(CUDAGraph, torch.nn.Module):
@@ -24,12 +24,11 @@ class DSUNet(CUDAGraph, torch.nn.Module):
         self.cuda_graph_created = False
 
     def _graph_replay(self, *inputs, **kwargs):
-        for i in range(len(inputs)):
-            if torch.is_tensor(inputs[i]):
-                self.static_inputs[i].copy_(inputs[i])
-        for k in kwargs:
-            if torch.is_tensor(kwargs[k]):
-                self.static_kwargs[k].copy_(kwargs[k])
+        for captured, latest in zip(self.static_inputs, inputs):
+            refresh_static_tensors(captured, latest)
+        for key, captured in self.static_kwargs.items():
+            if key in kwargs:
+                refresh_static_tensors(captured, kwargs[key])
         get_accelerator().replay_graph(self._cuda_graphs)
         return self.static_output
 

--- a/deepspeed/model_implementations/diffusers/vae.py
+++ b/deepspeed/model_implementations/diffusers/vae.py
@@ -5,7 +5,7 @@
 
 import torch
 from deepspeed.accelerator import get_accelerator
-from ..features.cuda_graph import CUDAGraph
+from ..features.cuda_graph import CUDAGraph, refresh_static_tensors
 
 
 class DSVAE(CUDAGraph, torch.nn.Module):
@@ -22,12 +22,11 @@ class DSVAE(CUDAGraph, torch.nn.Module):
         self.all_cuda_graph_created = False
 
     def _graph_replay_decoder(self, *inputs, **kwargs):
-        for i in range(len(inputs)):
-            if torch.is_tensor(inputs[i]):
-                self.static_decoder_inputs[i].copy_(inputs[i])
-        for k in kwargs:
-            if torch.is_tensor(kwargs[k]):
-                self.static_decoder_kwargs[k].copy_(kwargs[k])
+        for captured, latest in zip(self.static_decoder_inputs, inputs):
+            refresh_static_tensors(captured, latest)
+        for key, captured in self.static_decoder_kwargs.items():
+            if key in kwargs:
+                refresh_static_tensors(captured, kwargs[key])
         get_accelerator().replay_graph(self._decoder_cuda_graph)
         return self.static_decoder_output
 
@@ -65,12 +64,11 @@ class DSVAE(CUDAGraph, torch.nn.Module):
             return self._decode(*inputs, **kwargs)
 
     def _graph_replay_encoder(self, *inputs, **kwargs):
-        for i in range(len(inputs)):
-            if torch.is_tensor(inputs[i]):
-                self.static_encoder_inputs[i].copy_(inputs[i])
-        for k in kwargs:
-            if torch.is_tensor(kwargs[k]):
-                self.static_encoder_kwargs[k].copy_(kwargs[k])
+        for captured, latest in zip(self.static_encoder_inputs, inputs):
+            refresh_static_tensors(captured, latest)
+        for key, captured in self.static_encoder_kwargs.items():
+            if key in kwargs:
+                refresh_static_tensors(captured, kwargs[key])
         get_accelerator().replay_graph(self._encoder_cuda_graph)
         return self.static_encoder_output
 
@@ -108,12 +106,11 @@ class DSVAE(CUDAGraph, torch.nn.Module):
             return self._encode(*inputs, **kwargs)
 
     def _graph_replay(self, *inputs, **kwargs):
-        for i in range(len(inputs)):
-            if torch.is_tensor(inputs[i]):
-                self.static_inputs[i].copy_(inputs[i])
-        for k in kwargs:
-            if torch.is_tensor(kwargs[k]):
-                self.static_kwargs[k].copy_(kwargs[k])
+        for captured, latest in zip(self.static_inputs, inputs):
+            refresh_static_tensors(captured, latest)
+        for key, captured in self.static_kwargs.items():
+            if key in kwargs:
+                refresh_static_tensors(captured, kwargs[key])
         get_accelerator().replay_graph(self._all_cuda_graph)
         return self.static_output
 

--- a/deepspeed/model_implementations/features/cuda_graph.py
+++ b/deepspeed/model_implementations/features/cuda_graph.py
@@ -3,7 +3,32 @@
 
 # DeepSpeed Team
 
+import torch
 from abc import ABC, abstractmethod
+
+
+def refresh_static_tensors(static, new):
+    """Copy `new` into the tensors `static` holds, following dicts, lists and tuples.
+
+    A replay reuses the tensors that were captured into the graph, so a later call's values
+    reach the model only by being copied into them. Matching on `torch.is_tensor` alone stops
+    at the top level, which leaves a kwarg that keeps its tensors inside a container holding
+    whatever capture saw. SDXL passes `added_cond_kwargs` as
+    `{"text_embeds": ..., "time_ids": ...}`, so every image after the first was built from the
+    first prompt's conditioning, with no error to show for it.
+    """
+    if torch.is_tensor(static):
+        if torch.is_tensor(new):
+            static.copy_(new)
+    elif isinstance(static, dict):
+        if isinstance(new, dict):
+            for key, captured in static.items():
+                if key in new:
+                    refresh_static_tensors(captured, new[key])
+    elif isinstance(static, (list, tuple)):
+        if isinstance(new, (list, tuple)) and len(static) == len(new):
+            for captured, latest in zip(static, new):
+                refresh_static_tensors(captured, latest)
 
 
 class CUDAGraph(ABC):

--- a/deepspeed/model_implementations/transformers/clip_encoder.py
+++ b/deepspeed/model_implementations/transformers/clip_encoder.py
@@ -5,7 +5,7 @@
 
 import torch
 from deepspeed.accelerator import get_accelerator
-from ..features.cuda_graph import CUDAGraph
+from ..features.cuda_graph import CUDAGraph, refresh_static_tensors
 
 
 class DSClipEncoder(CUDAGraph, torch.nn.Module):
@@ -32,12 +32,11 @@ class DSClipEncoder(CUDAGraph, torch.nn.Module):
         return mask
 
     def _graph_replay(self, *inputs, **kwargs):
-        for i in range(len(inputs)):
-            if torch.is_tensor(inputs[i]):
-                self.static_inputs[self.iter][i].copy_(inputs[i])
-        for k in kwargs:
-            if torch.is_tensor(kwargs[k]):
-                self.static_kwargs[self.iter][k].copy_(kwargs[k])
+        for captured, latest in zip(self.static_inputs[self.iter], inputs):
+            refresh_static_tensors(captured, latest)
+        for key, captured in self.static_kwargs[self.iter].items():
+            if key in kwargs:
+                refresh_static_tensors(captured, kwargs[key])
         get_accelerator().replay_graph(self._cuda_graphs[self.iter])
         return self.static_output[self.iter]
 

--- a/tests/unit/inference/test_cuda_graph_static_inputs.py
+++ b/tests/unit/inference/test_cuda_graph_static_inputs.py
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSpeed Team
+
+import torch
+from types import SimpleNamespace
+
+import deepspeed.model_implementations.diffusers.unet as unet_module
+from deepspeed.model_implementations.diffusers.unet import DSUNet
+from deepspeed.model_implementations.features.cuda_graph import refresh_static_tensors
+
+
+class RecordingUNet(torch.nn.Module):
+    """Stands in for a diffusers UNet. DSUNet reads these four attributes in __init__."""
+
+    def __init__(self):
+        super().__init__()
+        self.in_channels = 4
+        self.device = torch.device("cpu")
+        self.dtype = torch.float32
+        self.config = None
+
+    def forward(self, *inputs, **kwargs):
+        return "unet"
+
+
+def test_refresh_static_tensors_follows_dicts_lists_and_tuples():
+    static = {"a": torch.zeros(2), "b": [torch.zeros(2), (torch.zeros(2), )]}
+
+    refresh_static_tensors(static, {"a": torch.ones(2), "b": [torch.full((2, ), 2.0), (torch.full((2, ), 3.0), )]})
+
+    assert torch.equal(static["a"], torch.ones(2))
+    assert torch.equal(static["b"][0], torch.full((2, ), 2.0))
+    assert torch.equal(static["b"][1][0], torch.full((2, ), 3.0))
+
+
+def test_refresh_static_tensors_keeps_what_the_new_call_does_not_cover():
+    # A replay runs the tensors the graph captured, so anything the new call does not line up
+    # with stays as captured. Raising from here would break a call that only passes some of them.
+    static = {"kept": torch.zeros(2), "refreshed": torch.zeros(2)}
+    refresh_static_tensors(static, {"refreshed": torch.ones(2)})
+    assert torch.equal(static["kept"], torch.zeros(2))
+    assert torch.equal(static["refreshed"], torch.ones(2))
+
+    pair = [torch.zeros(2), torch.zeros(2)]
+    refresh_static_tensors(pair, [torch.ones(2)])
+    assert torch.equal(pair[0], torch.zeros(2))
+
+    captured = torch.zeros(2)
+    refresh_static_tensors(captured, 5)
+    assert torch.equal(captured, torch.zeros(2))
+
+
+def test_ds_unet_graph_replay_refreshes_nested_conditioning(monkeypatch):
+    # SDXL passes added_cond_kwargs as a dict of tensors. Copying only top-level tensors left
+    # that dict holding what capture saw, so every later prompt replayed the first one's
+    # conditioning and the pipeline returned a plausible image for the wrong text.
+    monkeypatch.setattr(unet_module, "get_accelerator", lambda: SimpleNamespace(replay_graph=lambda graph: None))
+
+    ds_unet = DSUNet(RecordingUNet(), enable_cuda_graph=True)
+    added_cond_kwargs = {"text_embeds": torch.zeros(2), "time_ids": torch.zeros(2)}
+    ds_unet.static_inputs = (torch.zeros(2), )
+    ds_unet.static_kwargs = {"added_cond_kwargs": added_cond_kwargs}
+    ds_unet.static_output = "replayed"
+    ds_unet._cuda_graphs = None
+
+    output = ds_unet._graph_replay(torch.ones(2),
+                                   added_cond_kwargs={
+                                       "text_embeds": torch.full((2, ), 3.0),
+                                       "time_ids": torch.full((2, ), 4.0)
+                                   })
+
+    assert output == "replayed"
+    assert torch.equal(ds_unet.static_inputs[0], torch.ones(2))
+    assert torch.equal(added_cond_kwargs["text_embeds"], torch.full((2, ), 3.0))
+    assert torch.equal(added_cond_kwargs["time_ids"], torch.full((2, ), 4.0))


### PR DESCRIPTION
The UNet conditioning case depends on #8408 forwarding `added_cond_kwargs`; merge that PR first. This PR handles refreshing captured containers across the wrappers.

## What broke

`_graph_replay` copies a later call's values into the tensors the CUDA graph captured, but it only matched `torch.is_tensor`, so it stopped at the top level. An argument that keeps its tensors inside a container was never refreshed.

SDXL is the clearest case. Its pipeline calls the UNet with

```python
added_cond_kwargs={"text_embeds": ..., "time_ids": ...}
```

That is a dict, not a tensor, so it was skipped. Every image after the first was denoised with the first prompt's pooled embeddings and time ids. The pipeline still returns a plausible image, so nothing reports an error.

## Why

The same six lines are repeated at every replay site, and all six have the same gap:

- `DSUNet._graph_replay`
- `DSVAE._graph_replay_decoder`, `_graph_replay_encoder`, `_graph_replay`
- `DSClipEncoder._graph_replay`
- `InferenceEngine._graph_replay`

## What changed

`refresh_static_tensors()` lands next to `CUDAGraph` and all six sites call it. It walks dicts, lists and tuples and copies at the tensors.

The loops now zip over the captured side instead of indexing by the new call's length. An extra positional argument or a kwarg that was not present at capture now leaves the captured values alone, rather than raising `IndexError` or `KeyError` from inside the replay path.

## Tests

`tests/unit/inference/test_cuda_graph_static_inputs.py`:

- the walk over dicts, lists and tuples
- the cases it must leave alone: a missing key, a shorter list, a non-tensor
- `DSUNet._graph_replay` refreshing a nested `added_cond_kwargs`

The last one fails on master, where `text_embeds` keeps its capture-time value, and passes here. CPU only and no graph capture, because the bug is entirely in which tensors get copied.

```
3 passed in 5.50s
```

`yapf` 0.40.0 and `flake8` with the repo config are clean on all six files.
