### PR TITLE
feat(rollout): add continuous batching profiling

### DIFF
--- a/deepspeed/runtime/rollout/hybrid_engine_rollout.py
+++ b/deepspeed/runtime/rollout/hybrid_engine_rollout.py
@@ -397,7 +397,7 @@ class HybridEngineRollout(RolloutEngine):
         generation_end = self._profile_start(profile)
         post_processing_start = generation_end
         output = self._build_continuous_batch(original_request, responses)
-        post_processing_end = self._profile_end(profile, None, post_processing_start, synchronize=False)
+        post_processing_end = self._profile_end(profile, None, post_processing_start)
         if profile is not None:
             self._finish_continuous_profile(profile, original_request, responses, max_batch_size, prompt_len,
                                             generation_end, post_processing_end)

--- a/deepspeed/runtime/rollout/hybrid_engine_rollout.py
+++ b/deepspeed/runtime/rollout/hybrid_engine_rollout.py
@@ -259,6 +259,7 @@ class HybridEngineRollout(RolloutEngine):
         self._validate_continuous_inputs(requests, sampling, max_batch_size)
 
         module = self.engine.module
+        profile = self._start_continuous_profile() if self.enable_profiling else None
         prompt_len = requests[0].prompt_ids.shape[1]
         max_positions = getattr(module.config, "max_position_embeddings", None)
         if max_positions is not None:
@@ -282,6 +283,7 @@ class HybridEngineRollout(RolloutEngine):
         device = requests[0].prompt_ids.device
         model_dtype = next(module.parameters()).dtype
 
+        scheduler_start = self._profile_start(profile)
         scheduler = ContinuousBatchScheduler(max_batch_size, sampling.max_new_tokens)
         request_by_id = {}
         responses = {}
@@ -289,7 +291,9 @@ class HybridEngineRollout(RolloutEngine):
             scheduler.submit(ContinuousBatchRequest(request_id))
             request_by_id[request_id] = request
             responses[request_id] = []
+        self._profile_end(profile, "scheduler_overhead_ms", scheduler_start)
 
+        cache_start = self._profile_start(profile)
         cache = DeepSpeedStaticCache(
             module.config,
             batch_size=max_batch_size,
@@ -303,9 +307,15 @@ class HybridEngineRollout(RolloutEngine):
         next_tokens = {}
         cache_position = prompt_len
         trim_threshold = max(1, prompt_len)
+        self._profile_end(profile, "cache_management_overhead_ms", cache_start)
+        scheduler_start = self._profile_start(profile)
         update = scheduler.schedule()
+        self._profile_end(profile, "scheduler_overhead_ms", scheduler_start)
 
         while update.active:
+            if profile is not None:
+                profile["active_batch_sizes"].append(len(update.active))
+            cache_start = self._profile_start(profile)
             keep_slots = torch.tensor(update.keep_slots, dtype=torch.long, device=device)
             survivor_count = keep_slots.numel()
             if survivor_count:
@@ -332,6 +342,7 @@ class HybridEngineRollout(RolloutEngine):
                 write_positions.fill_(-1)
                 attention_mask.zero_()
                 cache_position = prompt_len
+            self._profile_end(profile, "cache_management_overhead_ms", cache_start)
 
             admitted_tokens = self._continuous_prefill(
                 module,
@@ -345,6 +356,7 @@ class HybridEngineRollout(RolloutEngine):
                 prompt_len,
                 model_dtype,
                 device,
+                profile,
             )
 
             decoded_tokens = {}
@@ -354,6 +366,7 @@ class HybridEngineRollout(RolloutEngine):
                 write_positions[:survivor_count].fill_(cache_position)
                 position_ids = attention_mask[:survivor_count, :cache_position].sum(dim=1, keepdim=True)
                 attention_mask[:survivor_count, cache_position] = 1
+                decode_start = self._profile_start(profile)
                 output = self._call_model(
                     module,
                     decode_input,
@@ -363,6 +376,7 @@ class HybridEngineRollout(RolloutEngine):
                     cache_position=torch.tensor([cache_position], dtype=torch.long, device=device),
                     position_ids=position_ids,
                 )
+                self._profile_end(profile, "decode_forward_ms", decode_start, count="num_decode_forwards")
                 decoded = output.logits[:, -1, :].argmax(dim=-1, keepdim=True)
                 decoded_tokens = dict(zip(survivor_ids, decoded.split(1, dim=0)))
 
@@ -374,11 +388,85 @@ class HybridEngineRollout(RolloutEngine):
                 if self._is_eos(token):
                     finished_ids.append(request_id)
 
+            scheduler_start = self._profile_start(profile)
             update = scheduler.advance(finished_ids)
+            self._profile_end(profile, "scheduler_overhead_ms", scheduler_start)
             if survivor_count:
                 cache_position += 1
 
-        return self._build_continuous_batch(original_request, responses)
+        generation_end = self._profile_start(profile)
+        post_processing_start = generation_end
+        output = self._build_continuous_batch(original_request, responses)
+        post_processing_end = self._profile_end(profile, None, post_processing_start, synchronize=False)
+        if profile is not None:
+            self._finish_continuous_profile(profile, original_request, responses, max_batch_size, prompt_len,
+                                            generation_end, post_processing_end)
+        return output
+
+    def _start_continuous_profile(self):
+        accelerator = get_accelerator()
+        accelerator.synchronize()
+        return {
+            "accelerator": accelerator,
+            "start": time.perf_counter(),
+            "prefill_forward_ms": 0.0,
+            "decode_forward_ms": 0.0,
+            "scheduler_overhead_ms": 0.0,
+            "cache_management_overhead_ms": 0.0,
+            "num_prefill_forwards": 0,
+            "num_decode_forwards": 0,
+            "active_batch_sizes": [],
+        }
+
+    @staticmethod
+    def _profile_start(profile):
+        if profile is None:
+            return None
+        profile["accelerator"].synchronize()
+        return time.perf_counter()
+
+    @staticmethod
+    def _profile_end(profile, field, start, count=None, count_if=True, synchronize=True):
+        if profile is None or start is None:
+            return None
+        if synchronize:
+            profile["accelerator"].synchronize()
+        end = time.perf_counter()
+        if field is not None and count_if:
+            profile[field] += (end - start) * 1000.0
+        if count is not None and count_if:
+            profile[count] += 1
+        return end
+
+    def _finish_continuous_profile(self, profile, request, responses, max_batch_size, prompt_len, generation_end,
+                                   post_processing_end):
+        total_ms = (post_processing_end - profile["start"]) * 1000.0
+        generation_ms = (generation_end - profile["start"]) * 1000.0
+        prefill_ms = profile["prefill_forward_ms"]
+        decode_ms = profile["decode_forward_ms"]
+        response_lengths = [len(response) for response in responses.values()]
+        num_generated_tokens = sum(response_lengths)
+        self._last_profile = {
+            "prompt_expansion_ms": 0.0,
+            "generation_ms": generation_ms,
+            "prefill_forward_ms": prefill_ms,
+            "decode_forward_ms": decode_ms,
+            "generation_overhead_ms": max(0.0, generation_ms - prefill_ms - decode_ms),
+            "num_prefill_forwards": profile["num_prefill_forwards"],
+            "num_decode_forwards": profile["num_decode_forwards"],
+            "scheduler_overhead_ms": profile["scheduler_overhead_ms"],
+            "cache_management_overhead_ms": profile["cache_management_overhead_ms"],
+            "post_processing_ms": (post_processing_end - generation_end) * 1000.0,
+            "total_ms": total_ms,
+            "num_generated_tokens": num_generated_tokens,
+            "tokens_per_second": num_generated_tokens / (total_ms / 1000.0) if total_ms > 0.0 else 0.0,
+            "batch_size": request.prompt_ids.shape[0],
+            "num_samples_per_prompt": 1,
+            "prompt_length": prompt_len,
+            "response_length": max(response_lengths, default=0),
+            "active_batch_size": max(profile["active_batch_sizes"], default=0),
+            "continuous_batch_size": max_batch_size,
+        }
 
     @staticmethod
     def _estimate_continuous_cache_len(prompt_len, max_new_tokens, max_batch_size):
@@ -448,8 +536,19 @@ class HybridEngineRollout(RolloutEngine):
             return 0
         return int(occupied.to(dtype=torch.int32).argmax().item())
 
-    def _continuous_prefill(self, module, static_cache_type, cache, update, request_by_id, attention_mask,
-                            write_positions, cache_position, prompt_len, model_dtype, device):
+    def _continuous_prefill(self,
+                            module,
+                            static_cache_type,
+                            cache,
+                            update,
+                            request_by_id,
+                            attention_mask,
+                            write_positions,
+                            cache_position,
+                            prompt_len,
+                            model_dtype,
+                            device,
+                            profile=None):
         if not update.admitted:
             return {}
 
@@ -459,6 +558,7 @@ class HybridEngineRollout(RolloutEngine):
                                      dim=0)
         prefill_cache = self._create_static_cache(static_cache_type, module.config, len(admitted_ids), prompt_len,
                                                   device, model_dtype)
+        prefill_start = self._profile_start(profile)
         prefill_output = self._call_model(
             module,
             prompt_ids,
@@ -467,16 +567,19 @@ class HybridEngineRollout(RolloutEngine):
             use_cache=True,
             cache_position=torch.arange(prompt_len, device=device),
         )
+        self._profile_end(profile, "prefill_forward_ms", prefill_start, count="num_prefill_forwards")
+        cache_start = self._profile_start(profile)
         prefill_tokens = prefill_output.logits[:, -1, :].argmax(dim=-1, keepdim=True)
-        cache_start = cache_position - prompt_len
+        cache_offset = cache_position - prompt_len
         for layer_idx, prefill_layer in enumerate(prefill_cache.layers):
             target_layer = cache.layers[layer_idx]
             for source_row, target_row in enumerate(update.admitted_slots):
-                target_layer.keys[target_row, :, cache_start:cache_position].copy_(prefill_layer.keys[source_row])
-                target_layer.values[target_row, :, cache_start:cache_position].copy_(prefill_layer.values[source_row])
+                target_layer.keys[target_row, :, cache_offset:cache_position].copy_(prefill_layer.keys[source_row])
+                target_layer.values[target_row, :, cache_offset:cache_position].copy_(prefill_layer.values[source_row])
         for source_row, target_row in enumerate(update.admitted_slots):
-            attention_mask[target_row, cache_start:cache_position].copy_(prompt_attention[source_row])
+            attention_mask[target_row, cache_offset:cache_position].copy_(prompt_attention[source_row])
             write_positions[target_row] = cache_position
+        self._profile_end(profile, "cache_management_overhead_ms", cache_start)
         return dict(zip(admitted_ids, prefill_tokens.split(1, dim=0)))
 
     def _is_eos(self, token):

--- a/docs/code-docs/source/inference-engine.rst
+++ b/docs/code-docs/source/inference-engine.rst
@@ -86,6 +86,18 @@ and pending rows are prefetched into the released slots. The returned
 The experimental path periodically trims unused cache columns from the left
 to keep long-running staggered-EOS workloads within the allocated cache span.
 
+When ``HybridEngineRolloutConfig(enable_profiling=True)`` is enabled, this path
+also records a snapshot in ``get_last_profile()``. In addition to the common
+rollout fields, the snapshot reports ``scheduler_overhead_ms`` for scheduler
+transitions, ``cache_management_overhead_ms`` for cache compaction, trimming,
+reset, and admitted-row copies, and separate ``prefill_forward_ms`` and
+``decode_forward_ms`` totals. ``num_prefill_forwards`` counts each admitted
+prompt batch, while ``num_decode_forwards`` counts decode steps that had
+surviving rows. ``num_generated_tokens`` counts tokens actually produced by
+all requests (padding is excluded), and ``active_batch_size`` is the maximum
+number of simultaneously active rows; ``continuous_batch_size`` is the
+configured capacity.
+
 The experimental path intentionally does not implement paged attention or change the
 default generation semantics. It currently requires one prompt width for all
 rows, a model with cache-class support, greedy decoding, and one sample per

--- a/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
+++ b/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
@@ -265,9 +265,9 @@ def test_continuous_generation_trims_cache_after_staggered_eos():
     ]
 
 
-@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")
-@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
-def test_continuous_generation_records_profile(mock_get_accelerator, mock_perf_counter):
+def test_continuous_generation_profile_on_cuda_device():
+    if not torch.cuda.is_available():  #ignore-cuda
+        pytest.skip("CUDA is required for asynchronous profiling coverage")
 
     class CacheConfig(SimpleNamespace):
 
@@ -292,30 +292,32 @@ def test_continuous_generation_records_profile(mock_get_accelerator, mock_perf_c
         def forward(self, input_ids, attention_mask, past_key_values=None, use_cache=True, **kwargs):
             states = input_ids[:, None, :, None].to(dtype=torch.float32)
             _, values = past_key_values.update(states, states, layer_idx=0, **kwargs)
-            logits = torch.zeros((input_ids.shape[0], input_ids.shape[1], 16))
+            logits = torch.zeros((input_ids.shape[0], input_ids.shape[1], 16), device=input_ids.device)
             logits[..., 7] = 1
             return SimpleNamespace(logits=logits, past_key_values=past_key_values)
 
-    model = CacheClassModel()
+    device = torch.device("cuda")
+    model = CacheClassModel().to(device)
     rollout = HybridEngineRollout(
         SimpleNamespace(module=model),
         SimpleNamespace(pad_token_id=0, eos_token_id=2),
         cfg=HybridEngineRolloutConfig(enable_profiling=True),
     )
-    request = RolloutRequest(torch.tensor([[1, 2, 3], [1, 2, 4]]), torch.ones((2, 3), dtype=torch.long))
-    mock_perf_counter.side_effect = iter(float(index) / 1000 for index in range(100))
+    request = RolloutRequest(
+        torch.tensor([[1, 2, 3], [1, 2, 4]], device=device),
+        torch.ones((2, 3), dtype=torch.long, device=device),
+    )
 
     output = rollout.generate(request, SamplingConfig(max_new_tokens=2, temperature=0, continuous_batch_size=1))
 
     profile = rollout.get_last_profile()
-    assert output.input_ids.tolist() == [[1, 2, 3, 7, 7], [1, 2, 4, 7, 7]]
+    assert output.input_ids[:, 3:].cpu().tolist() == [[7, 7], [7, 7]]
     assert profile["num_prefill_forwards"] == 2
     assert profile["num_decode_forwards"] == 2
     assert profile["num_generated_tokens"] == 4
     assert profile["active_batch_size"] == 1
     assert profile["continuous_batch_size"] == 1
-    assert profile["prefill_forward_ms"] > 0
-    assert profile["decode_forward_ms"] > 0
+    assert profile["total_ms"] >= profile["generation_ms"]
 
 
 @patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")

--- a/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
+++ b/tests/unit/runtime/rollout/test_hybrid_engine_rollout.py
@@ -267,6 +267,59 @@ def test_continuous_generation_trims_cache_after_staggered_eos():
 
 @patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")
 @patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
+def test_continuous_generation_records_profile(mock_get_accelerator, mock_perf_counter):
+
+    class CacheConfig(SimpleNamespace):
+
+        def get_text_config(self, **_kwargs):
+            return self
+
+    class CacheClassModel(torch.nn.Module):
+        _supports_cache_class = True
+
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(1))
+            self.config = CacheConfig(
+                max_position_embeddings=32,
+                num_hidden_layers=1,
+                num_attention_heads=1,
+                num_key_value_heads=1,
+                hidden_size=1,
+                head_dim=1,
+            )
+
+        def forward(self, input_ids, attention_mask, past_key_values=None, use_cache=True, **kwargs):
+            states = input_ids[:, None, :, None].to(dtype=torch.float32)
+            _, values = past_key_values.update(states, states, layer_idx=0, **kwargs)
+            logits = torch.zeros((input_ids.shape[0], input_ids.shape[1], 16))
+            logits[..., 7] = 1
+            return SimpleNamespace(logits=logits, past_key_values=past_key_values)
+
+    model = CacheClassModel()
+    rollout = HybridEngineRollout(
+        SimpleNamespace(module=model),
+        SimpleNamespace(pad_token_id=0, eos_token_id=2),
+        cfg=HybridEngineRolloutConfig(enable_profiling=True),
+    )
+    request = RolloutRequest(torch.tensor([[1, 2, 3], [1, 2, 4]]), torch.ones((2, 3), dtype=torch.long))
+    mock_perf_counter.side_effect = iter(float(index) / 1000 for index in range(100))
+
+    output = rollout.generate(request, SamplingConfig(max_new_tokens=2, temperature=0, continuous_batch_size=1))
+
+    profile = rollout.get_last_profile()
+    assert output.input_ids.tolist() == [[1, 2, 3, 7, 7], [1, 2, 4, 7, 7]]
+    assert profile["num_prefill_forwards"] == 2
+    assert profile["num_decode_forwards"] == 2
+    assert profile["num_generated_tokens"] == 4
+    assert profile["active_batch_size"] == 1
+    assert profile["continuous_batch_size"] == 1
+    assert profile["prefill_forward_ms"] > 0
+    assert profile["decode_forward_ms"] > 0
+
+
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.time.perf_counter")
+@patch("deepspeed.runtime.rollout.hybrid_engine_rollout.get_accelerator")
 def test_generate_records_profile_when_enabled(mock_get_accelerator, mock_perf_counter):
     engine = _make_engine()
     tok = _make_tokenizer()


### PR DESCRIPTION
## Summary
Thanks @delock for the continuous batching prototype and profiling follow-up.
Continuous batching currently bypasses `HybridEngineRollout` profiling, so no useful profile is recorded. This PR adds opt-in profiling for continuous batching, covering:
- prefill and decode forward time/counts
- scheduler and cache-management overhead
- generated tokens and throughput
- active batch size and configured capacity
Profiling remains disabled by default and does not change generation outputs or scheduling behavior.
## Validation
- Focused rollout tests: `38 passed`
- `py_compile`: passed
- `git diff --check`: passed
- YAPF and flake8 checks: passed

Related to #8459