### PR TITLE
Preserve each Adam group's beta2 in OneCycle

### DIFF
--- a/deepspeed/runtime/lr_schedules.py
+++ b/deepspeed/runtime/lr_schedules.py
@@ -569,8 +569,14 @@ class OneCycle(object):
             return
 
         self.decay_mom_rate = decay_mom_rate
-        self.min_moms = [(mom, 0.99) for mom in _format_param(optimizer, cycle_min_mom, 'cycle_min_mom')]
-        self.max_moms = [(mom, 0.99) for mom in _format_param(optimizer, cycle_max_mom, 'cycle_max_mom')]
+        self.min_moms = [
+            (mom, group['betas'][1])
+            for mom, group in zip(_format_param(optimizer, cycle_min_mom, 'cycle_min_mom'), optimizer.param_groups)
+        ]
+        self.max_moms = [
+            (mom, group['betas'][1])
+            for mom, group in zip(_format_param(optimizer, cycle_max_mom, 'cycle_max_mom'), optimizer.param_groups)
+        ]
 
         if last_batch_iteration == -1:
             for momentum, group in zip(self.min_moms, optimizer.param_groups):

--- a/tests/unit/runtime/test_lr_schedulers.py
+++ b/tests/unit/runtime/test_lr_schedulers.py
@@ -823,6 +823,46 @@ def _two_group_adam():
     return torch.optim.Adam([{"params": [dense], "lr": 0.1}, {"params": [expert], "lr": 0.2}], betas=(0.9, 0.99))
 
 
+def test_one_cycle_preserves_per_group_beta2():
+    model = torch.nn.Linear(2, 1)
+    reference = torch.nn.Linear(2, 1)
+    reference.load_state_dict(model.state_dict())
+    beta2s = [0.999, 0.95]
+
+    def make_optimizer(module):
+        return torch.optim.Adam([{
+            "params": [param],
+            "betas": (0.9, beta2)
+        } for param, beta2 in zip(module.parameters(), beta2s)],
+                                lr=0.1)
+
+    optimizer = make_optimizer(model)
+    expected_optimizer = make_optimizer(reference)
+    scheduler = OneCycle(optimizer,
+                         cycle_min_lr=0.01,
+                         cycle_max_lr=0.1,
+                         cycle_first_step_size=2,
+                         cycle_second_step_size=2,
+                         decay_step_size=2,
+                         decay_lr_rate=0.1)
+    assert [group["betas"][1] for group in optimizer.param_groups] == beta2s
+
+    inputs = torch.tensor([[1.0, -2.0]])
+    for _ in range(6):
+        for actual_group, expected_group, beta2 in zip(optimizer.param_groups, expected_optimizer.param_groups,
+                                                       beta2s):
+            expected_group["lr"] = actual_group["lr"]
+            expected_group["betas"] = (actual_group["betas"][0], beta2)
+        for module, optim in [(model, optimizer), (reference, expected_optimizer)]:
+            optim.zero_grad()
+            module(inputs).square().sum().backward()
+            optim.step()
+        for actual, expected in zip(model.parameters(), reference.parameters()):
+            torch.testing.assert_close(actual, expected)
+        scheduler.step()
+        assert [group["betas"][1] for group in optimizer.param_groups] == beta2s
+
+
 def test_one_cycle_accepts_per_group_lr_and_momentum_lists():
     # cycle_min_lr, cycle_max_lr, cycle_min_mom and cycle_max_mom are all documented as
     # "float or list ... for each parameter group", but OneCycle only broadcast a scalar,


### PR DESCRIPTION
Constructing `OneCycle` silently replaces every Adam group's beta2 with 0.99, changing the second-moment estimator before training starts.

**Cause:** Both momentum bounds hardcode `(beta1, 0.99)`.
**Fix:** Preserve each group's existing beta2 while scheduling beta1.
**Test:** `DS_ACCELERATOR=cpu python -m pytest tests/unit/runtime/test_lr_schedulers.py -k preserves_per_group_beta2`: fails before, passes after. A six-step linear-model training loop matches Adam with the configured beta2 values through both cycle and decay. All 44 standalone scheduler cases pass. Tested on Apple M2 Pro CPU, torch 2.11.0. Changed-file pre-commit checks pass.