### PR TITLE
Fix ZeRO-3 checkpoint tag selection during weight reconstruction

### DIFF
--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -4637,7 +4637,7 @@ class DeepSpeedEngine(Module):
         autoep_partitioned_experts = False
         allowed_missing_keys = None
         if self.zero_optimization_partition_weights() and not load_optimizer_states and not self.has_moe_layers:
-            checkpoint['module'] = get_fp32_state_dict_from_zero_checkpoint(load_dir)
+            checkpoint['module'] = get_fp32_state_dict_from_zero_checkpoint(load_dir, tag=tag)
             fetch_z3_params = True
 
         if is_pipe_parallel:

--- a/tests/unit/checkpoint/test_zero_optimizer.py
+++ b/tests/unit/checkpoint/test_zero_optimizer.py
@@ -20,6 +20,69 @@ from unit.checkpoint.common import *
 import pytest
 
 
+class TestZeROCheckpointTag(DistributedTest):
+    world_size = [1, 2]
+
+    @pytest.mark.parametrize('tag,save_latest,load_optimizer_states,load_module_only', [
+        ('earlier', True, False, False),
+        ('earlier', False, False, False),
+        ('earlier', True, False, True),
+        ('earlier', False, False, True),
+        ('earlier', True, True, False),
+        (None, True, False, False),
+    ])
+    def test_load_requested_tag(self, tmpdir, tag, save_latest, load_optimizer_states, load_module_only):
+        config = {
+            'train_micro_batch_size_per_gpu': 1,
+            'zero_allow_untested_optimizer': True,
+            'zero_optimization': {
+                'stage': 3,
+                'reduce_bucket_size': 1000,
+                'stage3_prefetch_bucket_size': 1000,
+            },
+        }
+
+        def make_engine():
+            model = torch.nn.Linear(4, 2)
+            optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+            return deepspeed.initialize(model=model, optimizer=optimizer, config=config)[0]
+
+        def snapshot(engine):
+            with deepspeed.zero.GatheredParameters(list(engine.module.parameters())):
+                return {name: value.detach().clone() for name, value in engine.module.state_dict().items()}
+
+        source = make_engine()
+        target = None
+        try:
+            snapshots = {}
+            for checkpoint_tag in ('earlier', 'later'):
+                loss = source(torch.ones(1, 4, device=source.device)).square().mean()
+                source.backward(loss)
+                source.step()
+                snapshots[checkpoint_tag] = snapshot(source)
+                source.save_checkpoint(tmpdir,
+                                       tag=checkpoint_tag,
+                                       client_state={'label': checkpoint_tag},
+                                       save_latest=save_latest)
+
+            assert any(not torch.equal(snapshots['earlier'][name], value)
+                       for name, value in snapshots['later'].items())
+            target = make_engine()
+            load_path, client_state = target.load_checkpoint(tmpdir,
+                                                             tag=tag,
+                                                             load_optimizer_states=load_optimizer_states,
+                                                             load_module_only=load_module_only)
+            expected_tag = tag if tag is not None else 'later'
+            assert load_path is not None
+            assert client_state['label'] == expected_tag
+            for name, value in snapshot(target).items():
+                torch.testing.assert_close(value, snapshots[expected_tag][name], rtol=0, atol=0)
+        finally:
+            if target is not None:
+                target.destroy()
+            source.destroy()
+
+
 class TestZeROCheckpoint(DistributedTest):
     world_size = 2
 


### PR DESCRIPTION
## Numeric checkpoint tags (2026-09-21)

`save_checkpoint()` accepts numeric tags and stringifies them for the directory name. The reconstruction path now also normalizes the resolved tag with `str(tag)` before forwarding it, preserving that existing API behavior.

The regression matrix adds five numeric-tag cases, covering `save_latest=True/False`, `load_module_only`, and the optimizer-state path. The test still trains a real model, saves two different checkpoints, and compares every restored parameter with the requested checkpoint.

- Before this follow-up, the numeric-tag regression fails with `TypeError: join() argument must be str, bytes, or os.PathLike object, not 'int'` on CPU/Gloo.
- After the fix, all **11 cases pass** on two NVIDIA GeForce RTX 3090 GPUs with PyTorch 2.12.1+cu126. Every case runs with both one and two ranks (22 distributed executions), including all six original cases.
- All applicable pre-commit hooks and `git diff --check` pass. The follow-up commit includes `Signed-off-by`.

The original CPU and full-model evidence below is historical; this follow-up reran the complete targeted real-GPU checkpoint matrix, not a full-model training run. OpenAI Codex assisted with the follow-up.

When a non-MoE ZeRO-3 model loads an explicit checkpoint tag with `load_optimizer_states=False`, FP32 reconstruction currently resolves `latest` again. As a result, a request for `earlier` can return its metadata while silently installing `later` weights, or fail if there is no `latest` file.

Pass the already resolved `tag` to `get_fp32_state_dict_from_zero_checkpoint()` so the reconstructed parameters and metadata come from the same checkpoint. The production change is one call argument.

Fixes #8499.

### Regression coverage

`TestZeROCheckpointTag` trains and saves distinct parameter snapshots, then checks restored parameters against the selected snapshot with zero tolerance. It covers explicit older tags with/without `latest`, `load_module_only=True/False`, default latest selection, and full optimizer-state restoration as a control. Tests use real engine training and checkpoint files, with no loader mocks.

Current-base checks on `71d316d608a56af2fcc27b84b14cf854b7052eff` plus this fix (2026-09-13):

- New regression: **6 passed on CPU/Gloo** and **6 passed on RTX 3090/CUDA/NCCL**. Each pytest case executes with both one and two ranks, giving 12 distributed executions per backend.
- Coverage includes explicit older tags with/without `latest`, both `load_module_only` values, omitted-tag selection, and a full optimizer-state restore control.
- Existing GPU regressions: `TestZeROCheckpoint::test_not_load_optimizer_state[3-False-Adam]` and `TestZeROCheckpoint::test_load_module_only[3]`: **2 passed**, each with two ranks.
- All applicable pre-commit hooks on the two modified files and `git diff --check` passed.

Run the new regression from the source checkout with its test dependencies installed:

```bash
export PYTHONPATH="$PWD:$PWD/tests"
export OMP_NUM_THREADS=1 LOCAL_SIZE=2 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
DS_ACCELERATOR=cpu python -m pytest -p pytest_forked --forked \
  tests/unit/checkpoint/test_zero_optimizer.py::TestZeROCheckpointTag \
  --torch_ver=2.12.1+cu126 --cuda_ver=12.6
DS_ACCELERATOR=cuda CUDA_VISIBLE_DEVICES=0,1 python -m pytest -p pytest_forked --forked \
  tests/unit/checkpoint/test_zero_optimizer.py::TestZeROCheckpointTag \
  --torch_ver=2.12.1+cu126 --cuda_ver=12.6
```

The explicit version options describe the tested PyTorch installation; adjust them for another environment.

### Full-model integration evidence

The same production fix was previously tested on base `29d0abbc21f11da806ca14970fa8b3ddb757a152` using the complete pretrained Qwen3.5-0.8B language model, all 24 decoder layers and all 752,393,024 language-model parameters trainable. Configuration: BF16, ZeRO-3, PyTorch AdamW, sequence length 32, microbatch 1 per GPU; one and four RTX 3090 24 GiB GPUs, driver 580.173.02, PyTorch 2.12.1+cu126, Transformers 5.10.4, NCCL.

Both baseline runs reproduced the wrong-tag load. With the fix, every restored model parameter matched the selected checkpoint exactly, and a subsequent training step updated parameters successfully. This was a short integration check, not a convergence or throughput benchmark; vision, multi-node training, and NVMe offload were outside its scope. Current-base regression results are listed separately above.

### Related changes

#3116 and #4089 address adjacent checkpoint behavior but do not pass this engine argument. Open PR #8378 modifies the same call for frozen-parameter dtype handling; it addresses a different contract, and both arguments may need to be retained when rebasing. No public API or checkpoint format changes are introduced here.
