### PR TITLE
Restore full training state in checkpoint writer engines

### DIFF
--- a/deepspeed/runtime/checkpoint_engine/decoupled_checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/decoupled_checkpoint_engine.py
@@ -151,7 +151,7 @@ class DecoupledCheckpointEngine(CheckpointEngine):
             self.checkpoint_size.set_pre_size(pre_size)
 
     def load(self, path: str, map_location=None):
-        sd = torch.load(path, map_location=map_location)
+        sd = torch.load(path, map_location=map_location, weights_only=False)
         return sd
 
     def save(self, state_dict, path: str):

--- a/deepspeed/runtime/checkpoint_engine/fast_checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/fast_checkpoint_engine.py
@@ -40,7 +40,7 @@ class FastCheckpointEngine(CheckpointEngine):
         self._writer.release_writer()
 
     def load(self, path: str, map_location=None):
-        sd = torch.load(path, map_location=map_location)
+        sd = torch.load(path, map_location=map_location, weights_only=False)
         return sd
 
     def commit(self, info: CheckpointCommitInfo):

--- a/tests/unit/checkpoint/test_other_optimizer.py
+++ b/tests/unit/checkpoint/test_other_optimizer.py
@@ -14,6 +14,76 @@ from unit.checkpoint.common import checkpoint_correctness_verification
 import pytest
 
 
+class TestCheckpointWriterResume(DistributedTest):
+    world_size = [1, 2]
+    non_daemonic_procs = True
+
+    @pytest.mark.parametrize('decoupled', [False, True])
+    @pytest.mark.parametrize('serialization', [False, True])
+    def test_resume_training(self, tmpdir, monkeypatch, decoupled, serialization):
+        # These launcher variables describe the single machine used by DistributedTest.
+        monkeypatch.setenv('CROSS_RANK', '0')
+        monkeypatch.setenv('CROSS_SIZE', '1')
+        config = {
+            'train_micro_batch_size_per_gpu': 1,
+            'zero_allow_untested_optimizer': True,
+            'zero_optimization': {
+                'stage': 3,
+                'reduce_bucket_size': 1000,
+                'stage3_prefetch_bucket_size': 1000,
+            },
+            'checkpoint': {
+                'checkpoint_serialization': serialization,
+                'writer': {
+                    'type': 'python',
+                    'decoupled': decoupled,
+                },
+            },
+        }
+
+        def make_engine():
+            model = torch.nn.Linear(4, 2)
+            optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+            return deepspeed.initialize(model=model, optimizer=optimizer, config=config)[0]
+
+        def train_step(engine):
+            loss = engine(torch.ones(1, 4, device=engine.device)).square().mean()
+            engine.backward(loss)
+            engine.step()
+
+        def snapshot(engine):
+            with deepspeed.zero.GatheredParameters(list(engine.module.parameters())):
+                return {name: value.detach().clone() for name, value in engine.module.state_dict().items()}
+
+        source = make_engine()
+        target = None
+        try:
+            train_step(source)
+            saved_weights = snapshot(source)
+            saved_steps = source.global_steps
+            source.save_checkpoint(tmpdir, tag='resume', client_state={'label': 'resume'})
+            # The next optimizer step commits pending asynchronous checkpoint writes.
+            train_step(source)
+            target = make_engine()
+            load_path, client_state = target.load_checkpoint(tmpdir, tag='resume')
+            assert load_path is not None
+            assert client_state['label'] == 'resume'
+            assert saved_steps == target.global_steps
+            for name, value in snapshot(target).items():
+                torch.testing.assert_close(value, saved_weights[name], rtol=0, atol=0)
+
+            # The next update checks restoration of Adam's moments and step counter,
+            # not just restoration of model weights.
+            train_step(target)
+            expected = snapshot(source)
+            for name, value in snapshot(target).items():
+                torch.testing.assert_close(value, expected[name], rtol=0, atol=0)
+        finally:
+            if target is not None:
+                target.destroy()
+            source.destroy()
+
+
 class TestOtherOptimizerCheckpoint(DistributedTest):
     world_size = 2
 


### PR DESCRIPTION
`FastCheckpointEngine` and `DecoupledCheckpointEngine` can save complete ZeRO-3 training checkpoints but fail to restore them under PyTorch's default weights-only loader, which rejects DeepSpeed's own `ZeroStageEnum`.

Pass `weights_only=False` in both `load()` methods, matching the existing `TorchCheckpointEngine` behavior for trusted complete training checkpoints. The production change is limited to these two calls.

Fixes #8500.

### Regression coverage

`TestCheckpointWriterResume` covers synchronous/asynchronous Python writers and legacy/ZIP serialization. It runs real ZeRO-3 training, saves step 1, and performs the next optimizer step to commit pending asynchronous writes. A fresh engine must restore the saved parameters and step count; its next Adam update must match uninterrupted training with zero tolerance. This checks the observable effect of restoring optimizer state, not only successful deserialization.

The asynchronous case uses a real subprocess. The only environment patch supplies the single-node launcher's `CROSS_RANK` / `CROSS_SIZE` values.

Current-base checks on `71d316d608a56af2fcc27b84b14cf854b7052eff` plus this fix (2026-09-13):

- New regression: **4 passed on CPU/Gloo** and **4 passed on RTX 3090/CUDA/NCCL**. Each pytest case executes with both one and two ranks, giving 8 distributed executions per backend.
- The four cases cover synchronous/asynchronous Python writers and legacy/ZIP serialization, including exact saved-parameter restoration, the restored training step count, and the next Adam update against uninterrupted training.
- Existing GPU regression: `TestOtherOptimizerCheckpoint::test_checkpoint_fp32_optimizer`: **1 passed** with two ranks.
- All applicable pre-commit hooks on the three modified files and `git diff --check` passed.

Run the new regression from the source checkout with its test dependencies installed:

```bash
export PYTHONPATH="$PWD:$PWD/tests"
export OMP_NUM_THREADS=1 LOCAL_SIZE=2 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
DS_ACCELERATOR=cpu python -m pytest -p pytest_forked --forked \
  tests/unit/checkpoint/test_other_optimizer.py::TestCheckpointWriterResume \
  --torch_ver=2.12.1+cu126 --cuda_ver=12.6
DS_ACCELERATOR=cuda CUDA_VISIBLE_DEVICES=0,1 python -m pytest -p pytest_forked --forked \
  tests/unit/checkpoint/test_other_optimizer.py::TestCheckpointWriterResume \
  --torch_ver=2.12.1+cu126 --cuda_ver=12.6
```

The explicit version options describe the tested PyTorch installation; adjust them for another environment.

### Full-model integration evidence

The same production fix was previously tested on base `29d0abbc21f11da806ca14970fa8b3ddb757a152` with the complete pretrained Qwen3.5-0.8B language model: 24 decoder layers, 752,393,024 trainable language-model parameters, BF16, ZeRO-3, PyTorch AdamW, sequence length 32, microbatch 1 per GPU. Hardware/software: one/four RTX 3090 24 GiB GPUs, driver 580.173.02, PyTorch 2.12.1+cu126, Transformers 5.10.4, NCCL.

Synchronous/asynchronous writer × one/four GPUs gave four baseline deserialization failures and four successful fixed runs. All restored model parameters, the training step count, and all model parameters after the next update matched the uninterrupted reference exactly. These full-model GPU runs used ZIP serialization and excluded the vision branch. Current-base regression results are listed separately above.

### Compatibility and scope

Full pickle deserialization requires self-produced or otherwise trusted checkpoints; `weights_only=False` must not be treated as safe for untrusted files. This restores the existing complete-checkpoint convention without adding a public API or changing the file format. An allowlist or a tensor/primitive-only format would require a separate compatibility design.

#6751 updated other load sites but did not cover these two calls. #7742 addresses asynchronous process reliability, a different failure mode. Multi-node, AIO/GDS, NVMe offload, long-run convergence, and the full DeepSpeed suite were not tested.
